### PR TITLE
fix path parameters in parent

### DIFF
--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -11,7 +11,7 @@ public static class ParameterExtractor
 {
     public static IEnumerable<string> GetParameters(CSharpClientGenerator generator, OpenApiOperation operation)
     {
-        var routeParameters = operation.Parameters
+        var routeParameters = operation.ActualParameters
             .Where(p => p.Kind == OpenApiParameterKind.Path)
             .Select(p => $"{generator.GetTypeName(p.ActualTypeSchema, true, null)} {p.Name}")
             .ToList();


### PR DESCRIPTION
Example YAML:
```yaml
swagger: '2.0'
info:
  title: Reference parameters
  version: v0.0.1
paths:
  '/orders/{orderId}/order-items/{orderItemId}':
    parameters:
      - $ref: '#/parameters/OrderId'
      - $ref: '#/parameters/OrderItemId'
    delete:
      summary: Delete an order item
      description: >-
        This method allows to remove an order item from an order, by specifying
        their ids.
      responses:
        "204":
          description: No Content.
        default:
          description: Default response
          schema:
            $ref: '#/definitions/Error'
definitions:
  Error:
    type: object
    properties:
      message:
          type: string
parameters:
  OrderId:
    name: orderId
    in: path
    description: Identifier of the order.
    required: true
    type: string
    format: uuid
  OrderItemId:
    name: orderItemId
    in: path
    description: Identifier of the order item.
    required: true
    type: string
    format: uuid
```
Generated code:
```C#
public interface IReferenceparameters
{
	/// <summary>
	/// This method allows to remove an order item from an order, by specifying their ids.
	/// </summary>
	[Delete("/orders/{orderId}/order-items/{orderItemId}")]
	Task OrderItems();
}
```
missing orderId and orderItemId path parameters