### PR TITLE
Fix missing support for Query Parameters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - "release"
 
 env:
-  VERSION: 0.3.0
+  VERSION: 0.3.1
   NUGET_REPO_URL: "https://api.nuget.org/v3/index.json"
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ namespace Your.Namespace.Of.Choice.GeneratedCode
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         [Get("/pet/findByTags")]
-        Task<ICollection<Pet>> FindPetsByTags([Query]System.Collections.Generic.ICollection<string> tags);
+        Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)]System.Collections.Generic.ICollection<string> tags);
 
         /// <summary>
         /// Returns a single pet

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ namespace Your.Namespace.Of.Choice.GeneratedCode
         /// Multiple status values can be provided with comma separated strings
         /// </summary>
         [Get("/pet/findByStatus")]
-        Task<ICollection<Pet>> FindPetsByStatus();
+        Task<ICollection<Pet>> FindPetsByStatus([Query]Status? status);
 
         /// <summary>
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         [Get("/pet/findByTags")]
-        Task<ICollection<Pet>> FindPetsByTags();
+        Task<ICollection<Pet>> FindPetsByTags([Query]System.Collections.Generic.ICollection<string> tags);
 
         /// <summary>
         /// Returns a single pet
@@ -91,13 +91,13 @@ namespace Your.Namespace.Of.Choice.GeneratedCode
         Task<Pet> GetPetById(long? petId);
 
         [Post("/pet/{petId}")]
-        Task UpdatePetWithForm(long? petId);
+        Task UpdatePetWithForm(long? petId, [Query]string name, [Query]string status);
 
         [Delete("/pet/{petId}")]
         Task DeletePet(long? petId);
 
         [Post("/pet/{petId}/uploadImage")]
-        Task<ApiResponse> UploadFile(long? petId, [Body]StreamPart body);
+        Task<ApiResponse> UploadFile(long? petId, [Query]string additionalMetadata, [Body]StreamPart body);
 
         /// <summary>
         /// Returns a map of status codes to quantities
@@ -136,7 +136,7 @@ namespace Your.Namespace.Of.Choice.GeneratedCode
         Task<User> CreateUsersWithListInput([Body]ICollection<User> body);
 
         [Get("/user/login")]
-        Task<string> LoginUser();
+        Task<string> LoginUser([Query]string username, [Query]string password);
 
         [Get("/user/logout")]
         Task LogoutUser();

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ namespace Your.Namespace.Of.Choice.GeneratedCode
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         [Get("/pet/findByTags")]
-        Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)]System.Collections.Generic.ICollection<string> tags);
+        Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)]ICollection<string> tags);
 
         /// <summary>
         /// Returns a single pet

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -18,7 +18,7 @@ public static class ParameterExtractor
         
         var queryParameters = operation.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Query)
-            .Select(p => $"[Query(CollectionFormat.Multi)]{generator.GetTypeName(p.ActualTypeSchema, true, null)} {p.Name}")
+            .Select(p => $"[Query(CollectionFormat.Multi)]{GetBodyParameterType(generator, p)} {p.Name}")
             .ToList();
 
         var bodyParameters = operation.Parameters

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NJsonSchema;
@@ -16,6 +15,11 @@ public static class ParameterExtractor
             .Where(p => p.Kind == OpenApiParameterKind.Path)
             .Select(p => $"{generator.GetTypeName(p.ActualTypeSchema, true, null)} {p.Name}")
             .ToList();
+        
+        var queryParameters = operation.Parameters
+            .Where(p => p.Kind == OpenApiParameterKind.Query)
+            .Select(p => $"[Query]{generator.GetTypeName(p.ActualTypeSchema, true, null)} {p.Name}")
+            .ToList();
 
         var bodyParameters = operation.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Body)
@@ -24,6 +28,7 @@ public static class ParameterExtractor
 
         var parameters = new List<string>();
         parameters.AddRange(routeParameters);
+        parameters.AddRange(queryParameters);
         parameters.AddRange(bodyParameters);
         return parameters;
     }

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -18,7 +18,7 @@ public static class ParameterExtractor
         
         var queryParameters = operation.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Query)
-            .Select(p => $"[Query]{generator.GetTypeName(p.ActualTypeSchema, true, null)} {p.Name}")
+            .Select(p => $"[Query(CollectionFormat.Multi)]{generator.GetTypeName(p.ActualTypeSchema, true, null)} {p.Name}")
             .ToList();
 
         var bodyParameters = operation.Parameters

--- a/test/ConsoleApp/Program.cs
+++ b/test/ConsoleApp/Program.cs
@@ -14,6 +14,10 @@ internal class Program
     //     Console.WriteLine($"Name: {pet.Name}");
     //     Console.WriteLine($"Category: {pet.Category.Name}");
     //     Console.WriteLine($"Status: {pet.Status}");
+
+    //     var pets = await client.FindPetsByStatus(Status.Available);
+    //     Console.WriteLine("Found " + pets.Count + " available pet(s)");
+    
     //     Console.ReadLine();
     // }
 

--- a/test/ConsoleApp/Program.cs
+++ b/test/ConsoleApp/Program.cs
@@ -8,7 +8,7 @@ internal class Program
 {
     // private static async Task Main(string[] args)
     // {
-    //     var client = RestService.For<GeneratedCode.ISwaggerPetstore>("https://petstore3.swagger.io/api/v3");
+    //     var client = RestService.For<Petstore.ISwaggerPetstore>("https://petstore3.swagger.io/api/v3");
     //     var pet = await client.GetPetById(2);
 
     //     Console.WriteLine($"Name: {pet.Name}");

--- a/test/ConsoleApp/Program.cs
+++ b/test/ConsoleApp/Program.cs
@@ -15,10 +15,11 @@ internal class Program
     //     Console.WriteLine($"Category: {pet.Category.Name}");
     //     Console.WriteLine($"Status: {pet.Status}");
 
-    //     var pets = await client.FindPetsByStatus(Status.Available);
-    //     Console.WriteLine("Found " + pets.Count + " available pet(s)");
-    
-    //     Console.ReadLine();
+    //     var pets = await client.FindPetsByStatus(Petstore.Status.Available);
+    //     Console.WriteLine("Found " + pets.Count + " available pet(s)");        
+
+    //     var taggedPets = await client.FindPetsByTags(new[] {"tag1Updated", "new"});
+    //     Console.WriteLine("Found " + taggedPets.Count + " tagged pet(s)");
     // }
 
     private static void Main(string[] args)


### PR DESCRIPTION
The changes here add's the missing Query parameters support in the generated Refit interface

Endpoints that use query parameters will be generated like this:

```cs
[Get("/pet/findByStatus")]
Task<ICollection<Pet>> FindPetsByStatus([Query]Status? status);

[Get("/pet/findByTags")]
Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)]ICollection<string> tags);
```

This was verified using the Swagger Petstore v3 OpenAPI specifications and tested using the following code:

```cs
var client = RestService.For<ISwaggerPetstore>("https://petstore3.swagger.io/api/v3");
var pet = await client.GetPetById(2);

Console.WriteLine($"Name: {pet.Name}");
Console.WriteLine($"Category: {pet.Category.Name}");
Console.WriteLine($"Status: {pet.Status}");

var pets = await client.FindPetsByStatus(Status.Available);
Console.WriteLine("Found " + pets.Count + " available pet(s)");        

var taggedPets = await client.FindPetsByTags(new[] {"tag1Updated", "new"});
Console.WriteLine("Found " + taggedPets.Count + " tagged pet(s)");
```

Which when executed returns the following text:

```
Name: Gatitotototo
Category: Chaucito
Status: Sold
Found 44 available pet(s)
Found 9 tagged pet(s)
```

This resolves #5 