### PR TITLE
Add support for kebab-string-casing parameters

### DIFF
--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -13,22 +13,22 @@ public static class ParameterExtractor
     {
         var routeParameters = operation.ActualParameters
             .Where(p => p.Kind == OpenApiParameterKind.Path)
-            .Select(p => $"{generator.GetTypeName(p.ActualTypeSchema, true, null)} {p.Name}")
+            .Select(p => $"{generator.GetTypeName(p.ActualTypeSchema, true, null)} {p.Name.ConvertKebabCaseToCamelCase()}")
             .ToList();
 
         var queryParameters = operation.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Query)
-            .Select(p => $"[Query(CollectionFormat.Multi)]{GetBodyParameterType(generator, p)} {p.Name}")
+            .Select(p => $"[Query(CollectionFormat.Multi)]{GetBodyParameterType(generator, p)} {p.Name.ConvertKebabCaseToCamelCase()}")
             .ToList();
 
         var bodyParameters = operation.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Body && !p.IsBinaryBodyParameter)
-            .Select(p => $"[Body]{GetBodyParameterType(generator, p)} {p.Name}")
+            .Select(p => $"[Body]{GetBodyParameterType(generator, p)} {p.Name.ConvertKebabCaseToCamelCase()}")
             .ToList();
 
         var multipartFormParameters = operation.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Body && p.IsBinaryBodyParameter)
-            .Select(p => $"[Body(BodySerializationMethod.UrlEncoded)] Dictionary<string, object> {p.Name}")
+            .Select(p => $"[Body(BodySerializationMethod.UrlEncoded)] Dictionary<string, object> {p.Name.ConvertKebabCaseToCamelCase()}")
             .ToList();
 
         var parameters = new List<string>();

--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -55,7 +55,7 @@ public class RefitInterfaceGenerator
 
                 GenerateMethodXmlDocComments(operation, code);
 
-                code.AppendLine($"{Separator}{Separator}[{verb}(\"{kv.Key}\")]")
+                code.AppendLine($"{Separator}{Separator}[{verb}(\"{kv.Key.ConvertKebabCaseToCamelCase()}\")]")
                     .AppendLine($"{Separator}{Separator}{returnType} {name}({parametersString});")
                     .AppendLine();
             }

--- a/src/Refitter.Core/StringCasingExtensions.cs
+++ b/src/Refitter.Core/StringCasingExtensions.cs
@@ -12,6 +12,17 @@ public static class StringCasingExtensions
 
         return string.Join(string.Empty, parts);
     }
+    
+    public static string ConvertKebabCaseToCamelCase(this string str)
+    {
+        var parts = str.Split('-');
+        for (var i = 1; i < parts.Length; i++)
+        {
+            parts[i] = parts[i].CapitalizeFirstCharacter();
+        }
+
+        return string.Join(string.Empty, parts);
+    }
 
     public static string CapitalizeFirstCharacter(this string str)
     {

--- a/src/Refitter.Tests/Build/BuildHelper.cs
+++ b/src/Refitter.Tests/Build/BuildHelper.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 
-namespace Refitter.Tests;
+namespace Refitter.Tests.Build;
 
 public static class BuildHelper
 {

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -1,4 +1,4 @@
-﻿namespace Refitter.Tests;
+﻿namespace Refitter.Tests.Build;
 
 public static class ProjectFileContents
 {

--- a/src/Refitter.Tests/KebabCaseTests.cs
+++ b/src/Refitter.Tests/KebabCaseTests.cs
@@ -86,7 +86,7 @@ components:
 
     private static async Task<string> CreateSwaggerFile(string contents)
     {
-        var filename = Guid.NewGuid().ToString() + ".yml";
+        var filename = $"{Guid.NewGuid()}.yml";
         var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(folder);
         var swaggerFile = Path.Combine(folder, filename);

--- a/src/Refitter.Tests/KebabCaseTests.cs
+++ b/src/Refitter.Tests/KebabCaseTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests;
+
+public class KebabCaseTests
+{
+    private const string OpenApiSpec = @"
+openapi: '3.0.0'
+info:
+  version: 'v1'
+  title: 'Test API'
+servers:
+  - url: 'https://test.host.com/api/v1'
+paths:
+  /jobs/{job-id}:
+    get:
+      tags:
+      - 'Jobs'
+      summary: 'Get job details'
+      description: 'Get the details of the specified job.'
+      parameters:
+        - in: 'path'
+          name: 'job-id'
+          description: 'Job ID'
+          required: true
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobResponse'
+components:
+  schemas:
+    JobResponse:
+      type: 'object'
+      properties:
+        job:
+          type: 'object'
+          properties:
+            start-date:
+              type: 'string'
+              format: 'date-time'
+            details:
+              type: 'string'
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Replaces_KababCase_Parameters_With_PascalCase()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().Contain("string jobId");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = Guid.NewGuid().ToString() + ".yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/src/Refitter.Tests/PathParametersTests.cs
+++ b/src/Refitter.Tests/PathParametersTests.cs
@@ -91,7 +91,7 @@ parameters:
 
     private static async Task<string> CreateSwaggerFile(string contents)
     {
-        var filename = Guid.NewGuid().ToString() + ".yml";
+        var filename = $"{Guid.NewGuid()}.yml";
         var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(folder);
         var swaggerFile = Path.Combine(folder, filename);

--- a/src/Refitter.Tests/PathParametersTests.cs
+++ b/src/Refitter.Tests/PathParametersTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests;
+
+public class PathParametersTests
+{
+    private const string OpenApiSpec = @"
+swagger: '2.0'
+info:
+  title: Reference parameters
+  version: v0.0.1
+paths:
+  '/orders/{orderId}/order-items/{orderItemId}':
+    parameters:
+      - $ref: '#/parameters/OrderId'
+      - $ref: '#/parameters/OrderItemId'
+    delete:
+      summary: Delete an order item
+      description: >-
+        This method allows to remove an order item from an order, by specifying
+        their ids.
+      responses:
+        '204':
+          description: No Content.
+        default:
+          description: Default response
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Error:
+    type: object
+    properties:
+      message:
+          type: string
+parameters:
+  OrderId:
+    name: orderId
+    in: path
+    description: Identifier of the order.
+    required: true
+    type: string
+    format: uuid
+  OrderItemId:
+    name: orderItemId
+    in: path
+    description: Identifier of the order item.
+    required: true
+    type: string
+    format: uuid
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        var generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Generates_Path_Parameters()
+    {
+        var generateCode = await GenerateCode();
+        using var scope = new AssertionScope();
+        generateCode.Should().Contain("Guid? orderId");
+        generateCode.Should().Contain("Guid? orderItemId");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        var generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = Guid.NewGuid().ToString() + ".yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/src/Refitter.Tests/RefitGeneratorTests.cs
+++ b/src/Refitter.Tests/RefitGeneratorTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Refitter.Core;
+using Refitter.Tests.Build;
 using Refitter.Tests.Resources;
 using Xunit;
 

--- a/src/Refitter.Tests/StringCasingExtensionTests.cs
+++ b/src/Refitter.Tests/StringCasingExtensionTests.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using Refitter.Core;
+using Xunit;
+
+namespace Refitter.Tests;
+
+public class StringCasingExtensionTests
+{
+    [Theory]
+    [InlineData("some-string", "SomeString")]
+    public void CanConvertToPascalCase(string input, string expected)
+        => input.ConvertKebabCaseToPascalCase().Should().Be(expected);
+    
+    [Theory]
+    [InlineData("some-string", "someString")]
+    public void CanConvertToCamelCase(string input, string expected)
+        => input.ConvertKebabCaseToCamelCase().Should().Be(expected);
+    
+    [Theory]
+    [InlineData("abcd", "Abcd")]
+    public void CanCaptilalizeFirstLetter(string input, string expected)
+        => input.CapitalizeFirstCharacter().Should().Be(expected);
+}


### PR DESCRIPTION
The changes here fix the missing support for using `kebab-string-casing` in path parameters

The following OpenAPI spec:

```yaml
openapi: "3.0.0"
info:
  version: "v1"
  title: "Test API"
servers:
  - url: "https://test.host.com/api/v1"
paths:
  /jobs/{job-id}:
    get:
      tags:
      - "Jobs"
      summary: "Get job details"
      description: "Get the details of the specified job."
      parameters:
        - in: "path"
          name: "job-id"
          description: "Job ID"
          required: true
          schema:
            type: "string"
      responses:
        "200":
          description: "successful operation"
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/JobResponse"
components:
  schemas:
    JobResponse:
      type: "object"
      properties:
        job:
          type: "object"
          properties:
            start-date:
              type: "string"
              format: "date-time"
            details:
              type: "string"
```

Generates the following code:

```cs
/// <summary>
/// Get the details of the specified job.
/// </summary>
[Get("/jobs/{jobId}")]
Task<JobResponse> Jobs(string jobId);
```

This resolves #10 reported by @m7clarke