### PR TITLE
Various name encoding fixes, fix multiline descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,4 @@ test/**/Link-example.cs
 test/**/Petstore.cs
 test/**/Uber.cs
 test/**/Uspto.cs
+test/**/IngramMicro.cs

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/src/Refitter/bin/Debug/net7.0/refitter.dll",
+      "args": [
+        "${workspaceFolder}/test/OpenAPI/v3.0/IngramMicro.json",
+        "--namespace",
+        "Refitter.Test",
+        "--output",
+        "${workspaceFolder}/test/Refitter.Test.cs"
+      ],
+      "cwd": "${workspaceFolder}/src/Refitter",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/src/Refitter.sln",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/src/Refitter/Refitter.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/src/Refitter/Refitter.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/src/Refitter.Core/CSharpClientGeneratorFactory.cs
+++ b/src/Refitter.Core/CSharpClientGeneratorFactory.cs
@@ -15,13 +15,17 @@ public class CSharpClientGeneratorFactory
         this.document = document;
     }
 
-    public CSharpClientGenerator Create() =>
+    public CustomCSharpClientGenerator Create() =>
         new(document, new CSharpClientGeneratorSettings
         {
             GenerateClientClasses = false,
             GenerateDtoTypes = true,
             GenerateClientInterfaces = false,
             GenerateExceptionClasses = false,
+            CodeGeneratorSettings =
+            {
+                PropertyNameGenerator = new CustomCSharpPropertyNameGenerator(),
+            },
             CSharpGeneratorSettings =
             {
                 Namespace = settings.Namespace,

--- a/src/Refitter.Core/CustomCSharpClientGenerator.cs
+++ b/src/Refitter.Core/CustomCSharpClientGenerator.cs
@@ -1,0 +1,16 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp;
+using NSwag.CodeGeneration.CSharp.Models;
+
+namespace Refitter.Core;
+
+public class CustomCSharpClientGenerator : CSharpClientGenerator
+{
+    public CustomCSharpClientGenerator(OpenApiDocument document, CSharpClientGeneratorSettings settings)
+        : base(document, settings)
+    {
+    }
+
+    public CSharpOperationModel CreateOperationModel(OpenApiOperation operation) =>
+        CreateOperationModel(operation, Settings);
+}

--- a/src/Refitter.Core/CustomCSharpPropertyNameGenerator.cs
+++ b/src/Refitter.Core/CustomCSharpPropertyNameGenerator.cs
@@ -1,0 +1,10 @@
+using NJsonSchema;
+using NJsonSchema.CodeGeneration.CSharp;
+
+namespace Refitter.Core;
+
+public class CustomCSharpPropertyNameGenerator : CSharpPropertyNameGenerator
+{
+    public override string Generate(JsonSchemaProperty property) =>
+        string.IsNullOrWhiteSpace(property.Name) ? "_" : base.Generate(property);
+}

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -1,34 +1,36 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NJsonSchema;
 using NSwag;
-using NSwag.CodeGeneration;
-using NSwag.CodeGeneration.CSharp;
+using NSwag.CodeGeneration.CSharp.Models;
 
 namespace Refitter.Core;
 
 public static class ParameterExtractor
 {
-    public static IEnumerable<string> GetParameters(CSharpClientGenerator generator, OpenApiOperation operation)
+    public static IEnumerable<string> GetParameters(CustomCSharpClientGenerator generator, OpenApiOperation operation)
     {
-        var routeParameters = operation.ActualParameters
+        var operationModel = generator.CreateOperationModel(operation);
+
+        var routeParameters = operationModel.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Path)
-            .Select(p => $"{generator.GetTypeName(p.ActualTypeSchema, true, null)} {p.Name}")
+            .Select(p => $"{JoinAttributes(GetAliasAsAttribute(p))}{p.Type} {p.VariableName}")
             .ToList();
 
-        var queryParameters = operation.Parameters
+        var queryParameters = operationModel.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Query)
-            .Select(p => $"[Query(CollectionFormat.Multi)]{GetBodyParameterType(generator, p)} {p.Name}")
+            .Select(p => $"{JoinAttributes("Query(CollectionFormat.Multi)", GetAliasAsAttribute(p))}{GetBodyParameterType(p)} {p.VariableName}")
             .ToList();
 
-        var bodyParameters = operation.Parameters
+        var bodyParameters = operationModel.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Body && !p.IsBinaryBodyParameter)
-            .Select(p => $"[Body]{GetBodyParameterType(generator, p)} {p.Name}")
+            .Select(p => $"{JoinAttributes("Body", GetAliasAsAttribute(p))}{GetBodyParameterType(p)} {p.VariableName}")
             .ToList();
 
-        var multipartFormParameters = operation.Parameters
+        var multipartFormParameters = operationModel.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Body && p.IsBinaryBodyParameter)
-            .Select(p => $"[Body(BodySerializationMethod.UrlEncoded)] Dictionary<string, object> {p.Name}")
+            .Select(p => $"{JoinAttributes("Body(BodySerializationMethod.UrlEncoded)", GetAliasAsAttribute(p))}Dictionary<string, object> {p.VariableName}")
             .ToList();
 
         var parameters = new List<string>();
@@ -39,13 +41,23 @@ public static class ParameterExtractor
         return parameters;
     }
 
-    private static string GetBodyParameterType(IClientGenerator generator, JsonSchema schema) =>
-        WellKnownNamesspaces.TrimImportedNamespaces(
-            FindSupportedType(
-                generator.GetTypeName(
-                    schema.ActualTypeSchema,
-                    true,
-                    null)));
+    private static string GetAliasAsAttribute(CSharpParameterModel parameterModel) =>
+        string.Equals(parameterModel.Name, parameterModel.VariableName, StringComparison.OrdinalIgnoreCase)
+            ? string.Empty
+            : $"AliasAs(\"{parameterModel.Name}\")";
+
+    private static string JoinAttributes(params string[] attributes)
+    {
+        var filteredAttributes = attributes.Where(a => !string.IsNullOrWhiteSpace(a));
+
+        if (!filteredAttributes.Any())
+            return string.Empty;
+
+        return "[" + string.Join(", ", filteredAttributes) + "] ";
+    }
+
+    private static string GetBodyParameterType(CSharpParameterModel parameterModel) =>
+        WellKnownNamesspaces.TrimImportedNamespaces(FindSupportedType(parameterModel.Type));
 
     private static string FindSupportedType(string typeName) =>
         typeName == "FileResponse" ? "StreamPart" : typeName;

--- a/src/Refitter.Core/StringCasingExtensions.cs
+++ b/src/Refitter.Core/StringCasingExtensions.cs
@@ -5,9 +5,10 @@ public static class StringCasingExtensions
     public static string ConvertKebabCaseToPascalCase(this string str)
     {
         var parts = str.Split('-');
+
         for (var i = 0; i < parts.Length; i++)
         {
-            parts[i] = parts[i].CapitalizeFirstCharacter();
+            parts[i] = parts[i].CapitalizeFirstCharacter().Replace(".", "_");
         }
 
         return string.Join(string.Empty, parts);

--- a/test/OpenAPI/v3.0/IngramMicro.json
+++ b/test/OpenAPI/v3.0/IngramMicro.json
@@ -1,0 +1,17759 @@
+{
+  "openapi" : "3.0.0",
+  "info" : {
+    "version" : "6.0",
+    "title" : "Reseller API Documentation",
+    "description" : "For Resellers. <br>\nWho are looking to Innovate with Ingram Micro's API SolutionsAutomate your eCommerce with our offering of APIs and Webhooks to create a seamless experience for your customers."
+  },
+  "tags" : [ {
+    "name" : "Product Catalog",
+    "description" : "\nThe Ingram Micro Product Catalog v6 API endpoints enable users to:\n  - Search products by SKU or additional criteria.\n  - Find price and availability for up to 50 SKUs at one time.\n  - View inventory by location in the product catalog.\n  \n *Host Production URL - https://api.ingrammicro.com:443/resellers/v6*\n "
+  }, {
+    "name" : "Orders",
+    "description" : "\nIngram Micro’s Orders v6 API endpoints support both standard products and direct-ship products, including licensing and warranties SKUs. Users can:\n  - Search existing orders by Ingram Micro sales order number.\n  - View order details.\n  - Create and place new orders.\n  - Cancel orders, as permitted by order status.\n  \n*Host Production URL - https://api.ingrammicro.com:443/resellers/v6*\n   "
+  }, {
+    "name" : "Quotes",
+    "description" : "\nThis endpoint enables the retrieval and filtering of relevant quote list key criteria data, such as quote number, special bid numbers, end user name, status, and date ranges from the Ingram Micro system. By default, the Quotes endpoint retrieves quotes modified or created within the last 30 days.\nObserve these additional parameters:\n  - Only active quotes are available through this API.\n  - Quotes older than 365 days are excluded by default.\n  - You can use date range filters to retrieve quotes older than 30 days and up to 365 days.\n  - Quotes that are in draft and closed states are excluded, and are not accessible through this API.\n  \n*Host Production URL - https://api.ingrammicro.com:443/resellers/v6*  "
+  }, {
+    "name" : "Invoices",
+    "description" : "\nThe Ingram Micro Invoice v6 API endpoint provide real-time information for invoices. Users can:\n  - Get invoice information.\n  - View invoice information is available for orders placed in the last 2 years, by providing an Invoice number.\n\n\n*Host Production URL - https://api.ingrammicro.com:443/resellers/v6*\n"
+  }, {
+    "name" : "OrderStatus",
+    "description" : "\nA customer/reseller can select one or all of the events listed above under one webhook or can create individual webhook for each event. The primary reason to create multiple webhooks would be to have a dedicated destination URL for each event for processing. It is not required to do so and is recommended to have a single webhook for a resource type, for example a webhook for orders and in future you may have a dedicated webhook for quotes.\n\n\n*Host Production URL - https://api.ingrammicro.com:443/resellers/v1* \n"
+  }, {
+    "name" : "StockUpdate",
+    "description" : "\nA customer/reseller can select this event to get the updated quantity of the IPN. This event will trigger the updated quantity with a particular interval. To get the information of any SKU/IPN the customer should be authorized.\n\n\n*Host Production URL - https://api.ingrammicro.com:443/resellers/v1*     \n"
+  }, {
+    "name" : "Orders v5",
+    "description" : "\nIngram Micro’s Orders v5 API endpoints support both standard products and direct-ship products, including licensing and warranties SKUs. Users can:\n  - Search existing orders by Ingram Micro sales order number.\n  - View order details.\n  - Create and place new orders.\n  - Cancel orders, as permitted by order status.\n\n\n*Host Production URL - https://api.ingrammicro.com:443/resellers/v5*\n"
+  }, {
+    "name" : "Product Catalog v5",
+    "description" : "\nThe Ingram Micro Product Catalog v6 API endpoints enable users to:\n  - Search products by SKU or additional criteria.\n  - Find price and availability for up to 50 SKUs at one time.\n  - View inventory by location in the product catalog.\n\n\n*Host Production URL - https://api.ingrammicro.com:443/resellers/v5*\n"
+  }, {
+    "name" : "Quotes v5",
+    "description" : "\nThe Ingram Micro Quotes v5 API endpoints enable users to:\n  - Obtain a list of all quotes.\n  - View details for each quote, including: quote name, quote number, expiration date, product quantity and product price.\n  - Ingram Micro does not currently offer an API to create a quote.\n\n\n*Host Production URL - https://api.ingrammicro.com:443/resellers/v5*\n"
+  }, {
+    "name" : "Invoices V5",
+    "description" : "\nThe Ingram Micro Invoice v5 API endpoint provide real-time information for invoices and corresponding orders. Users can:\n  - Get invoice information for an open order or shipped order.\n  - View invoice information is available for orders placed in the last 9 months, by providing a sales order number.\n\n\n*Host Production URL - https://api.ingrammicro.com:443/resellers/v5*\n"
+  }, {
+    "name" : "Invoices v4",
+    "description" : "\nAll our archived API endpoints, these APIs will be deprecated in 2021. We recommend using the latest version 6.0 endpoints."
+  }, {
+    "name" : "Orders v4",
+    "description" : "\nAll our archived API endpoints, these APIs will be deprecated in 2021. We recommend using the latest version 6.0 endpoints."
+  }, {
+    "name" : "Product Catalog v4",
+    "description" : "\nAll our archived API endpoints, these APIs will be deprecated in 2021. We recommend using the latest version 6.0 endpoints."
+  }, {
+    "name" : "Quotes v4",
+    "description" : "\nAll our archived API endpoints, these APIs will be deprecated in 2021. We recommend using the latest version 6.0 endpoints."
+  } ],
+  "x-tagGroups" : [ {
+    "name" : "Reseller API (Version 6)",
+    "tags" : [ "Product Catalog", "Orders", "Quotes", "Invoices" ]
+  }, {
+    "name" : "Webhook APIs (Version 6)",
+    "tags" : [ "OrderStatus", "StockUpdate" ]
+  }, {
+    "name" : "Legacy APIs (Version 6)",
+    "tags" : [ "Orders v6" ]
+  }, {
+    "name" : "Legacy APIs (Version 5)",
+    "tags" : [ "Product Catalog v5", "Orders v5", "Quotes v5", "Invoices V5" ]
+  }, {
+    "name" : "Legacy APIs (Version 4)",
+    "tags" : [ "Product Catalog v4", "Orders v4", "Quotes v4", "Invoices v4" ]
+  } ],
+  "paths" : {
+    "/resellers/v6/catalog/priceandavailability" : {
+      "post" : {
+        "summary" : "Price and Availability",
+        "tags" : [ "Product Catalog" ],
+        "description" : "The PriceAndAvailability API, will retrieve Pricing, Availability, discounts, Inventory Location, Reserve Inventory for the products upto 50 products. ",
+        "operationId" : "post-priceandavailability",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "includeAvailability",
+          "in" : "query",
+          "description" : "Pass boolean value as input, if true the response will contain warehouse availability details, if false the response will not hold warehouse availability details",
+          "required" : true,
+          "schema" : {
+            "type" : "boolean",
+            "items" : {
+              "type" : "boolean",
+              "uniqueItems" : false
+            }
+          }
+        }, {
+          "name" : "includePricing",
+          "in" : "query",
+          "description" : "Pass boolean value as input, if true the response will contain Pricing details of the Product, if false the response will not hold Pricing details.",
+          "required" : true,
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "includeProductAttributes",
+          "in" : "query",
+          "description" : "Pass boolean value as input, if true the response will contain detailed attributes related to the Product, if false or not sent the response will contain very few Product details.",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your unique Ingram Micro customer number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "example" : "20-222222"
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "description" : "Two-character ISO country code.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "example" : "US"
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "description" : "Unique transaction number to identify each transaction across all the systems.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "fbac82ba-cf0a-4bcf-fc03-0c5084"
+          }
+        }, {
+          "name" : "IM-SenderID",
+          "in" : "header",
+          "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "examples" : {
+                "with one product" : {
+                  "value" : {
+                    "products" : [ {
+                      "ingramPartNumber" : "123512"
+                    } ]
+                  }
+                },
+                "with multiple products (both valid)" : {
+                  "value" : {
+                    "products" : [ {
+                      "ingramPartNumber" : "123512"
+                    }, {
+                      "ingramPartNumber" : "QQ0202"
+                    } ]
+                  }
+                },
+                "with multiple products (valid + invalid)" : {
+                  "value" : {
+                    "products" : [ {
+                      "ingramPartNumber" : "123512"
+                    }, {
+                      "ingramPartNumber" : "12351211"
+                    } ]
+                  }
+                },
+                "Request with combination of part numbers" : {
+                  "value" : {
+                    "products" : [ {
+                      "ingramPartNumber" : "QQ0202"
+                    }, {
+                      "vendorPartNumber" : "5204303"
+                    } ]
+                  }
+                },
+                "To find availability for particular Ingram Warehouse" : {
+                  "value" : {
+                    "products" : [ {
+                      "ingramPartNumber" : "3N7314"
+                    } ],
+                    "availabilityByWarehouse" : [ {
+                      "availabilityByWarehouseId" : "40"
+                    } ]
+                  }
+                }
+              },
+              "schema" : {
+                "$ref" : "#/components/schemas/PriceAndAvailabilityRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PriceAndAvailabilityResponse"
+                },
+                "examples" : {
+                  "SampleResponse" : {
+                    "value" : [ {
+                      "productStatusMessage" : "ACOPS ARE AVAILABLE FOR THIS CUSTOMER AND SKU",
+                      "ingramPartNumber" : "123512",
+                      "vendorPartNumber" : "LS1016A-CISCO",
+                      "customerPartNumber" : "A5-8963TEST",
+                      "upc" : "0718908728116",
+                      "partNumberType" : "T",
+                      "vendorNumber" : "1234",
+                      "vendorName" : "INTERNAL",
+                      "description" : "6FT PARALLEL PRINTER DB25M TO  SVCS CENT36M PRO SERIES 28AWG ROHS",
+                      "productClass" : "P",
+                      "uom" : "EA",
+                      "acceptBackOrder" : true,
+                      "productAuthorized" : true,
+                      "returnableProduct" : true,
+                      "endUserInfoRequired" : true,
+                      "availability" : {
+                        "available" : true,
+                        "totalAvailability" : 240479,
+                        "availabilityByWarehouse" : [ {
+                          "location" : "Fort Worth, TX",
+                          "warehouseId" : "20",
+                          "quantityAvailable" : 105415
+                        }, {
+                          "warehouseId" : "25",
+                          "quantityAvailable" : 100000
+                        }, {
+                          "location" : "Millington, TN",
+                          "warehouseId" : "30",
+                          "quantityAvailable" : 9981
+                        }, {
+                          "location" : "Carol Stream, IL",
+                          "warehouseId" : "40",
+                          "quantityAvailable" : 1049
+                        }, {
+                          "location" : "Jonestown, PA",
+                          "warehouseId" : "80",
+                          "quantityAvailable" : 995
+                        }, {
+                          "location" : "Mira Loma, CA",
+                          "warehouseId" : "10",
+                          "quantityAvailable" : 23039
+                        }, {
+                          "warehouseId" : "81"
+                        }, {
+                          "warehouseId" : "05"
+                        } ],
+                        "pricing" : {
+                          "currencyCode" : "USD",
+                          "retailPrice" : 10,
+                          "mapPrice" : 540.25,
+                          "customerPrice" : 5.43
+                        }
+                      }
+                    } ]
+                  }
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "Multi Status",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PriceAndAvailabilityResponse"
+                },
+                "examples" : {
+                  "with multiple products (valid + invalid)" : {
+                    "value" : [ {
+                      "productStatusMessage" : "ACOPS ARE AVAILABLE FOR THIS CUSTOMER AND SKU",
+                      "ingramPartNumber" : "123512",
+                      "vendorPartNumber" : "LS1016A-CISCO",
+                      "customerPartNumber" : "A5-8963TEST",
+                      "upc" : "0718908728116",
+                      "partNumberType" : "T",
+                      "vendorNumber" : "1234",
+                      "vendorName" : "INTERNAL",
+                      "description" : "6FT PARALLEL PRINTER DB25M TO  SVCS CENT36M PRO SERIES 28AWG ROHS",
+                      "productClass" : "P",
+                      "uom" : "EA",
+                      "acceptBackOrder" : true,
+                      "productAuthorized" : true,
+                      "returnableProduct" : true,
+                      "endUserInfoRequired" : true,
+                      "availability" : {
+                        "available" : true,
+                        "totalAvailability" : 240479,
+                        "availabilityByWarehouse" : [ {
+                          "location" : "Fort Worth, TX",
+                          "warehouseId" : "20",
+                          "quantityAvailable" : 105415
+                        }, {
+                          "warehouseId" : "25",
+                          "quantityAvailable" : 100000
+                        }, {
+                          "location" : "Millington, TN",
+                          "warehouseId" : "30",
+                          "quantityAvailable" : 9981
+                        }, {
+                          "location" : "Carol Stream, IL",
+                          "warehouseId" : "40",
+                          "quantityAvailable" : 1049
+                        }, {
+                          "location" : "Jonestown, PA",
+                          "warehouseId" : "80",
+                          "quantityAvailable" : 995
+                        }, {
+                          "location" : "Mira Loma, CA",
+                          "warehouseId" : "10",
+                          "quantityAvailable" : 23039
+                        }, {
+                          "warehouseId" : "81"
+                        }, {
+                          "warehouseId" : "05"
+                        } ],
+                        "pricing" : {
+                          "currencyCode" : "USD",
+                          "retailPrice" : 10,
+                          "mapPrice" : 540.25,
+                          "customerPrice" : 5.43
+                        }
+                      }
+                    }, {
+                      "productStatusCode" : "E",
+                      "productStatusMessage" : "Product not found for IngramPartNumber:  12351211",
+                      "ingramPartNumber" : "12351211"
+                    } ]
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Single Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "-bw0a10t1-2021-02-19T11:04:37.312-08:00",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CorrelationID",
+                          "value" : "",
+                          "message" : "IM-CorrelationID cannot be blank"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Server Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "C123-bw0a10u3-2021-02-19T11:12:26.436-08:00",
+                        "type" : "/errors/system-errors",
+                        "message" : "Some unexpected error occured, please contact support team for more details."
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resellers/v6/catalog" : {
+      "get" : {
+        "summary" : "Search Products",
+        "tags" : [ "Product Catalog" ],
+        "description" : "Search the Ingram Micro product catalog by providing any of the information in the keyword(Ingram part number / vendor part number/ product description / UPC",
+        "operationId" : "get-reseller-v6-productsearch",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "pageNumber",
+          "in" : "query",
+          "description" : "Current page number. Default is 1",
+          "required" : false,
+          "schema" : {
+            "type" : "integer",
+            "default" : "1",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your unique Ingram Micro customer number",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "example" : "20-222222"
+          }
+        }, {
+          "name" : "pageSize",
+          "in" : "query",
+          "description" : "Number of records required in the call - max records 100 per page",
+          "required" : false,
+          "schema" : {
+            "type" : "integer",
+            "default" : "25",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "IM-SenderID",
+          "in" : "header",
+          "description" : "Sender Identification text",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        }, {
+          "name" : "type",
+          "in" : "query",
+          "description" : "The SKU type of product. One of Physical, Digital, or Any.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "IM::physical", "IM::digital", "IM::any" ]
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "description" : "Unique transaction number to identify each transaction accross all the systems",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "fbac82ba-cf0a-4bcf-fc03-0c5084"
+          }
+        }, {
+          "name" : "hasDiscounts",
+          "in" : "query",
+          "description" : "Specifies if there are discounts available for the product.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : true
+          }
+        }, {
+          "name" : "vendor",
+          "in" : "query",
+          "description" : "The name of the vendor/manufacturer of the product.",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "uniqueItems" : false
+            }
+          }
+        }, {
+          "name" : "vendorPartNumber",
+          "in" : "query",
+          "description" : "The vendors part number for the product.",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "uniqueItems" : false
+            }
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "description" : "Two-character ISO country code.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "example" : "US"
+          }
+        }, {
+          "name" : "Accept-Language",
+          "in" : "header",
+          "description" : "Header to the API calls, the content will help us identify the response language.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "en"
+          }
+        }, {
+          "name" : "vendorNumber",
+          "in" : "query",
+          "description" : "Vendor number of the product",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "keyword",
+          "in" : "query",
+          "description" : "Keyword search,can be ingram part number or vendor part number or product title or vendor nameKeyword search. Can be Ingram Micro part number, vender part number, product title, or vendor name.",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "uniqueItems" : false
+            }
+          }
+        }, {
+          "name" : "category",
+          "in" : "query",
+          "description" : "The category of the product. Example: Displays.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "Accessories"
+          }
+        }, {
+          "name" : "skipAuthorisation",
+          "in" : "query",
+          "description" : "This parameter is True when you want Skip the authorization, so template will work like current B2b template.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "a ProductSearchv6ResponseElement to be returned",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction accross all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "maxLength" : 32,
+                  "example" : "MyCompany"
+                },
+                "description" : "Sender Identification text ."
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProductSearch_Response"
+                },
+                "examples" : {
+                  "Success - 200" : {
+                    "value" : {
+                      "recordsFound" : 1180,
+                      "pageSize" : 25,
+                      "pageNumber" : 2,
+                      "catalog" : [ {
+                        "description" : " CLASS 10 100MB/S UHS-I CARD",
+                        "category" : "device storage",
+                        "subCategory" : "Flash Memory Devices",
+                        "productType" : "",
+                        "ingramPartNumber" : "1A8249",
+                        "vendorPartNumber" : "SDSQUNC-016G-AN6IA",
+                        "upcCode" : "0619659134587",
+                        "vendorName" : "Sandisk Mobile",
+                        "endUserRequired" : "false",
+                        "hasDiscounts" : "",
+                        "type" : "IM::Physical",
+                        "discontinued" : "false",
+                        "newProduct" : "false",
+                        "directShip" : "false",
+                        "hasWarranty" : "false",
+                        "extraDescription" : "IPAD AIR CELL 256GB SKY BLUE ",
+                        "replacementSku" : "",
+                        "authorizedToPurchase" : "true",
+                        "links" : [ {
+                          "topic" : "catalog",
+                          "href" : "/catalog/1A8249",
+                          "type" : "GET"
+                        } ]
+                      } ],
+                      "nextPage" : "/resellers/v6/catalog?keyword=mobilepageSize=25&pageNumber=3",
+                      "previousPage" : "/resellers/v6/catalog?keyword=mobilepageSize=25&pageNumber=1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction accross all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "maxLength" : 32,
+                  "example" : "MyCompany"
+                },
+                "description" : "Sender Identification text ."
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "400 - Bad Request" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "C123-bw0a10u3-2021-03-18T11:12:26.436-08:00",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CountryCode",
+                          "message" : "Required field is missing"
+                        }, {
+                          "field" : "IM-CustomerNumber",
+                          "message" : "Required field is missing"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No Content",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "404 - Not Found" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : 123,
+                        "type" : "Validation error",
+                        "message" : "No Records Found"
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction accross all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "maxLength" : 32,
+                  "example" : "MyCompany"
+                },
+                "description" : "Sender Identification text ."
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Server Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "C123-bw0a10u3-2021-03-18T11:12:26.436-08:00",
+                        "type" : "/errors/system-errors",
+                        "message" : "Some unexpected error occured, please contact support team for more details"
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resellers/v1/webhooks/availabilityupdate" : {
+      "post" : {
+        "summary" : "Stock Update",
+        "tags" : [ "StockUpdate" ],
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "targeturl",
+          "in" : "header",
+          "description" : "The webhook url where the request needs to sent.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "https://59a2dc5368073ab42fd9a92e210a9fdb.m.pipedream.net/"
+          }
+        }, {
+          "name" : "x-hub-signature",
+          "in" : "header",
+          "description" : "Ingram Micro creates a signature token by use of a secret key + Event ID. The algorithm to generate the secret ley is given at link https://developer.ingrammicro.com/reseller/article/how-use-webhook-secret-key. Use the event Id in the below sample along with your secret key to generate the key. Alternatively, to send try this out, use a random text to see how it works.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "3LeaTfLE5FLj1FcYflwdwFosH4ADHmMbds6thtirGC3e9lEkF9/1pt4T2fQQGlxf40EznDBER0b60M75K6ZW0A=="
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "examples" : {
+                "Order with Header Comments" : {
+                  "value" : {
+                    "topic" : "resellers/catalog",
+                    "event" : "im::updated",
+                    "eventTimeStamp" : "2021-11-01T13:02:06.369Z",
+                    "eventId" : "AH7ESSIWSIO22Y77DD",
+                    "resource" : [ {
+                      "eventType" : "IM::STOCK_UPDATE",
+                      "ingramPartNumber" : "5CX579",
+                      "vendorPartNumber" : "710412-001-BTI",
+                      "vendorName" : "BATTERY TECHNOLOGY INC.",
+                      "upcCode" : "0886734869201",
+                      "skuStatus" : null,
+                      "backOrderFlag" : "Y",
+                      "totalAvailability" : "120",
+                      "links" : [ {
+                        "topic" : "orders",
+                        "href" : "/resellers/v5/catalog/5CX579",
+                        "type" : "GET"
+                      } ]
+                    }, {
+                      "eventType" : "IM::STOCK_UPDATE",
+                      "ingramPartNumber" : "5CT275",
+                      "vendorPartNumber" : "AC-U90W-HP",
+                      "vendorName" : "BATTERY TECHNOLOGY INC.",
+                      "upcCode" : "0745473120182",
+                      "skuStatus" : null,
+                      "backOrderFlag" : "Y",
+                      "totalAvailability" : "120",
+                      "links" : [ {
+                        "topic" : "orders",
+                        "href" : "/resellers/v5/catalog/5CT275",
+                        "type" : "GET"
+                      } ]
+                    } ]
+                  }
+                }
+              },
+              "schema" : {
+                "$ref" : "#/components/schemas/AvailabilityAsyncNotificationRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/resellers/v1/webhooks/orderstatusevent" : {
+      "post" : {
+        "summary" : "Order Status",
+        "tags" : [ "OrderStatus" ],
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "targeturl",
+          "in" : "header",
+          "description" : "The webhook url where the request needs to sent.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "https://59a2dc5368073ab42fd9a92e210a9fdb.m.pipedream.net/"
+          }
+        }, {
+          "name" : "x-hub-signature",
+          "in" : "header",
+          "description" : "Ingram Micro creates a signature token by use of a secret key + Event ID. The algorithm to generate the secret ley is given at link https://developer.ingrammicro.com/reseller/article/how-use-webhook-secret-key. Use the event Id in the below sample along with your secret key to generate the key. Alternatively, to send try this out, use a random text to see how it works.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "3LeaTfLE5FLj1FcYflwdwFosH4ADHmMbds6thtirGC3e9lEkF9/1pt4T2fQQGlxf40EznDBER0b60M75K6ZW0A=="
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "examples" : {
+                "Order with Header Comments" : {
+                  "value" : {
+                    "topic" : "resellers/orders",
+                    "event" : "im::updated",
+                    "eventTimeStamp" : "2021-11-01T13:02:06.369Z",
+                    "eventId" : "N01CIB9VVFYKR9J6ZW",
+                    "resource" : [ {
+                      "eventType" : "im::order_shipped",
+                      "orderNumber" : "20-RD128",
+                      "customerOrderNumber" : "ZENPO",
+                      "orderEntryTimeStamp" : "2020-04-03T08:54:39-07:00",
+                      "lines" : [ {
+                        "ingramLineNumber" : "001",
+                        "subOrderNumber" : "20-RD128-21",
+                        "lineStatus" : "IM::shipped",
+                        "ingramPartNumber" : "5CX895",
+                        "vendorPartNumber" : "TC57HO-1PEZU4P-NA",
+                        "requestedQuantity" : 3,
+                        "shippedQuantity" : 2,
+                        "backOrderedQuantity" : 1,
+                        "shipmentDetails" : [ {
+                          "shipmentDate" : "2019-11-06",
+                          "shipFromWarehouseId" : "10",
+                          "warehouseName" : "New York",
+                          "carrierCode" : "4M",
+                          "carrierName" : "SMARTPOST-BM",
+                          "packageDetails" : [ {
+                            "cartonNumber" : "",
+                            "quantityInbox" : "",
+                            "trackingNumber" : ""
+                          } ]
+                        } ],
+                        "serialNumberDetails" : [ {
+                          "serialNumber" : "123123123"
+                        } ]
+                      } ],
+                      "links" : [ {
+                        "topic" : "orders",
+                        "href" : "/resellers/v5/orders/20-RD128",
+                        "type" : "GET"
+                      } ]
+                    } ]
+                  }
+                }
+              },
+              "schema" : {
+                "$ref" : "#/components/schemas/OrderStatusAsyncNotificationRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/resellers/v6/orders" : {
+      "post" : {
+        "summary" : "Create your Order",
+        "tags" : [ "Orders" ],
+        "description" : "Instantly create and place orders. The POST API supports stocked SKUs as well as licensing and warranties SKUs.\nIM-CustomerNumber, IM-CountryCode, IM-SenderID and IM-CorrelationID are required parameters.\nIngram Micro recommends that you provide the ingrampartnumber for each SKU contained in each order.\nNOTE: You must have net terms to use the Ingram Micro Order Create API. Ingram Micro offers trade credit when using our APIs, and repayment is based on net terms. For example, if your net terms agreement is net-30, you will have 30 days to make a full payment. Ingram Micro does not allow credit card transactions for API ordering. ",
+        "operationId" : "post-createorder_v6",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your unique Ingram Micro customer number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "example" : "20-222222"
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "description" : "Two-character ISO country code.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "example" : "US"
+          }
+        }, {
+          "name" : "IM-SenderID",
+          "in" : "header",
+          "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "description" : "Unique transaction number to identify each transaction accross all the systems.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "fbac82ba-cf0a-4bcf-fc03-0c5084"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "examples" : {
+                "Order with Header Comments" : {
+                  "value" : {
+                    "customerOrderNumber" : "SWAGGER-01",
+                    "notes" : "This is the field for comments",
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "DF4128",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Shipping Instructions and Signature Required" : {
+                  "value" : {
+                    "customerOrderNumber" : "SHIPVIAeg",
+                    "shipToInfo" : {
+                      "email" : "dummy.email@ingrammicro.co.in"
+                    },
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "4U0212",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ],
+                    "shipmentDetails" : {
+                      "signatureRequired" : "true",
+                      "shippingInstructions" : "This is the shipping instruction for this order"
+                    }
+                  }
+                },
+                "Combined Order(Stock + Direct ship)" : {
+                  "value" : {
+                    "customerOrderNumber" : "Tejal899",
+                    "endCustomerOrderNumber" : "ENDUSER",
+                    "notes" : "direct ship and stock Order",
+                    "shipToInfo" : {
+                      "contact" : "TOM SORENSEN",
+                      "companyName" : "FIRST NATIONAL BANK OF OMAHA",
+                      "addressLine1" : "17501 W 98TH ST SPC 1833",
+                      "city" : "LENEXA",
+                      "state" : "KS",
+                      "postalCode" : "662191736",
+                      "countryCode" : "US"
+                    },
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "DF4128",
+                      "quantity" : 1
+                    }, {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "RQ6000",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Ship from warehouseid" : {
+                  "value" : {
+                    "customerOrderNumber" : "newcustomerPO4",
+                    "notes" : "this is an partial order process sample",
+                    "billToAddressId" : "000",
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "DF4128",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "shipFromWarehouseId",
+                      "attributeValue" : "10"
+                    }, {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Ship Complete Order" : {
+                  "value" : {
+                    "customerOrderNumber" : "THIS_IS-121",
+                    "shipToInfo" : {
+                      "email" : "dummy.email@ingrammicro.co.in"
+                    },
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "4U0212",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowPartialOrder",
+                      "attributeValue" : "true"
+                    }, {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ],
+                    "shipmentDetails" : {
+                      "shipComplete" : "true"
+                    }
+                  }
+                },
+                "Partial Order and Special Bid Number" : {
+                  "value" : {
+                    "customerOrderNumber" : "newcustomerPO4",
+                    "specialBidNumber" : "43426380",
+                    "notes" : "this is an partial order process sample",
+                    "billToAddressId" : "000",
+                    "shipToInfo" : {
+                      "contact" : "TOM SORENSEN",
+                      "companyName" : "FIRST NATIONAL BANK OF OMAHA",
+                      "addressLine1" : "17501 W 98TH ST SPC 1833",
+                      "city" : "LENEXA",
+                      "state" : "KS",
+                      "postalCode" : "662191736",
+                      "countryCode" : "US"
+                    },
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "DF4128",
+                      "quantity" : 1
+                    }, {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "XXXXXX",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowPartialOrder",
+                      "attributeValue" : "true"
+                    }, {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Backordered Request" : {
+                  "value" : {
+                    "customerOrderNumber" : "newcustomerP1O6",
+                    "notes" : "this is backorder sample",
+                    "acceptBackOrder" : "true",
+                    "shipToInfo" : {
+                      "contact" : "TOM SORENSEN",
+                      "companyName" : "FIRST NATIONAL BANK OF OMAHA",
+                      "addressLine1" : "17501 W 98TH ST SPC 1833",
+                      "city" : "LENEXA",
+                      "state" : "KS",
+                      "postalCode" : "662191736",
+                      "countryCode" : "US"
+                    },
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "DF4128",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Order with CarrierCode & Freight Acount Number" : {
+                  "value" : {
+                    "customerOrderNumber" : "SPCLBID1",
+                    "notes" : "Sample Order with Required Shipvia",
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "DF4128",
+                      "quantity" : 1,
+                      "unitPrice" : 60
+                    } ],
+                    "shipmentDetails" : {
+                      "carrierCode" : "RG",
+                      "freightAccountNumber" : "FRT100"
+                    },
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Order on CustomerHold" : {
+                  "value" : {
+                    "customerOrderNumber" : "SWAGGER-01",
+                    "notes" : "CustomerHoldOrderSample",
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "DF4128",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    }, {
+                      "attributeName" : "allowOrderOnCustomerHold",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Requested Unit Price or Price Variance" : {
+                  "value" : {
+                    "customerOrderNumber" : "SWAGGER-02",
+                    "specialBidNumber" : "43426380",
+                    "notes" : "Test Order for Unit Price",
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "TSXML1",
+                      "quantity" : 1,
+                      "unitPrice" : 10
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Direct Ship with EndUser Info" : {
+                  "value" : {
+                    "customerOrderNumber" : "newcustomerPO9",
+                    "notes" : "This is enduser info Order",
+                    "shipToInfo" : {
+                      "contact" : "Customer 1",
+                      "companyName" : "ABC priavte Ltd",
+                      "addressLine1" : "7001 SW 24th Ave",
+                      "addressLine2" : "testing",
+                      "city" : "Gainesville",
+                      "state" : "FL",
+                      "postalCode" : "326070001",
+                      "countryCode" : "US",
+                      "phoneNumber" : "987654321",
+                      "email" : "testing@yaho.com"
+                    },
+                    "endUserInfo" : {
+                      "endUserId" : "",
+                      "companyName" : "MEDECISION INC",
+                      "contact" : "AARON RICCITELLI",
+                      "addressLine1" : "601 LEE RD",
+                      "city" : "wayne",
+                      "state" : "pa",
+                      "postalCode" : "190875607",
+                      "countryCode" : "US",
+                      "phoneNumber" : "6105400202",
+                      "email" : "aaron.riccitelli@medecision.com"
+                    },
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "YZ1478",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Order with Shipping Address" : {
+                  "value" : {
+                    "customerOrderNumber" : "SWAGGER-03",
+                    "endCustomerOrderNumber" : "ENDUSER1",
+                    "notes" : "Order with Shipping Address",
+                    "shipToInfo" : {
+                      "contact" : "TOM SORENSEN",
+                      "companyName" : "FIRST NATIONAL BANK OF OMAHA",
+                      "addressLine1" : "17501 W 98TH ST SPC 1833",
+                      "city" : "LENEXA",
+                      "state" : "KS",
+                      "postalCode" : "662191736",
+                      "countryCode" : "US",
+                      "phoneNumber" : "987654321",
+                      "email" : "testing@yaho.com"
+                    },
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "DF4128",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "All Distributions ShipComplete-SplitOrder" : {
+                  "value" : {
+                    "customerOrderNumber" : "newcustomerP1O6",
+                    "notes" : "this is a Ship Complete Order",
+                    "acceptBackOrder" : "true",
+                    "shipToInfo" : {
+                      "contact" : "TOM SORENSEN",
+                      "companyName" : "FIRST NATIONAL BANK OF OMAHA",
+                      "addressLine1" : "17501 W 98TH ST SPC 1833",
+                      "city" : "LENEXA",
+                      "state" : "KS",
+                      "postalCode" : "662191736",
+                      "countryCode" : "US"
+                    },
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "DF4128",
+                      "quantity" : 10
+                    }, {
+                      "customerLineNumber" : "2",
+                      "ingramPartNumber" : "RQ6000",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    } ],
+                    "shipmentDetails" : {
+                      "shipComplete" : "E"
+                    }
+                  }
+                },
+                "APPLE DEP Sample" : {
+                  "value" : {
+                    "customerOrderNumber" : "APPLE DEP-01",
+                    "notes" : "this is APPLE DEP sample",
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "DF4128",
+                      "quantity" : 10
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    }, {
+                      "attributeName" : "eudepid",
+                      "attributeValue" : "DepIDTest1"
+                    }, {
+                      "attributeName" : "depordernbr",
+                      "attributeValue" : "Test1"
+                    } ]
+                  }
+                },
+                "Order with CPN - SAP" : {
+                  "value" : {
+                    "customerOrderNumber" : "Order with CPN-SAP",
+                    "lines" : [ {
+                      "customerLineNumber" : "2",
+                      "customerPartNumber" : "90NB0GI4-M03110",
+                      "quantity" : 1
+                    } ]
+                  }
+                },
+                "Govt fields with End User Info" : {
+                  "value" : {
+                    "customerOrderNumber" : "GovtOrder-01",
+                    "endCustomerOrderNumber" : "EPK_01081841",
+                    "endUserInfo" : {
+                      "companyName" : "US AIR FORCEE",
+                      "addressLine1" : "14300 FANG DR",
+                      "city" : "JACKSONVILLE",
+                      "state" : "FL",
+                      "postalCode" : "322187933",
+                      "countryCode" : "US",
+                      "phoneNumber" : "4786620376",
+                      "email" : "MATT.DIXON@US.AF.MIL"
+                    },
+                    "lines" : [ {
+                      "customerLineNumber" : "1",
+                      "ingramPartNumber" : "4A0036",
+                      "quantity" : "1,",
+                      "unitPrice" : 41.71
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "allowDuplicateCustomerOrderNumber",
+                      "attributeValue" : "true"
+                    }, {
+                      "attributeName" : "govtProgramType",
+                      "attributeValue" : "PA"
+                    }, {
+                      "attributeName" : "govtEndUserType",
+                      "attributeValue" : "F"
+                    }, {
+                      "attributeName" : "govtSolicitationNumber",
+                      "attributeValue" : "438"
+                    }, {
+                      "attributeName" : "govtEndUserData",
+                      "attributeValue" : "US AIR FORCEE"
+                    }, {
+                      "attributeName" : "govtEndUserPostalCode",
+                      "attributeValue" : "322187933"
+                    }, {
+                      "attributeName" : "govtPublicPrivateCode",
+                      "attributeValue" : "P"
+                    } ]
+                  }
+                }
+              },
+              "schema" : {
+                "$ref" : "#/components/schemas/OrderCreateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "description" : "Created",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OrderCreateResponse"
+                },
+                "examples" : {
+                  "Order with Header Comments Response" : {
+                    "value" : {
+                      "customerOrderNumber" : "SWAGGER-01",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 14.29,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "addressId" : "200",
+                        "companyName" : "INGRAM MICRO TEST ACCOUNT",
+                        "addressLine1" : "ATTN TOD DEBIE",
+                        "addressLine2" : "1610 E SAINT ANDREW PL",
+                        "city" : "SANTA ANA",
+                        "state" : "CA",
+                        "postalCode" : "927054931",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFKW4",
+                        "ingramOrderDate" : "2021-05-26",
+                        "notes" : "",
+                        "orderType" : "S",
+                        "orderTotal" : 14.29,
+                        "freightCharges" : 14.29,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFKW4-11",
+                          "ingramLineNumber" : "001",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "Backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 61.22,
+                          "extendedUnitPrice" : 0,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "O1",
+                            "carrierName" : "ONTRAC",
+                            "shipFromWarehouseId" : "10",
+                            "shipFromLocation" : "Mira Loma, CA"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFKW4",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Order on customer Hold" : {
+                    "value" : {
+                      "customerOrderNumber" : "SWAGGER-01",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 0,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "addressId" : "200",
+                        "companyName" : "INGRAM MICRO TEST ACCOUNT",
+                        "addressLine1" : "ATTN TOD DEBIE",
+                        "addressLine2" : "1610 E SAINT ANDREW PL",
+                        "city" : "SANTA ANA",
+                        "state" : "CA",
+                        "postalCode" : "927054931",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFKWQ",
+                        "ingramOrderDate" : "2021-05-26",
+                        "notes" : "CUSTOMERHOLDORDERSAMPLE",
+                        "orderType" : "S",
+                        "orderTotal" : 0,
+                        "freightCharges" : 0,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFKWQ-11",
+                          "ingramLineNumber" : "002",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "Backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 61.22,
+                          "extendedUnitPrice" : 0,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "XC",
+                            "carrierName" : "RG 3001   ND",
+                            "shipFromWarehouseId" : "10",
+                            "shipFromLocation" : "Mira Loma, CA"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFKWQ",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Ship Complete Order Response" : {
+                    "value" : {
+                      "customerOrderNumber" : "THIS_IS-12",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 70.84,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "addressId" : "200",
+                        "companyName" : "INGRAM MICRO TEST ACCOUNT",
+                        "addressLine1" : "ATTN TOD DEBIE",
+                        "addressLine2" : "1610 E SAINT ANDREW PL",
+                        "city" : "SANTA ANA",
+                        "state" : "CA",
+                        "postalCode" : "927054931",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFJN3",
+                        "ingramOrderDate" : "2021-05-13",
+                        "notes" : "////ORDER HEADER",
+                        "orderType" : "D",
+                        "orderTotal" : 70.84,
+                        "freightCharges" : 0,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFJN3-11",
+                          "ingramLineNumber" : "002",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "In Progress",
+                          "ingramPartNumber" : "4U0212",
+                          "unitPrice" : 70.84,
+                          "extendedUnitPrice" : 70.84,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 1,
+                          "quantityBackOrdered" : 0,
+                          "notes" : "3YR NBD EXCH SJ PRO 3XXX SVC   SVCS",
+                          "shipmentDetails" : {
+                            "carrierCode" : "VL",
+                            "carrierName" : "VIRTUAL",
+                            "shipFromWarehouseId" : "10",
+                            "shipFromLocation" : "Mira Loma, CA"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFJN3",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Backordered response" : {
+                    "value" : {
+                      "customerOrderNumber" : "NEWCUSTOMERP1O6",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 7.83,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "contact" : "TOM SORENSEN",
+                        "companyName" : "FIRST NATIONAL BANK OF OMAHA",
+                        "addressLine1" : "17501 W 98TH ST SPC 1833",
+                        "city" : "LENEXA",
+                        "state" : "KS",
+                        "postalCode" : "662191736",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFKWP",
+                        "ingramOrderDate" : "2021-05-26",
+                        "notes" : "",
+                        "orderType" : "S",
+                        "orderTotal" : 7.83,
+                        "freightCharges" : 7.83,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFKWP-11",
+                          "ingramLineNumber" : "002",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "Backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 61.22,
+                          "extendedUnitPrice" : 0,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "4M",
+                            "carrierName" : "SMARTPOST-BM",
+                            "shipFromWarehouseId" : "30",
+                            "shipFromLocation" : "Millington, TN"
+                          }
+                        } ],
+                        "miscellaneousCharges" : [ {
+                          "subOrderNumber" : "20-RFKWP-11",
+                          "chargeLineReference" : "895",
+                          "chargeDescription" : "FREE FREIGHT",
+                          "chargeAmount" : 0
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFKWP",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Shipping Instruction and Signature Required" : {
+                    "value" : {
+                      "customerOrderNumber" : "SHIPVIAEG",
+                      "billToAddressId" : "20-RFKKT : 000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 70.84,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "addressId" : "20-RFKKT : 200",
+                        "companyName" : "INGRAM MICRO TEST ACCOUNT",
+                        "addressLine1" : "ATTN TOD DEBIE",
+                        "addressLine2" : "1610 E SAINT ANDREW PL",
+                        "city" : "SANTA ANA",
+                        "state" : "CA",
+                        "postalCode" : "927054931",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFKKT",
+                        "ingramOrderDate" : "2021-05-24",
+                        "notes" : "20-RFKKT : ///SHPI:THIS IS THE SHIPPING INSTRU || 20-RFKKT : ///SHPI:CTION FOR THIS ORDER",
+                        "orderType" : "D",
+                        "orderTotal" : 70.84,
+                        "freightCharges" : 0,
+                        "totalTax" : 0,
+                        "currencyCode" : "20-RFKKT : USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFKKT-11",
+                          "ingramLineNumber" : "003",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "In Progress",
+                          "ingramPartNumber" : "4U0212",
+                          "unitPrice" : 70.84,
+                          "extendedUnitPrice" : 70.84,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 1,
+                          "quantityBackOrdered" : 0,
+                          "notes" : "3YR NBD EXCH SJ PRO 3XXX SVC   SVCS",
+                          "shipmentDetails" : {
+                            "carrierCode" : "VL",
+                            "carrierName" : "VIRTUAL",
+                            "shipFromWarehouseId" : "10",
+                            "shipFromLocation" : "Mira Loma, CA",
+                            "signatureRequired" : "true",
+                            "shippingInstructions" : "This is the shipping instruction for this order"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFKKT",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Carrier Code & Fright Account Number Response" : {
+                    "value" : {
+                      "customerOrderNumber" : "SPCLBID1",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 9.54,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "addressId" : "200",
+                        "companyName" : "INGRAM MICRO TEST ACCOUNT",
+                        "addressLine1" : "ATTN TOD DEBIE",
+                        "addressLine2" : "1610 E SAINT ANDREW PL",
+                        "city" : "SANTA ANA",
+                        "state" : "CA",
+                        "postalCode" : "927054931",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFK3K",
+                        "ingramOrderDate" : "2021-05-21",
+                        "notes" : "TESTING MAULTIPLE LINE ITEMS",
+                        "orderType" : "S",
+                        "orderTotal" : 9.54,
+                        "freightCharges" : 9.54,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFK3K-11",
+                          "ingramLineNumber" : "002",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "Backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 61.22,
+                          "extendedUnitPrice" : 0,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "RG",
+                            "carrierName" : "FEDEX GROUND",
+                            "shipFromWarehouseId" : "10",
+                            "shipFromLocation" : "Mira Loma, CA",
+                            "freightAccountNumber" : "FRT100"
+                          }
+                        } ],
+                        "miscellaneousCharges" : [ {
+                          "subOrderNumber" : "20-RFK3K-11",
+                          "chargeLineReference" : "895",
+                          "chargeDescription" : "FREE FREIGHT",
+                          "chargeAmount" : 0
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFK3K",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Response with Shipping Address" : {
+                    "value" : {
+                      "customerOrderNumber" : "TESTING_APR07",
+                      "endCustomerOrderNumber" : "ENDUSER",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 0,
+                      "resellerInfo" : {
+                        "companyName" : "Demo"
+                      },
+                      "shipToInfo" : {
+                        "contact" : "TOM SORENSEN",
+                        "companyName" : "FIRST NATIONAL BANK OF OMAHA",
+                        "addressLine1" : "17501 W 98TH ST SPC 1833",
+                        "city" : "LENEXA",
+                        "state" : "KS",
+                        "postalCode" : "662191736",
+                        "countryCode" : "US",
+                        "phoneNumber" : "987654321",
+                        "email" : "testing@yaho.com"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFDMQ",
+                        "ingramOrderDate" : "2021-04-07",
+                        "notes" : "",
+                        "orderType" : "S",
+                        "orderTotal" : 7.13,
+                        "freightCharges" : 7.13,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFDMQ-11",
+                          "ingramLineNumber" : "001",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "im::backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 61.22,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "4M",
+                            "carrierName" : "SMARTPOST-BM",
+                            "shipFromWarehouseId" : "30",
+                            "shipFromLocation" : "Millington, TN"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v5/orders/20-RFDMQ",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Direct Ship with EndUser Info" : {
+                    "value" : {
+                      "customerOrderNumber" : "SWAGGER-03",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 2802.71,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "contact" : "CUSTOMER 1",
+                        "companyName" : "ABC PRIAVTE LTD",
+                        "addressLine1" : "7001 SW 24TH AVE",
+                        "addressLine2" : "TESTING",
+                        "city" : "GAINESVILLE",
+                        "state" : "FL",
+                        "postalCode" : "326073704",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFJYX",
+                        "ingramOrderDate" : "2021-05-20",
+                        "notes" : "This is enduser info Order",
+                        "orderType" : "D",
+                        "orderTotal" : 2802.71,
+                        "freightCharges" : 0,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFJYX-11",
+                          "ingramLineNumber" : "002",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "In Progress",
+                          "ingramPartNumber" : "YZ1478",
+                          "unitPrice" : 2802.71,
+                          "extendedUnitPrice" : 2802.71,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 1,
+                          "quantityBackOrdered" : 0,
+                          "notes" : "PROD SNS VSPHERE 6 ESSLPL KIT  SLIC || 3YR || EU#- 000418285 MEDIA3 TECHNOLOGIES || MC# C",
+                          "shipmentDetails" : {
+                            "carrierCode" : "VL",
+                            "carrierName" : "VIRTUAL",
+                            "shipFromWarehouseId" : "40",
+                            "shipFromLocation" : "Carol Stream, IL"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFJYX",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Combined Order(Stock + Diret Ship)" : {
+                    "value" : {
+                      "customerOrderNumber" : "TEJAL899",
+                      "endCustomerOrderNumber" : "ENDUSER",
+                      "billToAddressId" : "000000",
+                      "orderSplit" : true,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 34212.93,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "contact" : "TOM SORENSEN",
+                        "companyName" : "FIRST NATIONAL BANK OF OMAHA",
+                        "addressLine1" : "17501 W 98TH ST SPC 1833",
+                        "city" : "LENEXA",
+                        "state" : "KS",
+                        "postalCode" : "662191736",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFKM1",
+                        "ingramOrderDate" : "2021-05-25",
+                        "notes" : "",
+                        "orderType" : "S",
+                        "orderTotal" : 7.83,
+                        "freightCharges" : 7.83,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFKM1-11",
+                          "ingramLineNumber" : "001",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "Backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 61.22,
+                          "extendedUnitPrice" : 0,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "4M",
+                            "carrierName" : "SMARTPOST-BM",
+                            "shipFromWarehouseId" : "30",
+                            "shipFromLocation" : "Millington, TN"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFKM1",
+                          "type" : "GET"
+                        } ]
+                      }, {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFKM2",
+                        "ingramOrderDate" : "2021-05-25",
+                        "notes" : "////ORDER HEADER",
+                        "orderType" : "D",
+                        "orderTotal" : 34205.1,
+                        "freightCharges" : 0,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFKM2-11",
+                          "ingramLineNumber" : "002",
+                          "customerLineNumber" : "2",
+                          "lineStatus" : "In Progress",
+                          "ingramPartNumber" : "RQ6000",
+                          "unitPrice" : 34205.1,
+                          "extendedUnitPrice" : 34205.1,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 1,
+                          "quantityBackOrdered" : 0,
+                          "notes" : "TIERBEAST 2CTRL 8GB 14X600GB   PERP || SAS 28X1TB SATA BLACK",
+                          "shipmentDetails" : {
+                            "carrierCode" : "XC",
+                            "carrierName" : "GR 127050 UN",
+                            "shipFromWarehouseId" : "40",
+                            "shipFromLocation" : "Carol Stream, IL"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFKM2",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Ship from warehouseid Response" : {
+                    "value" : {
+                      "customerOrderNumber" : "NEWCUSTOMERPO4",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 14.29,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "addressId" : "200",
+                        "companyName" : "INGRAM MICRO TEST ACCOUNT",
+                        "addressLine1" : "ATTN TOD DEBIE",
+                        "addressLine2" : "1610 E SAINT ANDREW PL",
+                        "city" : "SANTA ANA",
+                        "state" : "CA",
+                        "postalCode" : "927054931",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFKTB",
+                        "ingramOrderDate" : "2021-05-25",
+                        "notes" : "",
+                        "orderType" : "S",
+                        "orderTotal" : 14.29,
+                        "freightCharges" : 14.29,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFKTB-11",
+                          "ingramLineNumber" : "003",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "Backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 61.22,
+                          "extendedUnitPrice" : 0,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "O1",
+                            "carrierName" : "ONTRAC",
+                            "shipFromWarehouseId" : "10",
+                            "shipFromLocation" : "Mira Loma, CA"
+                          }
+                        } ],
+                        "miscellaneousCharges" : [ {
+                          "subOrderNumber" : "20-RFKTB-11",
+                          "chargeLineReference" : "895",
+                          "chargeDescription" : "FREE FREIGHT",
+                          "chargeAmount" : 0
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFKTB",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Order Split Response" : {
+                    "value" : {
+                      "customerOrderNumber" : "TEJAL899",
+                      "endCustomerOrderNumber" : "ENDUSER",
+                      "billToAddressId" : "000",
+                      "orderSplit" : true,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 36445.03,
+                      "shipToInfo" : {
+                        "contact" : "TOM SORENSEN",
+                        "companyName" : "FIRST BANK OF OMAHA",
+                        "addressLine1" : "17501 W 98TH ST SPC 1833",
+                        "city" : "LENEXA",
+                        "state" : "KS",
+                        "postalCode" : "662191736",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "50-65931",
+                        "ingramOrderDate" : "2021-03-31",
+                        "notes" : "////ORDER HEADER",
+                        "orderType" : "S",
+                        "orderTotal" : 0,
+                        "freightCharges" : 9.03,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "50-65931-11",
+                          "ingramLineNumber" : "001",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "im::backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 69.51,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "RG",
+                            "carrierName" : "FEDEX GROUND",
+                            "shipFromWarehouseId" : "30",
+                            "shipFromLocation" : "Millington, TN"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v5/orders/50-65931",
+                          "type" : "GET"
+                        } ]
+                      }, {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "50-65932",
+                        "ingramOrderDate" : "2021-03-31",
+                        "notes" : "////ORDER HEADER",
+                        "orderType" : "D",
+                        "orderTotal" : 36436,
+                        "freightCharges" : 0,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "50-65932-11",
+                          "ingramLineNumber" : "002",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "im::open",
+                          "ingramPartNumber" : "RQ6000",
+                          "unitPrice" : 36436,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 1,
+                          "quantityBackOrdered" : 0,
+                          "notes" : "TIERBEAST 2CTRL 8GB 14X600GB   PERP || SAS 28X1TB SATA BLACK",
+                          "shipmentDetails" : {
+                            "carrierCode" : "GR",
+                            "carrierName" : "DR SHP GROUN",
+                            "shipFromWarehouseId" : "10",
+                            "shipFromLocation" : "Mira Loma, CA"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v5/orders/50-65932",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Price Variance Response" : {
+                    "value" : {
+                      "customerOrderNumber" : "PRICEVARIANCE",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 9.54,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "companyName" : "B2B_TESTING_DEV",
+                        "addressLine1" : "100 LIGHTING WAY, 3RD FLOOR",
+                        "city" : "SECAUCUS",
+                        "state" : "NJ",
+                        "postalCode" : 70940000,
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-B31TK",
+                        "ingramOrderDate" : "2021-05-20",
+                        "notes" : "",
+                        "orderType" : "S",
+                        "orderTotal" : 9.54,
+                        "freightCharges" : 9.54,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-B31TK-11",
+                          "ingramLineNumber" : "001",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "Backordered",
+                          "ingramPartNumber" : "TSXML1",
+                          "unitPrice" : 7.15,
+                          "extendedUnitPrice" : 0,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "TEST XML SKU WITH NO AVAILABLE CABL || STOCK",
+                          "shipmentDetails" : {
+                            "carrierCode" : "RG",
+                            "carrierName" : "FEDEX GROUND",
+                            "shipFromWarehouseId" : "80",
+                            "shipFromLocation" : "Jonestown, PA"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-B31TK",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "All Distributions ShipComplete-SplitOrder" : {
+                    "value" : {
+                      "customerOrderNumber" : "NEWCUSTOMERP1O6",
+                      "billToAddressId" : "000",
+                      "orderSplit" : true,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 34212.93,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "contact" : "TOM SORENSEN",
+                        "companyName" : "FIRST NATIONAL BANK OF OMAHA",
+                        "addressLine1" : "17501 W 98TH ST SPC 1833",
+                        "city" : "LENEXA",
+                        "state" : "KS",
+                        "postalCode" : "662191736",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFL62",
+                        "ingramOrderDate" : "2021-05-28",
+                        "notes" : "THIS IS A SHIP COMPLETE ORDER",
+                        "orderType" : "S",
+                        "orderTotal" : 7.83,
+                        "freightCharges" : 7.83,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFL62-11",
+                          "ingramLineNumber" : "002",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "Backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 61.22,
+                          "extendedUnitPrice" : 0,
+                          "quantityOrdered" : 10,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 10,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "4M",
+                            "carrierName" : "SMARTPOST-BM",
+                            "shipFromWarehouseId" : "30",
+                            "shipFromLocation" : "Millington, TN"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFL62",
+                          "type" : "GET"
+                        } ]
+                      }, {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFL63",
+                        "ingramOrderDate" : "2021-05-28",
+                        "notes" : "THIS IS BACKORDER SAMPLE",
+                        "orderType" : "D",
+                        "orderTotal" : 34205.1,
+                        "freightCharges" : 0,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFL63-11",
+                          "ingramLineNumber" : "002",
+                          "customerLineNumber" : "2",
+                          "lineStatus" : "In Progress",
+                          "ingramPartNumber" : "RQ6000",
+                          "unitPrice" : 34205.1,
+                          "extendedUnitPrice" : 34205.1,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 1,
+                          "quantityBackOrdered" : 0,
+                          "notes" : "TIERBEAST 2CTRL 8GB 14X600GB   PERP || SAS 28X1TB SATA BLACK",
+                          "shipmentDetails" : {
+                            "carrierCode" : "XC",
+                            "carrierName" : "GR 127050 UN",
+                            "shipFromWarehouseId" : "40",
+                            "shipFromLocation" : "Carol Stream, IL"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFL63",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "APPLE DEP Response" : {
+                    "value" : {
+                      "customerOrderNumber" : "APPLE DEP-01",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 14.29,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "addressId" : "200",
+                        "companyName" : "INGRAM MICRO TEST ACCOUNT",
+                        "addressLine1" : "ATTN TOD DEBIE",
+                        "addressLine2" : "1610 E SAINT ANDREW PL",
+                        "city" : "SANTA ANA",
+                        "state" : "CA",
+                        "postalCode" : "927054931",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFLV4",
+                        "ingramOrderDate" : "2021-06-03",
+                        "notes" : "THIS IS APPLE DEP SAMPLE",
+                        "orderType" : "S",
+                        "orderTotal" : 14.29,
+                        "freightCharges" : 14.29,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFLV4-11",
+                          "ingramLineNumber" : "002",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "Backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 61.22,
+                          "extendedUnitPrice" : 0,
+                          "quantityOrdered" : 10,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 10,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "O1",
+                            "carrierName" : "ONTRAC",
+                            "shipFromWarehouseId" : "10",
+                            "shipFromLocation" : "Mira Loma, CA"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFLV4",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Order with CPN Response-SAP" : {
+                    "value" : {
+                      "customerOrderNumber" : "Order with CPN-SAP",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 5,
+                      "resellerInfo" : { },
+                      "shipToInfo" : {
+                        "addressId" : "292711",
+                        "companyName" : "ASUS ONLINE STORE",
+                        "addressLine1" : "205 KALLANG BAHRU, 04-00",
+                        "city" : "SINGAPORE",
+                        "state" : "SG",
+                        "postalCode" : "339341",
+                        "countryCode" : "SG"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "7059827143",
+                        "ingramOrderDate" : "2021-06-03T18:37:08+08:00",
+                        "notes" : "",
+                        "orderType" : "ZOR",
+                        "orderTotal" : 5,
+                        "freightCharges" : 0,
+                        "totalTax" : 0,
+                        "currencyCode" : "SGD",
+                        "lines" : [ {
+                          "ingramLineNumber" : "10",
+                          "customerLineNumber" : "2",
+                          "lineStatus" : "Backordered",
+                          "ingramPartNumber" : "4008025",
+                          "unitPrice" : 2218,
+                          "extendedUnitPrice" : 2218,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "shipmentDetails" : {
+                            "carrierCode" : "FR1SG00030",
+                            "shipFromWarehouseId" : "SG01"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/7059827143",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Govt fields with End User Info" : {
+                    "value" : {
+                      "customerOrderNumber" : "GovtOrder-01",
+                      "endCustomerOrderNumber" : "EPK_01081841",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 41.71,
+                      "resellerInfo" : { },
+                      "shipToInfo" : { },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-B31TK",
+                        "ingramOrderDate" : "2021-05-20",
+                        "notes" : "EUNAME: US AIR FORCEE || EUADD1: 14300 FANG DR || EUPH: 4786620376 || EUEMAIL: MATT.DIXON@US.AF.MIL",
+                        "orderType" : "S",
+                        "orderTotal" : 41.71,
+                        "freightCharges" : 0,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-B31TK-11",
+                          "ingramLineNumber" : "001",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "Backordered",
+                          "globalSkuId" : "A300-4A0036",
+                          "ingramPartNumber" : "4A0036",
+                          "vendorPartNumber" : "E2016HV",
+                          "vendorNumber" : "802U",
+                          "unitPrice" : 41.71,
+                          "extendedUnitPrice" : 0,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "20IN MONITOR E2016HV 210-AGLU  MNTR || EU#- 010004087 US AIR FORCEE || MC# F",
+                          "shipmentDetails" : {
+                            "carrierCode" : "UG",
+                            "carrierName" : "UPS GROUND",
+                            "shipFromWarehouseId" : "40",
+                            "shipFromLocation" : "Carol Stream, IL"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-B31TK",
+                          "type" : "GET"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "Multi-Status",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OrderCreateResponse"
+                },
+                "examples" : {
+                  "Partial Success" : {
+                    "value" : {
+                      "customerOrderNumber" : "TESTING_APR08",
+                      "endCustomerOrderNumber" : "ENDUSER",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : false,
+                      "purchaseOrderTotal" : 0,
+                      "resellerInfo" : {
+                        "companyName" : "Demo"
+                      },
+                      "shipToInfo" : {
+                        "contact" : "TOM SORENSEN",
+                        "companyName" : "FIRST NATIONAL BANK OF OMAHA",
+                        "addressLine1" : "17501 W 98TH ST SPC 1833",
+                        "city" : "LENEXA",
+                        "state" : "KS",
+                        "postalCode" : "662191736",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 0,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFDMQ",
+                        "ingramOrderDate" : "2021-04-07",
+                        "notes" : "",
+                        "orderType" : "S",
+                        "orderTotal" : 7.13,
+                        "freightCharges" : 7.13,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFDMR-11",
+                          "ingramLineNumber" : "001",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "im::backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 61.22,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "4M",
+                            "carrierName" : "SMARTPOST-BM",
+                            "shipFromWarehouseId" : "30",
+                            "shipFromLocation" : "Millington, TN"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v5/orders/20-RFDMQ",
+                          "type" : "GET"
+                        } ],
+                        "rejectedLineItems" : [ {
+                          "customerLinenumber" : "1",
+                          "ingramPartNumber" : "DF4128MW",
+                          "quantityOrdered" : 1,
+                          "rejectCode" : "EN",
+                          "rejectReason" : "SKU-NOTFOUND    DF4128MW"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Partial Order and special bid Number" : {
+                    "value" : {
+                      "customerOrderNumber" : "NEWCUSTOMERPO4",
+                      "billToAddressId" : "000",
+                      "orderSplit" : false,
+                      "processedPartially" : true,
+                      "purchaseOrderTotal" : 7.83,
+                      "resellerInfo" : {
+                        "companyName" : "Demo"
+                      },
+                      "shipToInfo" : {
+                        "contact" : "TOM SORENSEN",
+                        "companyName" : "FIRST NATIONAL BANK OF OMAHA",
+                        "addressLine1" : "17501 W 98TH ST SPC 1833",
+                        "city" : "LENEXA",
+                        "state" : "KS",
+                        "postalCode" : "662191736",
+                        "countryCode" : "US"
+                      },
+                      "orders" : [ {
+                        "numberOfLinesWithSuccess" : 1,
+                        "numberOfLinesWithError" : 1,
+                        "numberOfLinesWithWarning" : 0,
+                        "ingramOrderNumber" : "20-RFJYP",
+                        "ingramOrderDate" : "2021-05-20",
+                        "notes" : "",
+                        "orderType" : "S",
+                        "orderTotal" : 7.83,
+                        "freightCharges" : 7.83,
+                        "totalTax" : 0,
+                        "currencyCode" : "USD",
+                        "lines" : [ {
+                          "subOrderNumber" : "20-RFJYP-11",
+                          "ingramLineNumber" : "001",
+                          "customerLineNumber" : "1",
+                          "lineStatus" : "Backordered",
+                          "ingramPartNumber" : "DF4128",
+                          "unitPrice" : 61.22,
+                          "extendedUnitPrice" : 0,
+                          "quantityOrdered" : 1,
+                          "quantityConfirmed" : 0,
+                          "quantityBackOrdered" : 1,
+                          "notes" : "COMBO WAVE MK550 WRLS DESKTOP  WRLS || WRLS LASER MOUSE",
+                          "shipmentDetails" : {
+                            "carrierCode" : "4M",
+                            "carrierName" : "SMARTPOST-BM",
+                            "shipFromWarehouseId" : "30",
+                            "shipFromLocation" : "Millington, TN"
+                          }
+                        } ],
+                        "links" : [ {
+                          "topic" : "orders",
+                          "href" : "/resellers/v6/orders/20-RFJYP",
+                          "type" : "GET"
+                        } ],
+                        "rejectedLineItems" : [ {
+                          "customerLinenumber" : "1",
+                          "ingramPartNumber" : "XXXXXX",
+                          "quantityOrdered" : 1,
+                          "rejectCode" : "EN",
+                          "rejectReason" : "SKU-NOTFOUND    XXXXXX"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "123-345-678-bw0a1077-2021-04-07T01:26:54.411-07:00",
+                        "type" : "/errors/validation-failed",
+                        "messaage" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CountryCode",
+                          "value" : "USA",
+                          "message" : "IM-CountryCode is not valid"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500" : {
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Server Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "C123-bw0a10u3-2021-02-19T11:12:26.436-08:00",
+                        "type" : "/errors/system-errors",
+                        "message" : "Some unexpected error occured, please contact support team for more details"
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resellers/v6/orders/{orderNumber}" : {
+      "put" : {
+        "summary" : "Modify your Order",
+        "tags" : [ "Orders" ],
+        "description" : "The Order Modify API endpoint allows for changes to be made to an order after the order creation process as long as the order was created with the customer hold flag.\n\n* Orders can be modified within 24hrs of being placed with the customer hold flag, after 24hrs they are voided if they are not released by the customer.\n\n* Modifying orders that were placed without the customer hold flag is not possible ",
+        "operationId" : "put-ordermodify",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "orderNumber",
+          "in" : "path",
+          "description" : "Ingram sales order number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "20-RC1RD"
+          }
+        }, {
+          "name" : "actionCode",
+          "in" : "query",
+          "description" : "Action code to be used for order release.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "release"
+          }
+        }, {
+          "name" : "regionCode",
+          "in" : "query",
+          "description" : "Region code paramter to be used only for order release functionality.Region code is only for sandbox not for production",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "CS"
+          }
+        }, {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your unique Ingram Micro customer number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "example" : "20-222222"
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "description" : "Two-character ISO country code.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "example" : "US"
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "description" : "Unique transaction number to identify each transaction across all the systems.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "fbac82ba-cf0a-4bcf-fc03-0c5084"
+          }
+        }, {
+          "name" : "IM-SenderID",
+          "in" : "header",
+          "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        } ],
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OrderModifyRequest"
+              },
+              "examples" : {
+                "SingleLine" : {
+                  "value" : {
+                    "lines" : [ {
+                      "customerLineNumber" : "002",
+                      "ingramPartNumber" : "2GZ200",
+                      "addUpdateDeleteLine" : "ADD",
+                      "quantity" : 2
+                    } ]
+                  }
+                },
+                "MultipleLines" : {
+                  "value" : {
+                    "lines" : [ {
+                      "customerLineNumber" : "003",
+                      "ingramPartNumber" : "2GZ200",
+                      "addUpdateDeleteLine" : "ADD",
+                      "quantity" : 2
+                    }, {
+                      "customerLineNumber" : "004",
+                      "ingramPartNumber" : "DF4128",
+                      "addUpdateDeleteLine" : "ADD",
+                      "quantity" : 2
+                    } ]
+                  }
+                },
+                "Valid SKU and Blank Line Number" : {
+                  "value" : {
+                    "lines" : [ {
+                      "customerLineNumber" : "",
+                      "ingramPartNumber" : "1C6094",
+                      "addUpdateDeleteLine" : "ADD",
+                      "quantity" : 1
+                    } ]
+                  }
+                },
+                "Modify Quantity with integer value" : {
+                  "value" : {
+                    "lines" : [ {
+                      "ingramLineNumber" : "003",
+                      "ingramPartNumber" : "1C6094",
+                      "addUpdateDeleteLine" : "UPDATE",
+                      "quantity" : 2
+                    } ]
+                  }
+                },
+                "Delete single line" : {
+                  "value" : {
+                    "lines" : [ {
+                      "ingramLineNumber" : "004",
+                      "ingramPartNumber" : "1C6094",
+                      "addUpdateDeleteLine" : "DELETE",
+                      "quantity" : 2
+                    } ]
+                  }
+                },
+                "Delete multiple lines" : {
+                  "value" : {
+                    "lines" : [ {
+                      "ingramLineNumber" : "005",
+                      "ingramPartNumber" : "1C6094",
+                      "addUpdateDeleteLine" : "DELETE",
+                      "quantity" : 2
+                    }, {
+                      "ingramLineNumber" : "006",
+                      "ingramPartNumber" : "TXSLM3",
+                      "addUpdateDeleteLine" : "DELETE",
+                      "quantity" : 2
+                    } ]
+                  }
+                },
+                "Modify address with valid details" : {
+                  "value" : {
+                    "shipToInfo" : {
+                      "contact" : "Shinchan Corp Contact",
+                      "companyName" : "SHINCHAN CORP",
+                      "addressLine1" : "2502 N. Fort Valley Road",
+                      "addressLine2" : "building 1",
+                      "addressLine3" : "",
+                      "city" : "flagstaff",
+                      "state" : "AZ",
+                      "postalCode" : "86001",
+                      "countryCode" : "US",
+                      "phoneNumber" : "800-000-000",
+                      "email" : "newcorp@hotmail.com"
+                    }
+                  }
+                },
+                "Add header comments(>35 characters) with additionalAttributes" : {
+                  "value" : {
+                    "notes" : "This is a header comment greater than 35 characters",
+                    "additionalAttributes" : [ {
+                      "attributeName" : "enableCommentsAsLines",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Add header comments(<35 characters) without additionalAttributes" : {
+                  "value" : {
+                    "notes" : "This is a header comment"
+                  }
+                },
+                "Modify header comments" : {
+                  "value" : {
+                    "lines" : [ {
+                      "ingramLineNumber" : 9,
+                      "addUpdateDeleteLine" : "UPDATE",
+                      "notes" : "Updated header coments"
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "enableCommentsAsLines",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Delete header comments" : {
+                  "value" : {
+                    "lines" : [ {
+                      "ingramLineNumber" : "010",
+                      "addUpdateDeleteLine" : "DELETE"
+                    } ]
+                  }
+                },
+                "Add line notes" : {
+                  "value" : {
+                    "lines" : [ {
+                      "customerLineNumber" : "010",
+                      "ingramPartNumber" : "1C6094",
+                      "addUpdateDeleteLine" : "ADD",
+                      "quantity" : 1,
+                      "notes" : "Line comment"
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "enableCommentsAsLines",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Modify line notes" : {
+                  "value" : {
+                    "lines" : [ {
+                      "ingramLineNumber" : "011",
+                      "ingramPartNumber" : "1C6094",
+                      "addUpdateDeleteLine" : "UPDATE",
+                      "quantity" : 1,
+                      "notes" : "Updated Line comment"
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "enableCommentsAsLines",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                },
+                "Delete line notes" : {
+                  "value" : {
+                    "lines" : [ {
+                      "ingramLineNumber" : "012",
+                      "ingramPartNumber" : "1C6094",
+                      "addUpdateDeleteLine" : "UPDATE",
+                      "quantity" : 1
+                    } ],
+                    "additionalAttributes" : [ {
+                      "attributeName" : "enableCommentsAsLines",
+                      "attributeValue" : "true"
+                    } ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OrderModifyResponse"
+                },
+                "examples" : {
+                  "OneValidLine-OneInvalidPart" : {
+                    "value" : {
+                      "ingramOrderNumber" : "30-B3PF2",
+                      "orderModifiedDate" : "2021-02-20T15:05:19.515+05:30",
+                      "customerOrderNumber" : "MIGRATION_30172001",
+                      "orderTotal" : 3801.32,
+                      "orderSubTotal" : 3801.32,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "im::hold",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "subOrderNumber" : "30-B3PF2-11",
+                        "lineNumber" : "005",
+                        "customerLineNumber" : "005",
+                        "ingramPartNumber" : "2GZ200",
+                        "vendorPartNumber" : "SIP-T46S",
+                        "quantityOrdered" : 5,
+                        "quantityConfirmed" : 5,
+                        "shipmentDetails" : {
+                          "carrierCode" : "OT",
+                          "carrierName" : "OTHER"
+                        }
+                      } ],
+                      "rejectedLineItems" : [ {
+                        "customerLineNumber" : "006",
+                        "ingramPartNumber" : "2GZ2000001",
+                        "quantityOrdered" : 6,
+                        "rejectCode" : "EN",
+                        "rejectReason" : "Line Modification/ Addition for Line Number 006 Failed for reason : ERROR-PART-NOT-FOUNDEN"
+                      } ]
+                    }
+                  },
+                  "Release" : {
+                    "value" : null
+                  },
+                  "Valid SKU and Blank quantity" : {
+                    "value" : {
+                      "orderNumber" : "20-RF9N6",
+                      "orderModifiedDate" : "2021-03-10T03:31:24.657-08:00",
+                      "customerOrderNumber" : "PO79123920",
+                      "orderTotal" : 140.02,
+                      "orderSubTotal" : 140.02,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "rejectedLineItems" : [ {
+                        "customerLineNumber" : "1",
+                        "ingramPartNumber" : "DF4128",
+                        "rejectCode" : "EQ",
+                        "rejectReason" : "ERROR-INVALID-QTY"
+                      } ]
+                    }
+                  },
+                  "Valid SKU with 0 quantity" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T05:14:26.451-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "rejectedLineItems" : [ {
+                        "customerLineNumber" : "001",
+                        "ingramPartNumber" : "1C6094",
+                        "rejectCode" : "EQ",
+                        "rejectReason" : "ERROR-INVALID-QTY"
+                      } ]
+                    }
+                  },
+                  "Modify Quantity with invalid ingramLineNumber" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T05:48:36.31-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "rejectedLineItems" : [ {
+                        "ingramLineNumber" : "009",
+                        "ingramPartNumber" : "1C6094",
+                        "quantityOrdered" : 2,
+                        "rejectCode" : "EL",
+                        "rejectReason" : "ERROR-LINE-NOT-FOUND"
+                      } ]
+                    }
+                  },
+                  "Delete single line" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T05:51:30.809-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "ingramLineNumber" : "004",
+                        "customerLineNumber" : "000",
+                        "ingramPartNumber" : "1C6094"
+                      } ]
+                    }
+                  },
+                  "Delete single line with invalid ingramLineNumber" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T06:09:26.746-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "rejectedLineItems" : [ {
+                        "ingramLineNumber" : "004",
+                        "ingramPartNumber" : "1C6094",
+                        "quantityOrdered" : 2,
+                        "rejectCode" : "EL",
+                        "rejectReason" : "ERROR-LINE-NOT-FOUND"
+                      } ]
+                    }
+                  },
+                  "Delete multiple lines" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T06:12:29.656-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "ingramLineNumber" : "005",
+                        "customerLineNumber" : "000",
+                        "ingramPartNumber" : "1C6094"
+                      }, {
+                        "ingramLineNumber" : "006",
+                        "customerLineNumber" : "000",
+                        "ingramPartNumber" : "TXSLM3"
+                      } ]
+                    }
+                  },
+                  "Delete header comments" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-21T00:21:33.419-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "ingramLineNumber" : "010",
+                        "customerLineNumber" : "000"
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OrderModifyResponse"
+                },
+                "examples" : {
+                  "SingleLine" : {
+                    "value" : {
+                      "ingramOrderNumber" : "30-B3PF2",
+                      "orderModifiedDate" : "2021-02-20T15:05:19.515+05:30",
+                      "customerOrderNumber" : "MIGRATION_30172001",
+                      "orderTotal" : 3801.32,
+                      "orderSubTotal" : 3801.32,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "im::hold",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "subOrderNumber" : "30-B3PF2-11",
+                        "lineNumber" : "002",
+                        "customerLineNumber" : "002",
+                        "ingramPartNumber" : "2GZ200",
+                        "vendorPartNumber" : "SIP-T46S",
+                        "quantityOrdered" : 2,
+                        "quantityConfirmed" : 2,
+                        "shipmentDetails" : {
+                          "carrierCode" : "OT",
+                          "carrierName" : "OTHER"
+                        }
+                      } ]
+                    }
+                  },
+                  "MultipleLines" : {
+                    "value" : {
+                      "ingramOrderNumber" : "30-B3PF2",
+                      "orderModifiedDate" : "2021-02-20T15:05:19.515+05:30",
+                      "customerOrderNumber" : "MIGRATION_30172001",
+                      "orderTotal" : 3801.32,
+                      "orderSubTotal" : 3801.32,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "im::hold",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "subOrderNumber" : "30-B3PF2-11",
+                        "lineNumber" : "003",
+                        "customerLineNumber" : "003",
+                        "ingramPartNumber" : "2GZ200",
+                        "vendorPartNumber" : "SIP-T46S",
+                        "quantityOrdered" : 2,
+                        "quantityConfirmed" : 2,
+                        "shipmentDetails" : {
+                          "carrierCode" : "OT",
+                          "carrierName" : "OTHER"
+                        }
+                      }, {
+                        "subOrderNumber" : "30-B3PF2-11",
+                        "lineNumber" : "004",
+                        "customerLineNumber" : "004",
+                        "ingramPartNumber" : "DF4128",
+                        "vendorPartNumber" : "920-002555",
+                        "quantityOrdered" : 2,
+                        "quantityConfirmed" : 2,
+                        "shipmentDetails" : {
+                          "carrierCode" : "PV",
+                          "carrierName" : "AMAZON PRIME WC"
+                        }
+                      } ]
+                    }
+                  },
+                  "Valid SKU and Blank Line Number" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T05:42:50.003-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "subOrderNumber" : "20-RFJWZ-11",
+                        "ingramLineNumber" : "3",
+                        "customerLineNumber" : "000",
+                        "ingramPartNumber" : "1C6094",
+                        "quantityOrdered" : 1,
+                        "quantityBackOrdered" : 1,
+                        "shipmentDetails" : {
+                          "carrierCode" : "OT",
+                          "carrierName" : "OTHER"
+                        }
+                      } ]
+                    }
+                  },
+                  "Modify Quantity with integer value" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T05:46:22.36-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "subOrderNumber" : "20-RFJWZ-11",
+                        "ingramLineNumber" : "4",
+                        "customerLineNumber" : "000",
+                        "ingramPartNumber" : "1C6094",
+                        "quantityOrdered" : 2,
+                        "quantityBackOrdered" : 2,
+                        "shipmentDetails" : {
+                          "carrierCode" : "OT",
+                          "carrierName" : "OTHER"
+                        }
+                      } ]
+                    }
+                  },
+                  "Modify address with valid details" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T06:47:39.455-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "shipToInfo" : {
+                        "contact" : "SHINCHAN CORP CONTACT",
+                        "companyName" : "SHINCHAN CORP",
+                        "addressLine1" : "2502 N FORT VALLEY RD",
+                        "addressLine2" : "BUILDING 1",
+                        "city" : "FLAGSTAFF",
+                        "state" : "AZ",
+                        "postalCode" : "860010000",
+                        "countryCode" : "US",
+                        "phoneNumber" : "800-000-000",
+                        "email" : "newcorphotmail.com"
+                      }
+                    }
+                  },
+                  "Add header comments(>35 characters) with additionalAttributes" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T06:56:53.403-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "ingramLineNumber" : "007",
+                        "customerLineNumber" : "1",
+                        "notes" : "THIS IS A HEADER COMMENT GREATER TH"
+                      }, {
+                        "ingramLineNumber" : 8,
+                        "customerLineNumber" : "2",
+                        "notes" : "AN 35 CHARACTERS"
+                      } ]
+                    }
+                  },
+                  "Add header comments(<35 characters) without additionalAttributes" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T07:02:03.521-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "notes" : "This is a header comment",
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "ingramLineNumber" : 9,
+                        "customerLineNumber" : "1",
+                        "notes" : "THIS IS A HEADER COMMENT"
+                      } ]
+                    }
+                  },
+                  "Modify header comments" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T07:04:48.453-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "subOrderNumber" : "20-RFJWZ-11",
+                        "ingramLineNumber" : "10",
+                        "customerLineNumber" : "000",
+                        "notes" : "UPDATED HEADER COMENTS"
+                      } ]
+                    }
+                  },
+                  "Add line notes" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T07:08:46.101-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "subOrderNumber" : "20-RFJWZ-11",
+                        "ingramLineNumber" : "11",
+                        "customerLineNumber" : "010",
+                        "ingramPartNumber" : "1C6094",
+                        "quantityOrdered" : 1,
+                        "quantityBackOrdered" : 1,
+                        "shipmentDetails" : {
+                          "carrierCode" : "OT",
+                          "carrierName" : "OTHER"
+                        },
+                        "notes" : "20IN WS LED 1080P VA2055SM VGA MNTR || DVI SUPERCLEAR MVA PANEL || LINE COMMENT"
+                      } ]
+                    }
+                  },
+                  "Modify line notes" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T07:11:33.17-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "subOrderNumber" : "20-RFJWZ-11",
+                        "ingramLineNumber" : "12",
+                        "customerLineNumber" : "000",
+                        "ingramPartNumber" : "1C6094",
+                        "quantityOrdered" : 1,
+                        "quantityBackOrdered" : 1,
+                        "shipmentDetails" : {
+                          "carrierCode" : "OT",
+                          "carrierName" : "OTHER"
+                        },
+                        "notes" : "20IN WS LED 1080P VA2055SM VGA MNTR || DVI SUPERCLEAR MVA PANEL || UPDATED LINE COMMENT"
+                      } ]
+                    }
+                  },
+                  "Delete line notes" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RFJWZ",
+                      "orderModifiedDate" : "2021-05-20T07:13:56.466-07:00",
+                      "customerOrderNumber" : "STYPETEST3",
+                      "orderTotal" : 14.29,
+                      "orderSubTotal" : 14.29,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "ON HOLD",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "subOrderNumber" : "20-RFJWZ-11",
+                        "ingramLineNumber" : "13",
+                        "customerLineNumber" : "000",
+                        "ingramPartNumber" : "1C6094",
+                        "quantityOrdered" : 1,
+                        "quantityBackOrdered" : 1,
+                        "shipmentDetails" : {
+                          "carrierCode" : "OT",
+                          "carrierName" : "OTHER"
+                        }
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "Multi-Status",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OrderModifyResponse"
+                },
+                "examples" : {
+                  "ValidLine-InvalidAddress" : {
+                    "value" : {
+                      "ingramOrderNumber" : "30-B3PF2",
+                      "orderModifiedDate" : "2021-02-20T15:05:19.515+05:30",
+                      "changeDescription" : "Invalid details in shipping adress.Please update line details with valid data",
+                      "customerOrderNumber" : "MIGRATION_30172001",
+                      "orderTotal" : 3801.32,
+                      "orderSubTotal" : 3801.32,
+                      "freightCharges" : 0,
+                      "totalTax" : 0,
+                      "orderStatus" : "im::hold",
+                      "billToAddressId" : "000",
+                      "lines" : [ {
+                        "subOrderNumber" : "30-B3PF2-11",
+                        "lineNumber" : "002",
+                        "customerLineNumber" : "002",
+                        "ingramPartNumber" : "2GZ200",
+                        "vendorPartNumber" : "SIP-T46S",
+                        "quantityOrdered" : 1,
+                        "quantityConfirmed" : 1,
+                        "shipmentDetails" : {
+                          "carrierCode" : "OT",
+                          "carrierName" : "OTHER"
+                        }
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Single Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "123-bw0a10t3-2021-02-19T11:10:03.497-08:00",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "OrderNumber",
+                          "value" : "20-123",
+                          "message" : "OrderNumber must be in the format xx-xxxxx or xx-xxxxx-xx"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Multiple Errors" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "-bw0a10t1-2021-02-19T11:04:37.312-08:00",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CustomerNumber",
+                          "value" : "20-22222222",
+                          "message" : "IM-CustomerNumber must be in the format XX-XXXXXX"
+                        }, {
+                          "field" : "IM-CorrelationID",
+                          "value" : "",
+                          "message" : "IM-CorrelationID cannot be blank"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Modify address with invalid details" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "AxYqwpeo=sa-Fgwh",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "shipToAddress",
+                          "message" : "Invalid details in shipping adress.Please update shipping address details with valid data"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Order already released" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "AxYqwpeo=sa-Fgwh",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "message" : "Order can not be modified/released. Order is already released or Order is not placed on Customer Hold"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Server Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "C123-bw0a10u3-2021-02-19T11:12:26.436-08:00",
+                        "type" : "/errors/system-errors",
+                        "message" : "Some unexpected error occured, please contact support team for more details. "
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resellers/v6.1/orders/{ordernumber}" : {
+      "get" : {
+        "summary" : "Get Order Details v6.1",
+        "operationId" : "get-orderdetails-v6.1",
+        "description" : "A new API Catalog Request is not required for v6.1, anyone registered for v6.0 will automatically have access to v6.1.\n\n New functions added are\n\n - Service contracts, subscriptions and licenses information added\n\n - Estimated ship’, ‘Estimated delivery’ and ‘Delivered’ dates retrieved directly from vendors for Directship orders.\n\nFollowing updates are made in the responses to have better alingment of information\n\n - carriersOrder statuses at header\n\n   - BackorderedProcessing : Order accepted by Ingram and being processed\n\n  - Credit review – Order placed under credit check\n\n  - Partially shipped – At least one shipment within order is shipped\n\n  - Shipped – All shipments within the order are shipped\n\n  - Partially delivered – At least one shipment within order is delivered\n\n  - Delivered – All shipments within the order are delivered, E-Delivered,\n\n  - Cancelled\n\n - Ingram purchase order number and date added to order header object",
+        "tags" : [ "Orders" ],
+        "parameters" : [ {
+          "name" : "ordernumber",
+          "in" : "path",
+          "description" : "The Ingram Micro sales order number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 12,
+            "example" : "20-RD3QV"
+          }
+        }, {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your unique Ingram Micro customer number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "example" : "20-222222"
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "required" : true,
+          "description" : "Two-character ISO country code.",
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "example" : "US"
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "required" : true,
+          "description" : "Unique transaction number to identify each transaction accross all the systems.",
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "fbac82ba-cf0a-4bcf-fc03-0c5084"
+          }
+        }, {
+          "name" : "IM-SenderID",
+          "in" : "header",
+          "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany.",
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        }, {
+          "name" : "ingramOrderDate",
+          "in" : "query",
+          "description" : "The date and time in UTC format that the order was created.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date",
+            "example" : "2020-05-13"
+          }
+        }, {
+          "name" : "vendorNumber",
+          "in" : "query",
+          "description" : "Vendor Number.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "simulateStatus",
+          "in" : "query",
+          "description" : "Order response for various order statuses. Not for use in production.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "IM::SHIPPED", "IM::PARTIALLY_SHIPPED", "IM::HOLD", "IM::INVOICED" ]
+          }
+        }, {
+          "name" : "isIml",
+          "in" : "query",
+          "description" : "True/False only for IML customers.",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "regionCode",
+          "in" : "query",
+          "description" : "Region code for sandbox testing - Not for use in production.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OrderDetailB2B"
+                },
+                "examples" : {
+                  "Success" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RD3QV",
+                      "ingramOrderDate" : "2020-05-13T00:38:52-07:00",
+                      "orderType" : "D",
+                      "customerOrderNumber" : "16",
+                      "endCustomerOrderNumber" : "16",
+                      "webOrderId" : "93455594",
+                      "vendorSalesOrderNumber" : "114945339",
+                      "ingramPurchaseOrderNumber" : "80CLY55",
+                      "orderStatus" : "Processing",
+                      "orderTotal" : 25371.27,
+                      "orderSubTotal" : 25371.27,
+                      "freightCharges" : 0,
+                      "currencyCode" : "USD",
+                      "totalWeight" : 1,
+                      "totalTax" : 0,
+                      "paymentTerms" : "NET 20 DAYS",
+                      "notes" : "********* DIRECT SHIP INFO ******** || JON.HAWKINS@PNMRESOURCES.COM || ECTN PNM || EU-CNT-PH #505-987-3456   - || EU-PO-ID# 16",
+                      "billToInfo" : {
+                        "contact" : "CLAY MORGANX67468",
+                        "companyName" : "INGRAM MICRO CAPS TEST ACCOUNT",
+                        "addressLine1" : "1759 WEHRLE DR",
+                        "addressLine2" : "",
+                        "addressLine3" : "",
+                        "city" : "WILLIAMSVILLE",
+                        "state" : "NY",
+                        "postalCode" : "142210000",
+                        "countryCode" : "US",
+                        "phoneNumber" : "8286674626",
+                        "email" : "clay.morgan@ingram.com"
+                      },
+                      "shipToInfo" : {
+                        "contact" : "RALPH BIZZELL",
+                        "companyName" : "ASBURY METHODIST CHURCH",
+                        "addressLine1" : "INGRAM MICRO TEST ACCOUNT",
+                        "addressLine2" : "ATTN TOD DEBIE",
+                        "addressLine3" : "city",
+                        "city" : "SANTA ANA",
+                        "state" : "CA",
+                        "postalCode" : "927054931",
+                        "countryCode" : "US",
+                        "phoneNumber" : "8286674626",
+                        "email" : "clay.morgan@ingram.com"
+                      },
+                      "endUserInfo" : {
+                        "contact" : "RALPH BIZZELL",
+                        "companyName" : "ASBURY METHODIST CHURCH",
+                        "addressLine1" : "INGRAM MICRO TEST ACCOUNT",
+                        "addressLine2" : "ATTN TOD DEBIE",
+                        "addressLine3" : "city",
+                        "city" : "SANTA ANA",
+                        "state" : "CA",
+                        "postalCode" : "927054931",
+                        "countryCode" : "US",
+                        "phoneNumber" : "8286674626",
+                        "email" : "clay.morgan@ingram.com"
+                      },
+                      "lines" : [ {
+                        "subOrderNumber" : "20-RD3QV-11",
+                        "ingramOrderLineNumber" : "002",
+                        "vendorSalesOrderLineNumber" : "114945339",
+                        "customerLineNumber" : "001",
+                        "lineStatus" : "In Progress",
+                        "ingramPartNumber" : "4AW708",
+                        "vendorPartNumber" : "BE7H-M5-K9",
+                        "vendorName" : "CISCO - HW UNIFIED COMM",
+                        "partDescription" : "BUSINESS ED 7000H M5 APPL",
+                        "unitWeight" : 0,
+                        "weightUom" : "EA",
+                        "unitPrice" : 20887.57,
+                        "upcCode" : "",
+                        "extendedPrice" : 20887.57,
+                        "taxAmount" : 0,
+                        "currencyCode" : "USD",
+                        "quantityOrdered" : 1,
+                        "quantityConfirmed" : 1,
+                        "quantityBackOrdered" : 0,
+                        "specialBidNumber" : "3223A",
+                        "requestedDeliverydate" : "",
+                        "promisedDeliveryDate" : "2020-05-13",
+                        "lineNotes" : "EU#- 001837114 ABC Technologies || MC# C",
+                        "shipmentDetails" : [ {
+                          "quantity" : 1,
+                          "deliveryNumber" : "23423423",
+                          "estimatedShipDate" : "2022-10-07",
+                          "shipFromWarehouseId" : "10",
+                          "shipFromLocation" : "Mira Loma, CA",
+                          "invoiceNumber" : "20RD3QV11",
+                          "invoiceDate" : "2022-10-07",
+                          "carrierDetails" : [ {
+                            "carrierCode" : "VL",
+                            "carrierName" : "VIRTUAL",
+                            "quantity" : 0,
+                            "shippedDate" : "2022-10-07",
+                            "estimatedDeliveryDate" : "2022-10-07",
+                            "deliveredDate" : "2022-10-07",
+                            "carrierPickupDate" : "2022-10-07",
+                            "trackingDetails" : [ {
+                              "trackingNumber" : "390064340282",
+                              "trackingUrl" : "string",
+                              "packageWeight" : "1.2",
+                              "cartonNumber" : "1",
+                              "quantityInBox" : "1",
+                              "serialNumbers" : [ {
+                                "serialNumber" : "Q2EV-5SJ3-E6LN"
+                              } ]
+                            } ]
+                          } ]
+                        } ],
+                        "serviceContractInfo" : {
+                          "contractInfo" : {
+                            "contractDescription" : "Cisco IP Phone 7841 with Multiplatform Phone firmwareSNTC-8X",
+                            "contractNumber" : "205004823",
+                            "contractStatus" : "MANUALLY_CONVERTED",
+                            "contractStartDate" : "2022-10-09",
+                            "contractEndDate" : "2023-10-08",
+                            "contractDuration" : null
+                          },
+                          "subscriptions" : {
+                            "subscriptionId" : "Cisco IP Phone 7841 with Multiplatform",
+                            "subscriptionTerm" : "1",
+                            "renewalTerm" : "1",
+                            "billingModel" : "YEAR",
+                            "subcriptionStartDate" : "2022-10-09",
+                            "subcriptionEndDate" : "2023-10-09"
+                          },
+                          "licenseInfo" : {
+                            "licenseNumber" : [ "EX2SXV2NBNR" ],
+                            "licenseStartDate" : "2022-10-07",
+                            "licenseEndDate" : "2023-10-07",
+                            "description" : "Cisco AnyConnect VPN Only, 25 Simultaneous (eDelivery)",
+                            "quantity" : "1"
+                          }
+                        },
+                        "additionalAttributes" : [ {
+                          "attributeName" : "additional description",
+                          "attributeValue" : "EXPORT RESTR SW"
+                        } ],
+                        "links" : [ {
+                          "topic" : "invoices",
+                          "href" : "/resellers/v5/invoices/7870011?customerNumber=70-386612&isoCountryCode=US",
+                          "type" : "GET"
+                        } ]
+                      } ],
+                      "miscellaneousCharges" : [ {
+                        "subOrderNumber" : "20-RD3QV-11",
+                        "chargeLineReference" : "885",
+                        "chargeDescription" : "RECYCLING FEE BC",
+                        "chargeAmount" : "4.7"
+                      }, {
+                        "subOrderNumber" : "20-RD3QV-11",
+                        "chargeLineReference" : "GST",
+                        "chargeDescription" : "STATETAX",
+                        "chargeAmount" : "100.4"
+                      } ],
+                      "additionalAttributes" : [ {
+                        "attributeName" : "additional description",
+                        "attributeValue" : "EXPORT RESTR SW"
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponseDTO"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "application" : [ "read" ]
+        } ]
+      }
+    },
+    "/resellers/v6/orders/{ordernumber}" : {
+      "get" : {
+        "summary" : "Get Order Details v6",
+        "tags" : [ "Orders v6" ],
+        "description" : "Use your Ingram Micro sales order number to search for existing orders or retrieve existing order details.\n\nThe sales order number, IM-CustomerNumber, IM-CountryCode, IM-SenderID and IM-CorrelationID are required parameters.\n\nIn a case when the IM sales order number is repeated, you can refine the result by providing for additional filtering.\n\nUse the \"simulateStatus\" query parameter to test the GET order response for various order statuses. This parameter is only available in the sandbox to help with development and testing of the GET order endpoint.",
+        "operationId" : "get-orderdetails-v6",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "ordernumber",
+          "in" : "path",
+          "description" : "The Ingram Micro sales order number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 12,
+            "example" : "20-RD3QV"
+          }
+        }, {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your unique Ingram Micro customer number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "example" : "20-222222"
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "description" : "Two-character ISO country code.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "example" : "US"
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "description" : "Unique transaction number to identify each transaction accross all the systems.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "fbac82ba-cf0a-4bcf-fc03-0c5084"
+          }
+        }, {
+          "name" : "IM-SenderID",
+          "in" : "header",
+          "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        }, {
+          "name" : "ingramOrderDate",
+          "in" : "query",
+          "description" : "The date and time in UTC format that the order was created.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date",
+            "example" : "2020-05-13"
+          }
+        }, {
+          "name" : "vendorNumber",
+          "in" : "query",
+          "description" : "Vendor Number.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "simulateStatus",
+          "in" : "query",
+          "description" : "Order response for various order statuses. Not for use in production.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "IM::SHIPPED", "IM::PARTIALLY_SHIPPED", "IM::HOLD", "IM::INVOICED" ]
+          }
+        }, {
+          "name" : "isIml",
+          "in" : "query",
+          "description" : "True/False only for IML customers.",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "name" : "regionCode",
+          "in" : "query",
+          "description" : "Region code for sandbox testing - Not for use in production.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OrderDetailResponse"
+                },
+                "examples" : {
+                  "Success" : {
+                    "value" : {
+                      "ingramOrderNumber" : "20-RD3QV",
+                      "ingramOrderDate" : "2020-05-13T00:38:52-07:00",
+                      "orderType" : "D",
+                      "customerOrderNumber" : "16",
+                      "endCustomerOrderNumber" : "16",
+                      "orderStatus" : "Processing",
+                      "orderTotal" : 25371.27,
+                      "orderSubTotal" : 25371.27,
+                      "currencyCode" : "USD",
+                      "totalWeight" : 1,
+                      "totalTax" : 0,
+                      "paymentTerms" : "NET 20 DAYS",
+                      "notes" : "********* DIRECT SHIP INFO ******** || JON.HAWKINS@PNMRESOURCES.COM || ECTN PNM || EU-CNT-PH #505-987-3456   - || EU-PO-ID# 16",
+                      "billToInfo" : {
+                        "contact" : "CLAY MORGANX67468",
+                        "companyName" : "INGRAM MICRO CAPS TEST ACCOUNT",
+                        "addressLine1" : "1759 WEHRLE DR",
+                        "city" : "WILLIAMSVILLE",
+                        "state" : "NY",
+                        "postalCode" : "142210000",
+                        "countryCode" : "US"
+                      },
+                      "shipToInfo" : {
+                        "addressLine1" : "INGRAM MICRO TEST ACCOUNT",
+                        "addressLine2" : "ATTN TOD DEBIE",
+                        "addressLine3" : "city",
+                        "city" : "SANTA ANA",
+                        "state" : "CA",
+                        "postalCode" : "927054931",
+                        "countryCode" : "US"
+                      },
+                      "lines" : [ {
+                        "subOrderNumber" : "20-RD3QV-11",
+                        "ingramOrderLineNumber" : "002",
+                        "customerLineNumber" : "001",
+                        "lineStatus" : "In Progress",
+                        "ingramPartNumber" : "4AW708",
+                        "vendorPartNumber" : "BE7H-M5-K9",
+                        "vendorName" : "CISCO - HW UNIFIED COMM",
+                        "partDescription" : "BUSINESS ED 7000H M5 APPL",
+                        "unitWeight" : 0,
+                        "weightUom" : "EA",
+                        "unitPrice" : 20887.57,
+                        "extendedPrice" : 20887.57,
+                        "taxAmount" : 0,
+                        "currencyCode" : "USD",
+                        "quantityOrdered" : 1,
+                        "quantityConfirmed" : 1,
+                        "quantityBackOrdered" : 0,
+                        "promisedDeliveryDate" : "2020-05-13",
+                        "lineNotes" : "EU#- 001837114 ABC Technologies || MC# C",
+                        "shipmentDetails" : [ {
+                          "quantity" : 1,
+                          "shipFromWarehouseId" : "10",
+                          "shipFromLocation" : "Mira Loma, CA",
+                          "carrierDetails" : {
+                            "carrierCode" : "VL",
+                            "carrierName" : "VIRTUAL"
+                          }
+                        } ],
+                        "additionalAttributes" : [ {
+                          "attributeName" : "additional description",
+                          "attributeValue" : "EXPORT RESTR SW"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "No Content",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Data not found" : {
+                    "value" : null
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Single Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "123-bw0a10t3-2021-02-19T11:10:03.497-08:00",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "OrderNumber",
+                          "value" : "20-123",
+                          "message" : "OrderNumber must be in the format xx-xxxxx or xx-xxxxx-xx"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Multiple Errors" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "-bw0a10t1-2021-02-19T11:04:37.312-08:00",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CustomerNumber",
+                          "value" : "20-22222222",
+                          "message" : "IM-CustomerNumber must be in the format XX-XXXXXX"
+                        }, {
+                          "field" : "IM-CorrelationID",
+                          "value" : "",
+                          "message" : "IM-CorrelationID cannot be blank"
+                        }, {
+                          "field" : "IM-SenderID",
+                          "value" : "",
+                          "message" : "IM-SenderID cannot be blank"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Server Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "C123-bw0a10u3-2021-02-19T11:12:26.436-08:00",
+                        "type" : "/errors/system-errors",
+                        "message" : "Some unexpected error occured, please contact support team for more details"
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resellers/v6/orders/search" : {
+      "get" : {
+        "summary" : "Search your Orders",
+        "tags" : [ "Orders" ],
+        "description" : "Search your Ingram Micro orders. This endpoint searches by multiple order parameters and supports pagination of results.",
+        "operationId" : "get-resellers-v6-ordersearch",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "ingramOrderNumber",
+          "in" : "query",
+          "description" : "The Ingram Micro order number.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 11
+          }
+        }, {
+          "name" : "orderStatus",
+          "in" : "query",
+          "description" : "Ingram Micro order status.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "SHIPPED", "PROCESSING", "ON HOLD", "BACKORDERED", "CANCELLED" ]
+          }
+        }, {
+          "name" : "orderStatus-in",
+          "in" : "query",
+          "description" : "Ingram Micro order status(can use it for multiple entries).",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "uniqueItems" : false
+            }
+          }
+        }, {
+          "name" : "ingramOrderDate",
+          "in" : "query",
+          "description" : "Search by Order date(yyyy-MM-dd).",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "2021-04-23"
+          }
+        }, {
+          "name" : "ingramOrderDate-bt",
+          "in" : "query",
+          "description" : "Search with start and end date(only 2 entries allowed).",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "uniqueItems" : false
+            }
+          }
+        }, {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your unique Ingram Micro customer number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "20-222222",
+            "maxLength" : 10
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "description" : "Two-character ISO country code.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "US",
+            "maxLength" : 2,
+            "minLength" : 2
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "description" : "Unique transaction number to identify each transaction accross all the systems.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "fbac82ba-cf0a-4bcf-fc03-0c5084"
+          }
+        }, {
+          "name" : "IM-SenderID",
+          "in" : "header",
+          "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        }, {
+          "name" : "customerOrderNumber",
+          "in" : "query",
+          "description" : "Search using your PO/Order number.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 35
+          }
+        }, {
+          "name" : "pageSize",
+          "in" : "query",
+          "description" : "Number of records required in the call - max records 100 per page.",
+          "required" : false,
+          "schema" : {
+            "type" : "integer",
+            "default" : "25",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "pageNumber",
+          "in" : "query",
+          "description" : "The page number reference.",
+          "required" : false,
+          "schema" : {
+            "type" : "integer",
+            "default" : "1",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OrderSearch_Response to be returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OrderSearch_Response"
+                },
+                "examples" : {
+                  "Success - 200" : {
+                    "value" : {
+                      "recordsFound" : "123",
+                      "pageSize" : "25",
+                      "pageNumber" : "1",
+                      "orders" : [ {
+                        "ingramOrderNumber" : "20-RD128",
+                        "ingramOrderDate" : "2020-04-03T08:54:39+05:30",
+                        "customerOrderNumber" : "MyPONumber",
+                        "vendorSalesOrderNumber" : "8987380",
+                        "vendorName" : "Microsoft",
+                        "endUserCompanyName" : "ABC TECHNOLOGIES",
+                        "orderTotal" : "120.00",
+                        "orderStatus" : "OPEN",
+                        "subOrders" : [ {
+                          "subOrderNumber" : "20-RD128-11",
+                          "subOrderTotal" : "100.00",
+                          "subOrderStatus" : "SHIPPED",
+                          "links" : {
+                            "topic" : "orders",
+                            "href" : "/resellers/v6/orders/20-RD128-11",
+                            "type" : "GET"
+                          }
+                        }, {
+                          "links" : {
+                            "topic" : "orders",
+                            "href" : "/resellers/v6/orders/20-RD128",
+                            "type" : "GET"
+                          }
+                        } ]
+                      } ],
+                      "nextPage" : "/resellers/v6/orders/[original_parameters]&pageNumber=2",
+                      "previousPage" : "/resellers/v6/orders/[original_parameters]&pageNumber=1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "No Content",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "description" : "Unique transaction number to identify each transaction accross all the systems.",
+                "schema" : {
+                  "type" : "string"
+                }
+              },
+              "IM-SenderID" : {
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany",
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "400 - Bad Request" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "d27059e19119",
+                        "1ype" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "customerOrderNumber",
+                          "message" : "Required field is missing"
+                        }, {
+                          "field" : "ingramOrderDate/ingramOrderDate-bt",
+                          "message" : "input date format error expected format is - yyyy-MM-dd",
+                          "value" : "2020-10-21"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Server Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "74681b27-b1ea-454d-9847-d27059e19119",
+                        "type" : "/errors/server-error",
+                        "message" : "ConnectivityIssue/ERP issue Contact Ingram Micro API Support   "
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resellers/v6/orders/{OrderNumber}" : {
+      "delete" : {
+        "summary" : "Cancel your Order",
+        "tags" : [ "Orders" ],
+        "description" : "This call must be submitted before the order is released to Ingram Micro’s warehouse. The order cannot be canceled once it is released to the warehouse. Order should be on customer hold to delete any order from Ingram system.",
+        "operationId" : "delete-ordercancel",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "regionCode",
+          "in" : "query",
+          "description" : "Region code for sandbox testing - Not for use in production.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "CS"
+          }
+        }, {
+          "name" : "OrderNumber",
+          "in" : "path",
+          "description" : "Ingram Micro sales order number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "20-RD128"
+          }
+        }, {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your unique Ingram Micro customer number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "20-222222"
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "description" : "Two-character ISO country code.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "example" : "US"
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "description" : "Unique transaction number to identify each transaction accross all the systems.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "fbac82ba-cf0a-4bcf-fc03-0c5084"
+          }
+        }, {
+          "name" : "IM-SenderID",
+          "in" : "header",
+          "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Ok",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : { }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "400 - Bad Request" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "74681b27-b1ea-454d-9847-d27059e19119",
+                        "1ype" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "Country Code",
+                          "message" : "Country Code is missing."
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "404 - Not Found" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "74681b27-b1ea-454d-9847-d27059e19119",
+                        "type" : "/errors/validation-error",
+                        "message" : "Order not found."
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Method Not Allowed",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "405 - Method Not Allowed" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "74681b27-b1ea-454d-9847-d27059e19119",
+                        "type" : "/errors/validation-error",
+                        "message" : "Order can not be deleted as the order is not no hold."
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "500 - Internal Server Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "74681b27-b1ea-454d-9847-d27059e19119",
+                        "type" : "/errors/server-error",
+                        "message" : "ConnectivityIssue/ERP issue Contact Ingram Micro API Support. "
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resellers/v6/quotes/search" : {
+      "get" : {
+        "summary" : "Quote Search",
+        "tags" : [ "Quotes" ],
+        "description" : "The Quote Search API, by default, will retrieve quotes modified or created within the last 30 days. Quotes older than 365 days are excluded by default. The date filters enable the retrieval of quotes older than 30 days and up to 365 days when using date range criteria. The Quote Search API enables the retrieval and filtering of relevant quote list key criteria data such as Quote Number, Special Bid Numbers, End User Name, Quote Status, and Date Ranges from Ingram Micros CRM system. Only Active quotes are avaiable through the API.  Draft and Closed quotes are excluded and are not accessable through the Quote List Search API.",
+        "operationId" : "get-quotessearch_v6",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "ingramOrderDate-bt",
+          "in" : "query",
+          "description" : "Search with start and end date(only 2 entries allowed).",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "uniqueItems" : false
+            }
+          }
+        }, {
+          "name" : "quoteNumber",
+          "in" : "query",
+          "description" : "Unique identifier generated by Ingram Micros CRM specific to each quote.  When applying a filter to the quoteNumber and including a partial quote number in the filter, all quotes containing any information included in the filter can be retrieved as a subset of all available customer quotes.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "QUO-10985-C4C3F7"
+          }
+        }, {
+          "name" : "specialBidNumber",
+          "in" : "query",
+          "description" : "Special Pricing Bid Number, also referred to as a Dart Number by some vendors, is a unique identifier associated with vendor specific products and discounts.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "9638445-1880"
+          }
+        }, {
+          "name" : "endUserContact",
+          "in" : "query",
+          "description" : "End User Name is the end customer name that is associated with a quote in Ingram Micros CRM.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "JD Enterprises"
+          }
+        }, {
+          "name" : "sortingOrder",
+          "in" : "query",
+          "description" : "Sort applies to the selected column (sortingColumnName) and may be specified in  Ascending (asc) or Descending (desc) order. The default sort is Descending (desc) - most recent first.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "desc"
+          }
+        }, {
+          "name" : "sortBy",
+          "in" : "query",
+          "description" : "Refers to the column selected to apply the sorting criteria.  The default column is dateCreated and will sort by the most recently created quote first with the following in descending order.  The default filter retrieves quotes created within the last 30 days. Filtering allows user to select a specific column to sort: quoteNumber, createdDate, lastModifiedDate, expiryDate, and endUserName.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "quoteNumber"
+          }
+        }, {
+          "name" : "thirdPartySource",
+          "in" : "query",
+          "description" : "Unique identifier used to identify the third party source accessing the services.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "3RDPIDCONWISE"
+          }
+        }, {
+          "name" : "pageSize",
+          "in" : "query",
+          "description" : "Number of records (quotes) to display per page in the quote list.  The default is 25, but may be decreased using the filter .",
+          "required" : false,
+          "schema" : {
+            "type" : "integer",
+            "example" : 25
+          }
+        }, {
+          "name" : "pageNumber",
+          "in" : "query",
+          "description" : "Page index or page number for the list of quotes being returned.",
+          "required" : false,
+          "schema" : {
+            "type" : "integer",
+            "default" : 1
+          }
+        }, {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your unique Ingram Micro customer number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "example" : "20-222222"
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "description" : "Two-character ISO country code.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "example" : "US"
+          }
+        }, {
+          "name" : "IM-CustomerContact",
+          "in" : "header",
+          "description" : "Logged in Users email address contact.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 64,
+            "example" : "John.Doe@reseller.com"
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "description" : "Unique transaction number to identify each transaction across all the systems.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "fbac82ba-cf0a-4bcf-fc03-0c5084"
+          }
+        }, {
+          "name" : "IM-SenderID",
+          "in" : "header",
+          "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/QuoteSearchResponse"
+                },
+                "examples" : {
+                  "SampleResponse" : {
+                    "value" : {
+                      "recordsFound" : 4,
+                      "pageSize" : 25,
+                      "pageNumber" : 1,
+                      "quotes" : [ {
+                        "quoteGuid" : "30786810-d7e8-e911-a97b-000d3a30e34c",
+                        "quoteName" : "Test Quote - 999",
+                        "quoteNumber" : "QUO-10985-C4C3F7",
+                        "revision" : "1",
+                        "endUserContact" : "test",
+                        "specialBidNumber" : null,
+                        "quoteTotal" : 400.03,
+                        "quoteStatus" : "Active",
+                        "ingramQuoteDate" : "2019-10-07",
+                        "lastModifiedDate" : "2020-01-10",
+                        "ingramQuoteExpiryDate" : "0001-01-01"
+                      }, {
+                        "quoteGuid" : "88f0efdc-53e5-e911-a97b-000d3a30e34c",
+                        "quoteName" : "Test1",
+                        "quoteNumber" : "QUO-10637-W4M3G1",
+                        "revision" : "0",
+                        "endUserContact" : null,
+                        "specialBidNumber" : null,
+                        "quoteTotal" : 0,
+                        "quoteStatus" : "Active",
+                        "ingramQuoteDate" : "2019-10-02",
+                        "lastModifiedDate" : "2019-10-02",
+                        "ingramQuoteExpiryDate" : "0001-01-01"
+                      }, {
+                        "quoteGuid" : "02bdecfd-33e1-e911-a97a-000d3a30eb04",
+                        "quoteName" : "MSJ Singapore Test 02",
+                        "quoteNumber" : "QUO-10477-X9M2N4",
+                        "revision" : "0",
+                        "endUserContact" : null,
+                        "specialBidNumber" : null,
+                        "quoteTotal" : 11642.1,
+                        "quoteStatus" : "Active",
+                        "ingramQuoteDate" : "2019-09-27",
+                        "lastModifiedDate" : "2019-09-27",
+                        "ingramQuoteExpiryDate" : "0001-01-01"
+                      }, {
+                        "quoteGuid" : "994690a2-33e1-e911-a97a-000d3a30eb04",
+                        "quoteName" : "MSJ Singapore Test 01",
+                        "quoteNumber" : "QUO-10475-S4M1N0",
+                        "revision" : "0",
+                        "endUserContact" : null,
+                        "specialBidNumber" : null,
+                        "quoteTotal" : 11902.38,
+                        "quoteStatus" : "Active",
+                        "ingramQuoteDate" : "2019-09-27",
+                        "lastModifiedDate" : "2019-09-27",
+                        "ingramQuoteExpiryDate" : "0001-01-01"
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Multiple Errors" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "-bw0a10t1-2021-02-19T11:04:37.312-08:00",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CustomerNumber",
+                          "value" : "20-22222222",
+                          "message" : "IM-CustomerNumber must be in the format XX-XXXXXX"
+                        }, {
+                          "field" : "IM-CorrelationID",
+                          "value" : "",
+                          "message" : "IM-CorrelationID cannot be blank"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "No records found" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "-bw0a10t1-2021-02-19T11:04:37.312-08:00",
+                        "type" : "/errors/validation-failed",
+                        "message" : "No records found for the provided criteria."
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-SenderID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Server Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "C123-bw0a10u3-2021-02-19T11:12:26.436-08:00",
+                        "type" : "/errors/system-errors",
+                        "message" : "Some unexpected error occured, please contact support team for more details."
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resellers/v6/quotes/{quoteNumber}" : {
+      "get" : {
+        "summary" : "Get Quote Details",
+        "tags" : [ "Quotes" ],
+        "description" : "The quote details API provides all quote details associated with the quote number provided.\n\nThe **“quoteNumber”**, **“isoCountryCode”** and **“customerNumber”** parameters are required. ",
+        "operationId" : "get-resellers-v6-quotes",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your Ingram Micro unique customer number",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "example" : "20-222222"
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "description" : "Two-character ISO country code.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "example" : "US"
+          }
+        }, {
+          "name" : "IM-SenderID",
+          "in" : "header",
+          "description" : "Unique identifier used to identify the third party source accessing the services.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        }, {
+          "name" : "quoteNumber",
+          "in" : "path",
+          "description" : "Unique identifier generated by Ingram Micro's CRM specific to each quote.  When applying a filter to the quoteNumber and including a partial quote number in the filter, all quotes containing any information included in the filter can be retrieved as a subset of all available customer quotes.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "QUO-10926-Y8G1B3"
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "description" : "Unique transaction number to identify each transaction accross all the systems.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "ASJDasbjdn-asjnd12dalks-asjkn"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/QuoteDetailsResponse"
+                },
+                "examples" : {
+                  "Success" : {
+                    "value" : {
+                      "quoteName" : "Q3",
+                      "quoteNumber" : "QUO-10926-Y8G1B3",
+                      "revision" : "0",
+                      "ingramQuoteDate" : "2019-10-04T18:17:28Z",
+                      "lastModifiedDate" : "2019-10-04T19:12:03Z",
+                      "currencyCode" : "USD",
+                      "specialBidId" : "TEST-9771006-1923",
+                      "specialBidExpirationDate" : "2020-01-01T00:00:00",
+                      "status" : "Active",
+                      "customerNeed" : "Customer Need",
+                      "introPreamble" : "<font color='red' size='8pt'><b></b></font>#####<font>Thank you for contacting Ingram Micro. We value your business greatly and will continue to deliver the services you need to retain it. This quote is not intended to represent the entire conversation; only what was relevant to the solution you requested. We make every effort to provide a complete and correct solution. However, the accuracy of the solution provided is dependent on the information gathered. If relevant information is not provided by our customer, Ingram Micro cannot be held responsible. We urge you to review this quote fully, to ensure it reflects all of your required specifications. If you have additional questions, please contact your designated Ingram Micro contact. Remember to reference your Quote Number.</font>#####<font>Call reference # <QUOTE NUMBER> <br /> To ensure fastest and most accurate processing of your order, please provide the quote# at the time of purchase</font>",
+                      "purchaseInstructions" : "For specific pricing and to order the above products, you may \r\n\r\n  • Some product may be orderable on Imonline at http://us-new.ingrammicro.com\r\n\r\n   • Call the Ingram Micro Sales department at 1.800.456.8000\r\n* Your PO number  *End User\r\n* Your fax number\r\n* Shipping instructions\r\n* End user PO number\r\n* End user license, contract or authorization number\r\n\r\nThank you for your order!",
+                      "legalTerms" : "This offer to sell the listed product(s) is subject to product availability and Ingram Micro's standard terms and conditions that are published on http://www.ingrammicro.com prices are subject to change without notice.\r\nPlease contact the Ingram Micro Sales desk at 1.800.456.8000 if you have any additional questions.",
+                      "resellerInfo" : {
+                        "contact" : "INGRAM MICRO ITSOLUTIONS LLC Contact3 INGRAM MICRO ITSOLUTIONS LLC last name3",
+                        "companyName" : "INGRAM MICRO IT SOLUTIONS LLC",
+                        "email" : "TestQuote3@INGRAMMICROITSOLUTIONS.com",
+                        "phoneNumber" : "9999999000"
+                      },
+                      "endUserInfo" : {
+                        "companyName" : "End User3"
+                      },
+                      "productsCount" : 1,
+                      "extendedMsrpTotal" : 12000,
+                      "quantityTotal" : 10,
+                      "extendedQuotePriceTotal" : 10000,
+                      "additionalAttributes" : [ {
+                        "attributeName" : "estimateId",
+                        "attributeValue" : "DO85027550IK"
+                      }, {
+                        "attributeName" : "dealId",
+                        "attributeValue" : "123456"
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "CustomerNumber format incorrect" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "1629203530223-2021-08-17T18:02:10.21+05:30-123",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CustomerNumber",
+                          "value" : "20222222",
+                          "message" : "IM-CustomerNumber must be in the format xx-xxxx or xx-xxxxx or xx-xxxxxx"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "CustomerNumber blank" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "1629204354596-2021-08-17T18:15:54.596+05:30-123",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CustomerNumber",
+                          "value" : "",
+                          "message" : "IM-CustomerNumber is blank"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "CountryCode invalid" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "1629204465806-2021-08-17T18:17:45.806+05:30-123",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CountryCode",
+                          "value" : "UU",
+                          "message" : "IM-CountryCode is invalid"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Multiple error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "1629204746878-2021-08-17T18:22:26.867+05:30-123",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CountryCode",
+                          "value" : "UU",
+                          "message" : "IM-CountryCode is invalid"
+                        }, {
+                          "field" : "IM-CustomerNumber",
+                          "value" : "",
+                          "message" : "IM-CustomerNumber is blank"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Unexpected Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "1629204961192-2021-08-17T18:26:01.191+05:30-bw0a103",
+                        "type" : "/errors/system-errors",
+                        "message" : "Some unexpected error occured, please contact support team for more details "
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resellers/v6/invoices/" : {
+      "get" : {
+        "summary" : "Search your invoice",
+        "tags" : [ "Invoices" ],
+        "description" : "Search your Ingram Micro invoices. This endpoint searches by multiple invoice parameters and supports pagination of results.",
+        "operationId" : "get-resellers-v6-invoicesearch",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "IM-ApplicationID ",
+          "in" : "header",
+          "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        }, {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your unique Ingram Micro customer number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "20-222222",
+            "maxLength" : 10
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "description" : "Two-character ISO country code.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "US",
+            "maxLength" : 2,
+            "minLength" : 2
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "description" : "Unique transaction number to identify each transaction across all the systems.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "fbac82ba-cf0a-4bcf-fc03-0c5084"
+          }
+        }, {
+          "name" : "PaymentTermsNetDate",
+          "in" : "query",
+          "description" : "Search by payment terms net date(yyyy-MM-dd).",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "2021-04-23"
+          }
+        }, {
+          "name" : "InvoiceDate",
+          "in" : "query",
+          "description" : "Search by invoice date(yyyy-MM-dd).",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "2021-04-23"
+          }
+        }, {
+          "name" : "InvoiceDueDate",
+          "in" : "query",
+          "description" : "Search by invoice date from(yyyy-MM-dd).",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "2021-04-23"
+          }
+        }, {
+          "name" : "OrderDate",
+          "in" : "query",
+          "description" : "Search by OrderDate date(yyyy-MM-dd).",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "2021-04-23"
+          }
+        }, {
+          "name" : "OrderFromDate",
+          "in" : "query",
+          "description" : "Search by OrderFromDate date(yyyy-MM-dd).",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "2021-04-23"
+          }
+        }, {
+          "name" : "OrderToDate",
+          "in" : "query",
+          "description" : "Search by OrderToDate date(yyyy-MM-dd).",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "2021-04-23"
+          }
+        }, {
+          "name" : "OrderNumber",
+          "in" : "query",
+          "description" : "Search by order number",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "2021-04-23"
+          }
+        }, {
+          "name" : "DeliveryNumber",
+          "in" : "query",
+          "description" : "Search by delivery number.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "335238411"
+          }
+        }, {
+          "name" : "InvoiceNumber",
+          "in" : "query",
+          "description" : "The Ingram Micro invoice number.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 11
+          }
+        }, {
+          "name" : "InvoiceStatus",
+          "in" : "query",
+          "description" : "Ingram Micro invoice status.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "InvoiceType",
+          "in" : "query",
+          "description" : "Ingram Micro InvoiceType.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "CustomerOrderNumber",
+          "in" : "query",
+          "description" : "Ingram Micro CustomerOrderNumber.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "EndCustomerOrderNumber",
+          "in" : "query",
+          "description" : "Ingram Micro EndCustomerOrderNumber.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "SpecialBidNumber",
+          "in" : "query",
+          "description" : "Ingram Micro SpecialBidNumber.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "InvoiceFromDueDate",
+          "in" : "query",
+          "description" : "Search by invoice due date from(yyyy-MM-dd).",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "2021-04-23"
+          }
+        }, {
+          "name" : "InvoiceToDueDate",
+          "in" : "query",
+          "description" : "Search by invoice due date to(yyyy-MM-dd).",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "example" : "2021-04-23"
+          }
+        }, {
+          "name" : "InvoiceFromDate",
+          "in" : "query",
+          "description" : "Search by invoice date from(yyyy-MM-dd).",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "items" : {
+              "type" : "string",
+              "example" : "2021-04-23"
+            }
+          }
+        }, {
+          "name" : "InvoiceToDate",
+          "in" : "query",
+          "description" : "Search by invoice date To(yyyy-MM-dd).",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "items" : {
+              "type" : "string",
+              "example" : "2021-04-23"
+            }
+          }
+        }, {
+          "name" : "pageSize",
+          "in" : "query",
+          "description" : "Number of records required in the call - max records 100 per page.",
+          "required" : false,
+          "schema" : {
+            "type" : "integer",
+            "default" : "25",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "pageNumber",
+          "in" : "query",
+          "description" : "The page number reference.",
+          "required" : false,
+          "schema" : {
+            "type" : "integer",
+            "default" : "1",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "Orderby",
+          "in" : "query",
+          "description" : "Column name with which we want to sort.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "InvoiceDate"
+          }
+        }, {
+          "name" : "Direction",
+          "in" : "query",
+          "description" : "asc or desc , along with orderby column result set will be sorted.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "desc"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "InvoiceSearchResponse to be returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InvoiceSearchResponse"
+                },
+                "examples" : {
+                  "Success - 200" : {
+                    "value" : {
+                      "invoices" : [ {
+                        "paymentTermsDueDate" : "2022-11-10",
+                        "erpOrderNumber" : "40-MKTRW-11",
+                        "invoiceNumber" : "40MKTRW11",
+                        "invoiceStatus" : "OPEN",
+                        "invoiceDate" : "2022-10-29",
+                        "invoiceDueDate" : "2022-11-10",
+                        "invoicedAmountDue" : 243.16,
+                        "customerOrderNumber" : "ZBJ3724",
+                        "endCustomerOrderNumber" : [ "NFP259" ],
+                        "orderCreateDate" : "2022-10-27"
+                      } ],
+                      "nextPage" : "/resellers/v6/invoices/?customerNumber=40-017165&invoiceDateFrom=5/3/2022&invoiceDateTo=10/30/2022&page=1&size=10&orderBy=invoiceDate&direction=desc&pageNumber=2",
+                      "recordsFound" : 89701,
+                      "pageSize" : 10,
+                      "pageNumber" : 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "400 - Bad Request" : {
+                    "value" : {
+                      "errors" : [ {
+                        "traceid" : "1",
+                        "type" : "errors/bad-request",
+                        "message" : "Input passed is not in right or expected format. Model Binding Error Happens at Global Model Binding Exception Handler.",
+                        "fields" : [ {
+                          "field" : "IM-CountryCode",
+                          "message" : "The countryCode field is required.",
+                          "value" : null
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Server Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "traceid" : "121",
+                        "type" : "System.Net.WebException",
+                        "message" : "Error while processing request for 1121,for SiteCode sg,for CorrelationId :121 , Message :The remote server returned an error: (404) Not Found.",
+                        "fields" : [ ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resellers/v6/invoices/{invoicenumber}" : {
+      "get" : {
+        "summary" : "Get Invoice Details",
+        "tags" : [ "Invoices" ],
+        "description" : "Use your Ingram Micro invoice number to search for existing invoices or retrieve existing invoice details.\n\nThe invoice number, IM-CustomerNumber, IM-CountryCode, IM-ApplicationId and IM-CorrelationID are required parameters.\n\n.",
+        "operationId" : "get-invoicedetails-v6",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "name" : "invoicenumber",
+          "in" : "path",
+          "description" : "The Ingram Micro invoice number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 12,
+            "example" : "335238411"
+          }
+        }, {
+          "name" : "version",
+          "in" : "header",
+          "description" : "Version of codebase.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "example" : "20-222222"
+          }
+        }, {
+          "name" : "IM-CustomerNumber",
+          "in" : "header",
+          "description" : "Your unique Ingram Micro customer number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "example" : "20-222222"
+          }
+        }, {
+          "name" : "IM-CountryCode",
+          "in" : "header",
+          "description" : "Two-character ISO country code.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "example" : "US"
+          }
+        }, {
+          "name" : "IM-CorrelationID",
+          "in" : "header",
+          "description" : "Unique transaction number to identify each transaction across all the systems.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "fbac82ba-cf0a-4bcf-fc03-0c5084"
+          }
+        }, {
+          "name" : "IM-ApplicationID",
+          "in" : "header",
+          "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "MyCompany"
+          }
+        }, {
+          "name" : "customerType",
+          "in" : "query",
+          "description" : "it should be invoice or order",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "example" : "invoice"
+          }
+        }, {
+          "name" : "includeSerialNumbers",
+          "in" : "query",
+          "description" : "if serial in the response send as true or else false",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "example" : "false"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "IM-CorrelationID" : {
+                "schema" : {
+                  "type" : "string"
+                },
+                "description" : "Unique transaction number to identify each transaction across all the systems."
+              },
+              "IM-ApplicationID" : {
+                "schema" : {
+                  "type" : "string",
+                  "example" : "MyCompany"
+                },
+                "description" : "Unique value used to identify the sender of the transaction. Example: MyCompany"
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InvoiceDetailResponse"
+                },
+                "examples" : {
+                  "Success" : {
+                    "value" : {
+                      "InvoiceNumber" : "40-DPJ17-11",
+                      "InvoiceDate" : "2022-09-07",
+                      "OrderDate" : "2022-09-07",
+                      "IngramPurchaseOrderNumber" : "70GZJ35",
+                      "InvoiceType" : "Invoice",
+                      "InvoiceDueDate" : "2022-10-22",
+                      "IngramInvoiceNumber" : "",
+                      "Notes" : "HEADER || H:1427214",
+                      "PaymentTermsInfo" : {
+                        "PaymentTermsCode" : "45",
+                        "PaymentTermsDescription" : "NET 45 DAYS",
+                        "PaymentTermsDueDate" : "2022-10-22"
+                      },
+                      "BillToInfo" : {
+                        "CompanyName" : "SOFTWARE ONE INC",
+                        "AddressLine1" : "20875 CROSSROADS CIR",
+                        "City" : "WAUKESHA",
+                        "State" : "WI",
+                        "PostalCode" : "531864052"
+                      },
+                      "ShipToInfo" : {
+                        "CompanyName" : "RITE-HITE CORPORATION",
+                        "AddressLine1" : "8900 N ARBON DR",
+                        "City" : "MILWAUKEE",
+                        "State" : "WI",
+                        "PostalCode" : "532230000"
+                      },
+                      "Lines" : [ {
+                        "IngramLineNumber" : "12",
+                        "CustomerLineNumber" : "1",
+                        "IngramPartNumber" : "05QC29",
+                        "VendorPartNumber" : "65324394AD01A00",
+                        "VendorName" : "ADOBE COMMERCIA",
+                        "ProductDescription" : "AOO LICS ACROBAT PRO 2020 MPLATLICS || 1+ 540PT",
+                        "UnitWeight" : "0.0",
+                        "Quantity" : 1,
+                        "UnitPrice" : 533.33,
+                        "UnitOfMeasure" : "EA",
+                        "CurrencyCode" : "USD",
+                        "ExtendedPrice" : 533.33,
+                        "TaxPercentage" : 0,
+                        "taxPercentage" : 0,
+                        "TaxAmount" : 0,
+                        "serialNumbers" : [ {
+                          "serialNumber" : "0AMY3CPRA00359"
+                        }, {
+                          "serialNumber" : "0AMY3CPRA00484"
+                        }, {
+                          "serialNumber" : "0AMY3CPRA00485"
+                        }, {
+                          "serialNumber" : "0AMY3CPRA00479"
+                        }, {
+                          "serialNumber" : "0AMY3CPRA00486"
+                        }, {
+                          "serialNumber" : "0AMY3CPRA00480"
+                        }, {
+                          "serialNumber" : "0AMY3CPRA00465"
+                        }, {
+                          "serialNumber" : "0AMY3CPRA00481"
+                        }, {
+                          "serialNumber" : "0AMY3CPRA00483"
+                        }, {
+                          "serialNumber" : "0AMY3CPRA00493"
+                        }, {
+                          "serialNumber" : "0AMY3CPRA00476"
+                        } ],
+                        "QuantityOrdered" : 1,
+                        "QuantityShipped" : 1
+                      } ],
+                      "EndUserInfo" : {
+                        "Contact" : "RITE-HITE CORPORATION",
+                        "AddressLine1" : "8900 N ARBON DR",
+                        "AddressLine2" : "",
+                        "AddressLine3" : "",
+                        "City" : "MILWAUKEE",
+                        "State" : "WI",
+                        "PostalCode" : "532232451",
+                        "CountryCode" : "US",
+                        "PhoneNumber" : "14143624491",
+                        "Email" : "MPOWERS@RITEHITE.COM"
+                      },
+                      "FxRateInfo" : {
+                        "CurrencyCode" : "USD",
+                        "CompanyCurrency" : "USD",
+                        "InvoiceCurrency" : "USD",
+                        "CurrencyFxRate" : 1
+                      },
+                      "Summary" : {
+                        "Lines" : {
+                          "ProductLineCount" : 1,
+                          "ProductLineTotalQuantity" : 1
+                        },
+                        "MiscCharges" : [ {
+                          "ChargeDescription" : "STATETAX",
+                          "MiscChargeLineCount" : 0,
+                          "MiscChargeLineTotal" : 355.83,
+                          "ChargeLineReference" : "GST"
+                        }, {
+                          "ChargeDescription" : "FREIGHT OUT",
+                          "MiscChargeLineCount" : 1,
+                          "MiscChargeLineTotal" : 31.9,
+                          "ChargeLineReference" : "8"
+                        } ],
+                        "Totals" : {
+                          "NetInvoiceAmount" : 533.33,
+                          "DiscountAmount" : 0,
+                          "DiscountType" : "Terms Charge",
+                          "InvoicedAmountDue" : 533.33
+                        },
+                        "ForeignFxTotals" : {
+                          "ForeignCurrencyCode" : "USD",
+                          "ForeignCurrencyFxRate" : 1,
+                          "ForeignTotalTaxableAmount" : "533.33",
+                          "ForeignTotalTaxAmount" : 0,
+                          "ForeignInvoiceAmountDue" : "533.33"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "CustomerNumber format incorrect" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "1629203530223-2021-08-17T18:02:10.21+05:30-123",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CustomerNumber",
+                          "value" : "20222222",
+                          "message" : "IM-CustomerNumber must be in the format xx-xxxx or xx-xxxxx or xx-xxxxxx"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "CustomerNumber blank" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "1629204354596-2021-08-17T18:15:54.596+05:30-123",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CustomerNumber",
+                          "value" : "",
+                          "message" : "IM-CustomerNumber is blank"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "CountryCode invalid" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "1629204465806-2021-08-17T18:17:45.806+05:30-123",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CountryCode",
+                          "value" : "UU",
+                          "message" : "IM-CountryCode is invalid"
+                        } ]
+                      } ]
+                    }
+                  },
+                  "Multiple error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "1629204746878-2021-08-17T18:22:26.867+05:30-123",
+                        "type" : "/errors/validation-failed",
+                        "message" : "Validation failed",
+                        "fields" : [ {
+                          "field" : "IM-CountryCode",
+                          "value" : "UU",
+                          "message" : "IM-CountryCode is invalid"
+                        }, {
+                          "field" : "IM-CustomerNumber",
+                          "value" : "",
+                          "message" : "IM-CustomerNumber is blank"
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                },
+                "examples" : {
+                  "Server Error" : {
+                    "value" : {
+                      "errors" : [ {
+                        "id" : "1",
+                        "type" : "InternalServerError",
+                        "message" : "Un-handled Exception \n Please contact to administrator."
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resellers/v5/invoices/{invoiceNumber}" : {
+      "get" : {
+        "summary" : "Get Invoice Details",
+        "operationId" : "get-invoices",
+        "description" : "View invoice details. This is a request to query invoice details for a specific Ingram Micro order placed in the last 9 months, whether open or shipped.\n\n <strong>invoiceNumber</strong>, <strong>isoCountryCode</strong> and <strong>customerNumber</strong> parameters are required.",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "tags" : [ "Invoices V5" ],
+        "parameters" : [ {
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "default" : "20-222222"
+          },
+          "in" : "query",
+          "name" : "customerNumber",
+          "description" : "Your unique Ingram Micro customer number",
+          "required" : true
+        }, {
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "default" : "US"
+          },
+          "in" : "query",
+          "name" : "isoCountryCode",
+          "description" : "ISO 2 char country code",
+          "required" : true
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/invoiceDetails"
+                },
+                "examples" : {
+                  "Example" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "responsestatus" : "SUCCESS",
+                          "statuscode" : "200",
+                          "responsemessage" : "Invoice Found"
+                        },
+                        "invoicedetailresponse" : {
+                          "invoicenumber" : "RCW67-11",
+                          "customerordernumber" : "ZFEDRGT",
+                          "customerfreightamount" : "0.00",
+                          "customerforeignfrightamt" : "0.00",
+                          "totaltaxamount" : "0",
+                          "totalamount" : "61.22",
+                          "shiptosuffix" : "200",
+                          "billtosuffix" : "000",
+                          "billto" : {
+                            "name1" : "INGRAM MICRO CAPS TEST ACCOUNT",
+                            "addressline1" : "1759 WEHRLE DR",
+                            "city" : "WILLIAMSVILLE",
+                            "state" : "NY",
+                            "postalcode" : "142217033",
+                            "countrycode" : "US"
+                          },
+                          "paymentterms" : "200",
+                          "orderdate" : "2020-01-06",
+                          "carrier" : "OT",
+                          "carrierdescription" : "OTHER",
+                          "discountamount" : "0.00",
+                          "enduserponumber" : null,
+                          "freightforwardercode" : null,
+                          "creditmemoreasoncode" : null,
+                          "holdreason" : null,
+                          "shipcomplete" : null,
+                          "shipdate" : "2020-01-06",
+                          "companycurrency" : "USD",
+                          "currencycode" : "USD",
+                          "currencyrate" : "1.000000",
+                          "globalorderid" : "20-RCW67-11",
+                          "originalshipcode" : null,
+                          "orderstatus" : "I",
+                          "shiptoaddress" : {
+                            "name1" : "INGRAM MICRO TEST ACCOUNT",
+                            "addressline1" : "ATTN TOD DEBIE",
+                            "addressline2" : "1610 E SAINT ANDREW PL",
+                            "city" : "SANTA ANA",
+                            "state" : "CA",
+                            "postalcode" : "927054931",
+                            "countrycode" : "US"
+                          },
+                          "totalsales" : "61.22",
+                          "weight" : "5.00",
+                          "lines" : [ {
+                            "linenumber" : "1",
+                            "partnumber" : "123511",
+                            "vendorpartnumber" : "F2A032-06",
+                            "partdescription" : "666 PARALLEL PRINTER DB25M TO  CABLCENT36M PRO SERIES 28AWG ROHS",
+                            "shipfrombranch" : "10",
+                            "shippedquantity" : "1",
+                            "orderedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "extendedprice" : "30.61",
+                            "specialbidnumber" : null,
+                            "ordersuffix" : "11",
+                            "unitprice" : "30.61",
+                            "unitofmeasure" : "EA",
+                            "productextendedspecs" : [ {
+                              "attributename" : "commenttext",
+                              "attributevalue" : "EU#-001599983  ASPECT AUTOMATION LLMC#C"
+                            } ]
+                          }, {
+                            "linenumber" : "2",
+                            "partnumber" : "123511",
+                            "vendorpartnumber" : "F2A032-06",
+                            "partdescription" : "666 PARALLEL PRINTER DB25M TO  CABLCENT36M PRO SERIES 28AWG ROHS",
+                            "shipfrombranch" : "10",
+                            "shippedquantity" : "1",
+                            "orderedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "extendedprice" : "30.61",
+                            "specialbidnumber" : null,
+                            "ordersuffix" : "11",
+                            "unitprice" : "30.61",
+                            "unitofmeasure" : "EA",
+                            "productextendedspecs" : [ {
+                              "attributename" : "commenttext",
+                              "attributevalue" : "EU#-001599983  ASPECT AUTOMATION LLMC#C"
+                            } ]
+                          }, {
+                            "linenumber" : "3",
+                            "partnumber" : "123511",
+                            "vendorpartnumber" : "F2A032-06",
+                            "partdescription" : "666 PARALLEL PRINTER DB25M TO  CABLCENT36M PRO SERIES 28AWG ROHS",
+                            "shipfrombranch" : "10",
+                            "shippedquantity" : "0",
+                            "orderedquantity" : "1",
+                            "backorderquantity" : "1",
+                            "extendedprice" : "0.00",
+                            "specialbidnumber" : null,
+                            "ordersuffix" : "11",
+                            "unitprice" : "30.61",
+                            "unitofmeasure" : "EA"
+                          }, {
+                            "linenumber" : "895",
+                            "vendorpartnumber" : null,
+                            "partdescription" : "FREE FREIGHT",
+                            "shipfrombranch" : "10",
+                            "shippedquantity" : "0",
+                            "orderedquantity" : "0",
+                            "backorderquantity" : "0",
+                            "extendedprice" : "0.00",
+                            "specialbidnumber" : null,
+                            "ordersuffix" : "11",
+                            "unitprice" : "0",
+                            "unitofmeasure" : null
+                          } ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters" : [ {
+        "schema" : {
+          "type" : "string",
+          "maxLength" : 12,
+          "default" : "20-RCW67-11"
+        },
+        "name" : "invoiceNumber",
+        "in" : "path",
+        "description" : "Ingram Micro Invoice Number",
+        "required" : true
+      } ]
+    },
+    "/resellers/v5/Orders" : {
+      "post" : {
+        "summary" : "Create a New Order",
+        "operationId" : "post-v5-orders-create",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/orderCreateResponse"
+                },
+                "examples" : {
+                  "Example" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "responsestatus" : "SUCCESS",
+                          "statuscode" : "WY",
+                          "responsemessage" : "Note: (WY) Address fixed by group 1"
+                        },
+                        "ordersummary" : {
+                          "customerponumber" : "CUSTUMERPO-1",
+                          "totalorderamount" : 6.77,
+                          "totalordercreated" : "1",
+                          "shiptoaddress" : {
+                            "attention" : "INGRAM MICRO",
+                            "addressline1" : "3351 MICHELSON DR",
+                            "city" : "IRVINE",
+                            "state" : "CA",
+                            "postalcode" : "926120696",
+                            "countrycode" : "US"
+                          },
+                          "ordercreateresponse" : [ {
+                            "numberoflineswithsuccess" : "1",
+                            "numberoflineswitherror" : "0",
+                            "numberoflineswithwarning" : "0",
+                            "globalorderid" : "20-RD12J",
+                            "ordertype" : "S",
+                            "ordertimestamp" : "2020-04-04",
+                            "invoicingsystemorderid" : "20-RD12J",
+                            "taxamount" : 0,
+                            "freightamount" : 0,
+                            "orderamount" : 6.77,
+                            "lines" : [ {
+                              "linetype" : "P",
+                              "globallinenumber" : "002",
+                              "partnumber" : "TSXML3",
+                              "linenumber" : "4",
+                              "carriercode" : "OT",
+                              "carrierdescription" : "OTHER",
+                              "requestedunitprice" : 6.77,
+                              "requestedquantity" : 1,
+                              "confirmedquantity" : 1,
+                              "backorderedquantity" : 0,
+                              "unitproductprice" : 6.77,
+                              "netamount" : 6.77,
+                              "warehouseid" : "10",
+                              "ordersuffix" : "11"
+                            } ]
+                          } ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "application" : [ "write" ]
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/orderCreateRequest"
+              },
+              "examples" : {
+                "With Ingram Part No." : {
+                  "value" : {
+                    "ordercreaterequest" : {
+                      "requestpreamble" : {
+                        "isocountrycode" : "US",
+                        "customernumber" : "20-222222"
+                      },
+                      "ordercreatedetails" : {
+                        "customerponumber" : "CustumerPO-1",
+                        "shiptoaddress" : {
+                          "attention" : "John Smith",
+                          "addressline1" : "Ingram Micro",
+                          "addressline2" : "3351 Michelson Dr",
+                          "city" : "Long Beach",
+                          "state" : "CA",
+                          "postalcode" : "92612",
+                          "countrycode" : "US"
+                        },
+                        "carriercode" : "OT",
+                        "lines" : [ {
+                          "linetype" : "P",
+                          "linenumber" : "002",
+                          "quantity" : "1",
+                          "ingrampartnumber" : "TSXML3"
+                        } ],
+                        "extendedspecs" : [ {
+                          "attributename" : "isdirectshiporder",
+                          "attributevalue" : "false"
+                        }, {
+                          "attributename" : "euponumber",
+                          "attributevalue" : "1234"
+                        }, {
+                          "attributename" : "commenttext",
+                          "attributevalue" : "Happy Birthday Mom"
+                        }, {
+                          "attributename" : "duplicatecustomerordernumbervalidate",
+                          "attributevalue" : "ALLOW"
+                        }, {
+                          "attributename" : "commenttext",
+                          "attributevalue" : "///This order must ship on FedEx"
+                        }, {
+                          "attributename" : "commenttext",
+                          "attributevalue" : "/// 3rd account# 12345678"
+                        } ]
+                      }
+                    }
+                  }
+                },
+                "With Vendor Part No." : {
+                  "value" : {
+                    "ordercreaterequest" : {
+                      "requestpreamble" : {
+                        "isocountrycode" : "US",
+                        "customernumber" : "20-222222"
+                      },
+                      "ordercreatedetails" : {
+                        "customerponumber" : "CustumerPO-1",
+                        "carriercode" : "OT",
+                        "lines" : [ {
+                          "linetype" : "P",
+                          "linenumber" : "002",
+                          "quantity" : "1",
+                          "vendorpartnumber" : "PA03670-B055"
+                        } ],
+                        "extendedspecs" : [ {
+                          "attributename" : "commenttext",
+                          "attributevalue" : "This is a test comment text"
+                        } ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Orders v5" ],
+        "description" : "Instantly create and place orders. The POST API supports stocked SKUs as well as licensing and warranties SKUs.\n\n Every order to be created with this API must complete these validations to be placed and processed:<ul><li>SKU, shipping address, product authorization and stock allocations must clear validation.</li><li>Ingram Micro Sales validates pricing, stock or other processing parameters. Ingram Micro sales may place an order a hold if revision is necessary.</li><li>Credit validation confirms available credit prior to processing an order. If an order does not clear credit validation, the Ingram Micro sales rep or accounts receivable manager will contact you for next steps.</li><li>Warehouse validation selects the location closest to the destination zip code. If the stock is not available in any of the warehouses, Ingram Micro places a backorder in the warehouse closest to the destination zip code.</li></ul>\n\n Ingram Micro recommends that you provide the <strong>ingrampartnumber</strong> for each SKU contained in each order.\n\n When using <strong>vendorpartnumber</strong> to place an order, please use the product search endpoint to find the <strong>ingrampartnumber</strong> for a specific <strong>vendorpartnumber</strong>, and then supply the <strong>ingrampartnumber</strong> to place an order.\n\n <strong>NOTE:</strong> You must have net terms to use the <strong>Ingram Micro Order Create API</strong>. Ingram Micro offers trade credit when using our APIs, and repayment is based on net terms. For example, if your net terms agreement is net-30, you will have 30 days to make a full payment. Ingram Micro does not allow credit card transactions for API ordering."
+      }
+    },
+    "/resellers/v5/Orders/search" : {
+      "get" : {
+        "summary" : "Search your Orders",
+        "operationId" : "get-orders-search",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/orderSearchResponse"
+                },
+                "examples" : {
+                  "Success Example" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "requeststatus" : "SUCCESS",
+                          "returnmessage" : "Data found"
+                        },
+                        "ordesearchresponse" : {
+                          "ordersfound" : "1",
+                          "pagesize" : "1",
+                          "pagenumber" : "1",
+                          "orders" : [ {
+                            "ordernumber" : "20-RD128",
+                            "entrytimestamp" : "2020-04-03T15:54:39Z",
+                            "customerordernumber" : "ZENPO",
+                            "suborders" : [ {
+                              "subordernumber" : "20-RD128-11",
+                              "statuscode" : "C",
+                              "status" : "CREDIT HOLD",
+                              "holdreasoncode" : "CH",
+                              "holdreason" : "HARD-9 CUST NOT FLOOR ORD",
+                              "links" : [ {
+                                "topic" : "orders",
+                                "href" : "/resellers/v5/orders/20-RD128-11?customerNumber=20-222222&isoCountryCode=US",
+                                "type" : "GET"
+                              }, {
+                                "topic" : "invoices",
+                                "href" : "/resellers/v5/invoices/20-RD128-11?customerNumber=20-222222&isoCountryCode=US",
+                                "type" : "GET"
+                              } ]
+                            } ],
+                            "links" : {
+                              "topic" : "orders",
+                              "href" : "/resellers/v5/orders/20-RD128?customerNumber=20-222222&isoCountryCode=US",
+                              "type" : "GET"
+                            }
+                          } ]
+                        }
+                      }
+                    }
+                  },
+                  "Data not found" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "requeststatus" : "FAILED",
+                          "returnmessage" : "No data found"
+                        },
+                        "ordesearchresponse" : {
+                          "ordersfound" : "0",
+                          "pagesize" : "0",
+                          "pagenumber" : "1"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description" : "Search your Ingram Micro orders. This endpoint searches by multiple order parameters and supports pagination of results. Search using one or more of the parameters below:\n\n <ul><li>ordernumber — Ingram Micro sales order number</li><li>customerordernumber — The PO or order number provided by you when creating an order</li><li>orderstatus — user order status codes for the search, default is set to \"any\"</li><li>startcreatetimestamp and endcreatetimestamp — Order create date range</li></ul>\n\n For pagination, please use these parameters:\n <ul><li>pagesize — default 25, max 100</li><li>pagenumber — default 1</li></ul>\n\n Order Status Values:\n <ul><li>P – PENDING</li><li>R – RELEASED</li><li>4 – SHIPPED</li><li>I – INVOICED</li><li>V – VOIDED</li></ul>\n\n The search endpoint also returns HATEOAS links for order details and invoice details, if applicable.",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "schema" : {
+            "type" : "string",
+            "example" : "20-222222"
+          },
+          "in" : "query",
+          "name" : "customerNumber",
+          "description" : "Your unique Ingram Micro customer number",
+          "required" : true
+        }, {
+          "schema" : {
+            "type" : "string",
+            "minLength" : 2,
+            "maxLength" : 2,
+            "example" : "US"
+          },
+          "in" : "query",
+          "name" : "isocountrycode",
+          "description" : "2 char iso country code",
+          "required" : true
+        }, {
+          "schema" : {
+            "type" : "string"
+          },
+          "in" : "query",
+          "name" : "ordernumber",
+          "description" : "Ingram sales order number"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "example" : "ZENPO1"
+          },
+          "in" : "query",
+          "name" : "customerordernumber",
+          "description" : "Search using your PO/Order number"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "default" : "any",
+            "enum" : [ "P", "R", "4", "I", "V" ],
+            "example" : "",
+            "minLength" : 1,
+            "uniqueItems" : false
+          },
+          "in" : "query",
+          "name" : "orderstatus",
+          "description" : "Ingram Micro order status"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "in" : "query",
+          "name" : "startcreatetimestamp",
+          "description" : "Search start date/time in UTC format",
+          "explode" : false,
+          "allowEmptyValue" : false,
+          "allowReserved" : false
+        }, {
+          "schema" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "in" : "query",
+          "name" : "endcreatetimestamp",
+          "description" : "Search end date/time in UTC format"
+        }, {
+          "schema" : {
+            "type" : "integer",
+            "default" : "25"
+          },
+          "in" : "query",
+          "name" : "pagesize",
+          "description" : "Number of records required in the call"
+        }, {
+          "schema" : {
+            "type" : "integer",
+            "default" : 1
+          },
+          "in" : "query",
+          "name" : "pagenumber",
+          "description" : "the page number reference"
+        } ],
+        "tags" : [ "Orders v5" ]
+      }
+    },
+    "/resellers/v5/Orders/{ordernumber}" : {
+      "get" : {
+        "summary" : "Get Order Details",
+        "tags" : [ "Orders v5" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/orderDetailResponse"
+                },
+                "examples" : {
+                  "Success" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "responsestatus" : "SUCCESS"
+                        },
+                        "orderdetailresponse" : {
+                          "ordernumber" : "20-RD128",
+                          "ordertype" : "D",
+                          "customerordernumber" : "ZENPO",
+                          "orderstatus" : "CREDIT HOLD",
+                          "entrytimestamp" : "2020-04-03T08:54:39-07:00",
+                          "entrymethoddescription" : "VIA LU62",
+                          "ordertotalvalue" : 14.67,
+                          "ordersubtotal" : 6.67,
+                          "freightamount" : 8,
+                          "currencycode" : "USD",
+                          "totalweight" : "1",
+                          "totaltax" : "0",
+                          "billtoaddress" : {
+                            "suffix" : "000",
+                            "name" : "INGRAM MICRO CAPS TEST ACCOUNT",
+                            "addressline1" : "1759 WEHRLE DR",
+                            "city" : "WILLIAMSVILLE",
+                            "state" : "NY",
+                            "postalcode" : "142217033",
+                            "countrycode" : "US"
+                          },
+                          "shiptoaddress" : null,
+                          "enduserinfo" : null,
+                          "lines" : [ {
+                            "linenumber" : "004",
+                            "globallinenumber" : "002",
+                            "ordersuffix" : "11",
+                            "erpordernumber" : "20-RD128-11",
+                            "linestatus" : "CREDIT HOLD",
+                            "partnumber" : "TSXML2",
+                            "manufacturerpartnumber" : "TESTXMLSKU2",
+                            "vendorname" : "TEST VENDOR NUMBER 6",
+                            "vendorcode" : "TST6",
+                            "partdescription1" : "CLASS X SKU NO STOCK",
+                            "unitweight" : "1",
+                            "unitprice" : 6.67,
+                            "extendedprice" : 6.67,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipfromwarehouseid" : "40",
+                              "warehousename" : "Carol Stream, IL",
+                              "status" : "C",
+                              "statusdescription" : "CREDIT HOLD",
+                              "holdreasoncodedescription" : "NO DESCRIPTION",
+                              "carriertype" : "LTL",
+                              "carriercode" : "OT",
+                              "carriername" : "OTHER",
+                              "pronumber" : "OTHER"
+                            } ],
+                            "productextendedspecs" : [ {
+                              "attributename" : "ponumber",
+                              "attributevalue" : "PO NOT GENERATED YET"
+                            } ]
+                          } ],
+                          "extendedspecs" : [ {
+                            "attributename" : "commenttext",
+                            "attributevalue" : "HAPPY BIRTHDAY MOM"
+                          }, {
+                            "attributename" : "commenttext",
+                            "attributevalue" : "///THIS ORDER MUST SHIP ON FEDEX"
+                          }, {
+                            "attributename" : "commenttext",
+                            "attributevalue" : "/// 3RD ACCOUNT# 12345678"
+                          } ]
+                        }
+                      }
+                    }
+                  },
+                  "Order number not found" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "responsestatus" : "FAILED"
+                        },
+                        "orderdetailresponse" : {
+                          "ordernumber" : "Not Found",
+                          "customerordernumber" : "Not-Found",
+                          "orderstatus" : "Not-Found"
+                        }
+                      }
+                    }
+                  },
+                  "Shipped Order" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "responsestatus" : "SUCCESS"
+                        },
+                        "orderdetailresponse" : {
+                          "ordernumber" : "20-V9R37",
+                          "ordertype" : "S",
+                          "customerordernumber" : "9WYLT4PNC",
+                          "enduserponumber" : "20369444086587527",
+                          "orderstatus" : "Shipped",
+                          "entrytimestamp" : "2020-01-22T09:11:14-08:00",
+                          "entrymethoddescription" : "XML/PCG",
+                          "ordertotalvalue" : 197.55,
+                          "ordersubtotal" : 164.62,
+                          "currencycode" : "GBP",
+                          "totalweight" : "1.87",
+                          "totaltax" : "32.93",
+                          "billtoaddress" : {
+                            "suffix" : "000",
+                            "name" : "AMAZON EU SARL",
+                            "addressline1" : "AMAZON EU SARL, UK BRANCH",
+                            "addressline2" : "1 PRINCIPAL PLACE",
+                            "addressline3" : "WORSHIP  STREET",
+                            "city" : "LONDON",
+                            "postalcode" : "EC2A 2FA",
+                            "countrycode" : "UK"
+                          },
+                          "shiptoaddress" : {
+                            "attention" : "ATTENTION LINE",
+                            "name" : "COMPANY NAME HERE",
+                            "addressline1" : "ADDRESS LINE 1",
+                            "addressline2" : "ADDRESS LINE 2",
+                            "city" : "MILTON KEYNES",
+                            "postalcode" : "MK9 2EA",
+                            "countrycode" : "UK"
+                          },
+                          "enduserinfo" : null,
+                          "lines" : [ {
+                            "linenumber" : "002",
+                            "globallinenumber" : "001",
+                            "ordersuffix" : "11",
+                            "erpordernumber" : "20-V9R37-11",
+                            "linestatus" : "Shipped",
+                            "partnumber" : "V934027",
+                            "manufacturerpartnumber" : "45PAT7MYL",
+                            "vendorname" : "STARTECH - CABLES",
+                            "vendorcode" : "D825",
+                            "partdescription1" : "7M YELLOW CAT5E CABLE",
+                            "partdescription2" : "SNAGLESS ETHERNET CABLE - UTP",
+                            "unitweight" : "0.36",
+                            "unitprice" : 2.04,
+                            "extendedprice" : 2.04,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "serialnumberdetails" : [ {
+                              "serialnumber" : "011",
+                              "deliverynumber" : "1123"
+                            } ],
+                            "trackingnumber" : [ "10660208" ],
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipfromwarehouseid" : "10",
+                              "warehousename" : "Mira Loma, CA",
+                              "status" : "S",
+                              "statusdescription" : "Shipped",
+                              "holdreasoncodedescription" : "NA",
+                              "carriercode" : "4M",
+                              "carriername" : "SMARTPOST-BM",
+                              "pronumber" : "121",
+                              "packagedetails" : [ {
+                                "trackingnumber" : "65792630",
+                                "packageweight" : "2",
+                                "cartonnumber" : "1",
+                                "quantityinbox" : "3"
+                              } ]
+                            } ]
+                          }, {
+                            "linenumber" : "003",
+                            "globallinenumber" : "002",
+                            "ordersuffix" : "11",
+                            "erpordernumber" : "20-V9R37-11",
+                            "linestatus" : "Shipped",
+                            "partnumber" : "V934357",
+                            "manufacturerpartnumber" : "DK30CHDPPDUE",
+                            "vendorname" : "STARTECH - IO NETWORKING",
+                            "vendorcode" : "D822",
+                            "partdescription1" : "DUAL MONITOR USB C DOCK - POWER",
+                            "partdescription2" : "DELIVERY 60W - DUAL 4K DP/HDMI SD",
+                            "unitweight" : "1.35",
+                            "unitprice" : 143.42,
+                            "extendedprice" : 143.42,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "serialnumberdetails" : [ {
+                              "serialnumber" : "011",
+                              "deliverynumber" : "1123"
+                            } ],
+                            "trackingnumber" : [ "10660208" ],
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipfromwarehouseid" : "10",
+                              "warehousename" : "Mira Loma, CA",
+                              "status" : "S",
+                              "statusdescription" : "Shipped",
+                              "holdreasoncodedescription" : "NA",
+                              "carriercode" : "4M",
+                              "carriername" : "SMARTPOST-BM",
+                              "pronumber" : "121",
+                              "packagedetails" : [ {
+                                "trackingnumber" : "65792630",
+                                "packageweight" : "2",
+                                "cartonnumber" : "1",
+                                "quantityinbox" : "3"
+                              } ]
+                            } ]
+                          }, {
+                            "linenumber" : "004",
+                            "globallinenumber" : "003",
+                            "ordersuffix" : "11",
+                            "erpordernumber" : "20-V9R37-11",
+                            "linestatus" : "Shipped",
+                            "partnumber" : "242F880",
+                            "manufacturerpartnumber" : "1511B001",
+                            "vendorname" : "CANON - SUPPLIES INK HV",
+                            "vendorcode" : "M032",
+                            "partdescription1" : "CLI-36 INK CARTRIDGE COLOUR",
+                            "partdescription2" : "F/ PIXMA MINI260",
+                            "unitweight" : "0.05",
+                            "unitprice" : 8.88,
+                            "extendedprice" : 8.88,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "serialnumberdetails" : [ {
+                              "serialnumber" : "011",
+                              "deliverynumber" : "1123"
+                            } ],
+                            "trackingnumber" : [ "10660208" ],
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipfromwarehouseid" : "10",
+                              "warehousename" : "Mira Loma, CA",
+                              "status" : "S",
+                              "statusdescription" : "Shipped",
+                              "holdreasoncodedescription" : "NA",
+                              "carriercode" : "4M",
+                              "carriername" : "SMARTPOST-BM",
+                              "pronumber" : "121",
+                              "packagedetails" : [ {
+                                "trackingnumber" : "65792630",
+                                "packageweight" : "2",
+                                "cartonnumber" : "1",
+                                "quantityinbox" : "3"
+                              } ]
+                            } ]
+                          }, {
+                            "linenumber" : "005",
+                            "globallinenumber" : "004",
+                            "ordersuffix" : "11",
+                            "erpordernumber" : "20-V9R37-11",
+                            "linestatus" : "Shipped",
+                            "partnumber" : "V931792",
+                            "manufacturerpartnumber" : "RJ45SPLITTER",
+                            "vendorname" : "STARTECH - CABLES",
+                            "vendorcode" : "D825",
+                            "partdescription1" : "2-TO-1 RJ45 SPLITTER CABLE",
+                            "partdescription2" : "ADAPTER - F/M",
+                            "unitweight" : "0.03",
+                            "unitprice" : 4.8,
+                            "extendedprice" : 4.8,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "serialnumberdetails" : [ {
+                              "serialnumber" : "011",
+                              "deliverynumber" : "1123"
+                            } ],
+                            "trackingnumber" : [ "10660208" ],
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipfromwarehouseid" : "10",
+                              "warehousename" : "Mira Loma, CA",
+                              "status" : "S",
+                              "statusdescription" : "Shipped",
+                              "holdreasoncodedescription" : "NA",
+                              "carriercode" : "4M",
+                              "carriername" : "SMARTPOST-BM",
+                              "pronumber" : "121",
+                              "packagedetails" : [ {
+                                "trackingnumber" : "65792630",
+                                "packageweight" : "2",
+                                "cartonnumber" : "1",
+                                "quantityinbox" : "3"
+                              } ]
+                            } ]
+                          }, {
+                            "linenumber" : "006",
+                            "globallinenumber" : "005",
+                            "ordersuffix" : "11",
+                            "erpordernumber" : "20-V9R37-11",
+                            "linestatus" : "Shipped",
+                            "partnumber" : "V931639",
+                            "manufacturerpartnumber" : "HDMM1MHS",
+                            "vendorname" : "STARTECH - CABLES",
+                            "vendorcode" : "D825",
+                            "partdescription1" : "1M HIGH SPEED HDMI CABLE WITH",
+                            "partdescription2" : "ETHERNET - HDMI - M/M",
+                            "unitweight" : "0.08",
+                            "unitprice" : 3.48,
+                            "extendedprice" : 3.48,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "serialnumberdetails" : [ {
+                              "serialnumber" : "011",
+                              "deliverynumber" : "1123"
+                            } ],
+                            "trackingnumber" : [ "10660208" ],
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipfromwarehouseid" : "10",
+                              "warehousename" : "Mira Loma, CA",
+                              "status" : "S",
+                              "statusdescription" : "Shipped",
+                              "holdreasoncodedescription" : "NA",
+                              "carriercode" : "4M",
+                              "carriername" : "SMARTPOST-BM",
+                              "pronumber" : "121",
+                              "packagedetails" : [ {
+                                "trackingnumber" : "65792630",
+                                "packageweight" : "2",
+                                "cartonnumber" : "1",
+                                "quantityinbox" : "3"
+                              } ]
+                            } ]
+                          } ],
+                          "miscfeeline" : [ {
+                            "code" : "895",
+                            "description" : "FN PARCELFORCE NEXT DAY",
+                            "chargeamount" : "2.00"
+                          } ],
+                          "extendedspecs" : [ {
+                            "attributename" : "commenttext",
+                            "attributevalue" : "///CN:CONTACT NAME HERE"
+                          } ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId" : "get-v5-orders-details",
+        "description" : "Use your Ingram Micro sales order number to search for existing orders or retrieve existing order details.\n\n <b>The sales order number, customer number and isoCountryCode are required parameters.</b>\n\n The sales order number is returned in the Order Create POST response. Ingram Micro recommends that you save this number for future uses.\n\n The IM sales order number can also be retrieved by searching for your existing order using the Order Search GET endpoint. You will need the customer PO number or order number that was provided at the time of order creation.\n\n In a case when the IM sales order number is repeated, you can refine the result by providing customer order number for additional filtering or using the date range to filter orders by creation date.\n\n Use the \"simulate\" query parameter to test the GET order response for various order statuses. This parameter is only available in the sandbox to help with development and testing of the GET order endpoint.",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "schema" : {
+            "type" : "string",
+            "default" : "20-222222"
+          },
+          "in" : "query",
+          "name" : "customernumber",
+          "required" : true,
+          "description" : "Your unique Ingram Micro customer number"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "default" : "US",
+            "minLength" : 2
+          },
+          "in" : "query",
+          "name" : "isocountrycode",
+          "required" : true,
+          "description" : "2 chars ISO country code"
+        }, {
+          "schema" : {
+            "type" : "string"
+          },
+          "in" : "query",
+          "name" : "customerordernumber",
+          "description" : "Your PO/Order Number provide at the time of order creation"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "format" : "date",
+            "example" : "2020-03-15"
+          },
+          "in" : "query",
+          "name" : "startcreatetimestamp",
+          "description" : "Filter start date - format YYYY-MM-DD"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "example" : "2020-04-20"
+          },
+          "in" : "query",
+          "name" : "endcreatetimestamp",
+          "description" : "Filter end date - format YYYY-MM-DD"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "IM::shipped", "IM::invoiced", "IM::hold", "IM::partially_shipped" ],
+            "example" : ""
+          },
+          "in" : "query",
+          "name" : "simulate",
+          "description" : "Order response for various order statuses. Not for use in production."
+        } ]
+      },
+      "parameters" : [ {
+        "schema" : {
+          "type" : "string",
+          "example" : "20-RD128"
+        },
+        "name" : "ordernumber",
+        "in" : "path",
+        "required" : true,
+        "description" : "Ingram Micro sales order number"
+      } ],
+      "delete" : {
+        "summary" : "Cancel an Existing Order",
+        "operationId" : "delete-orders-orderNumber",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/orderCancelResponse"
+                },
+                "examples" : {
+                  "Example" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "requestStatus" : "SUCCESS",
+                          "returnCode" : "00",
+                          "returnMessage" : "Order Deleted Successfully"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Orders v5" ],
+        "security" : [ {
+          "application" : [ "write" ]
+        } ],
+        "parameters" : [ {
+          "schema" : {
+            "type" : "string"
+          },
+          "in" : "query",
+          "name" : "customerNumber",
+          "required" : true,
+          "description" : "Your unique Ingram Micro customer number"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2
+          },
+          "in" : "query",
+          "name" : "isoCountryCode",
+          "required" : true,
+          "description" : "2 chars ISO country code"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "default" : "2020-04-03"
+          },
+          "in" : "query",
+          "name" : "entryDate",
+          "required" : true,
+          "description" : "Order entry date (yyyy-mm-dd)"
+        } ],
+        "description" : "This endpoint is a request to cancel a previously accepted order. Use your Ingram Micro sales order number to cancel an order.\n\n The <strong>orderNumber, isoCountryCode, customerNumber</strong> and <strong>entryDate</strong> parameters are required.\n\n This call must be submitted <strong>before</strong> the order is released to Ingram Micro’s warehouse. The order cannot be canceled once it is released to the warehouse.\n\n Direct ship orders cannot be canceled. Contact your Ingram Micro sales rep for assistance."
+      }
+    },
+    "/resellers/v5/Catalog/priceandavailability" : {
+      "post" : {
+        "description" : "Search the product catalog for the price and availability for up to 50 SKUs at one time. This endpoint helps to confirm the details just prior to placing a real-time call.<ul><li>You may request visibility for reserve stock if you participate in reserved inventory, in addition to the stock that is open to all the partners. Please see the details in the endpoint model below.</li><li>Follow these guidelines when using this endpoint:<ul><li>This endpoint is not for refreshing the full catalog with availability and pricing information. Ingram Micro applies rate limits on this endpoint. Continuous cyclical calls will error out. Customers that perform this activity may lose access to the endpoint.</li><li>For the full catalog refresh, Ingram Micro can provide a Price and Inventory file in flat file format, made available through FTP download. Please contact your Ingram Micro sales rep for details.</li></ul></li></ul>",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/priceAndAvailabilityRequest"
+              },
+              "examples" : {
+                "Ingram Part Number" : {
+                  "value" : {
+                    "servicerequest" : {
+                      "requestpreamble" : {
+                        "customernumber" : "20-222223",
+                        "isocountrycode" : "US"
+                      },
+                      "priceandstockrequest" : {
+                        "showwarehouseavailability" : "True",
+                        "extravailabilityflag" : "Y",
+                        "item" : [ {
+                          "ingrampartnumber" : "TB6489",
+                          "quantity" : 1
+                        }, {
+                          "ingrampartnumber" : "1AQ821",
+                          "quantity" : 1
+                        } ],
+                        "includeallsystems" : false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/priceAndAvailabilityResponse"
+                },
+                "examples" : {
+                  "Example" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "responsestatus" : "SUCCESS",
+                          "statuscode" : "200",
+                          "responsemessage" : "Data Found"
+                        },
+                        "priceandstockresponse" : {
+                          "details" : [ {
+                            "itemstatus" : "SUCCESS",
+                            "statusmessage" : "3000-SKU not found/replic",
+                            "ingrampartnumber" : "TB6489",
+                            "vendorpartnumber" : "H1180HD",
+                            "globalskuid" : "A300-TB6489",
+                            "customerprice" : 0,
+                            "partdescription1" : "H1180HD DLP 3D PROJ 2000L 1080PPROJ",
+                            "partdescription2" : "10000:1 VGA HDMI RCA",
+                            "vendornumber" : "Q680",
+                            "vendorname" : "VIVITEK",
+                            "cpucode" : "DLP-PR",
+                            "class" : "X",
+                            "skustatus" : "ACTIVE",
+                            "mediacpu" : "PROJ  DLP-PR",
+                            "categorysubcategory" : "04  25",
+                            "retailprice" : 899,
+                            "newmedia" : "PROJ",
+                            "enduserrequired" : "Y",
+                            "backorderflag" : "Y",
+                            "skuauthorized" : "Y",
+                            "warehousedetails" : [ {
+                              "warehouseid" : "30",
+                              "warehousedescription" : "Millington, TN",
+                              "availablequantity" : 0,
+                              "onorderquantity" : 0,
+                              "onholdquantity" : 0
+                            }, {
+                              "warehouseid" : "49",
+                              "warehousedescription" : "Electronic Download",
+                              "availablequantity" : 0,
+                              "onorderquantity" : 0,
+                              "onholdquantity" : 0
+                            }, {
+                              "warehouseid" : "80",
+                              "warehousedescription" : "Jonestown, PA",
+                              "availablequantity" : 690,
+                              "onorderquantity" : 0,
+                              "onholdquantity" : 0
+                            }, {
+                              "warehouseid" : "40",
+                              "warehousedescription" : "Carol Stream, IL",
+                              "availablequantity" : 0,
+                              "onorderquantity" : 0,
+                              "onholdquantity" : 0
+                            }, {
+                              "warehouseid" : "10",
+                              "warehousedescription" : "Mira Loma, CA",
+                              "availablequantity" : 781,
+                              "onorderquantity" : 2,
+                              "onholdquantity" : 0,
+                              "etadate" : "2028-07-06"
+                            }, {
+                              "warehouseid" : "20",
+                              "warehousedescription" : "Carrolton, TX",
+                              "availablequantity" : 256,
+                              "onorderquantity" : 0,
+                              "onholdquantity" : 0
+                            } ]
+                          }, {
+                            "itemstatus" : "SUCCESS",
+                            "statusmessage" : "3000-SKU not found/replic",
+                            "ingrampartnumber" : "1AQ821",
+                            "vendorpartnumber" : "NP940X3M-K03US",
+                            "globalskuid" : "A300-1AQ821",
+                            "customerprice" : 0,
+                            "partdescription1" : "NOTEBOOK 9 PRO I5-7200U 2.5G   SYST",
+                            "partdescription2" : "128GB SSD 13IN TITAN SILVER Z",
+                            "vendornumber" : "QG86",
+                            "vendorname" : "SAMSUNG",
+                            "cpucode" : "NOTEBK",
+                            "class" : "E",
+                            "skustatus" : "ACTIVE",
+                            "mediacpu" : "SYST  NOTEBK",
+                            "categorysubcategory" : "00  46",
+                            "retailprice" : 949.99,
+                            "newmedia" : "SYST",
+                            "backorderflag" : "N",
+                            "skuauthorized" : "N",
+                            "extendedvendorpartnumber" : "NP940X3M-K03US",
+                            "warehousedetails" : [ {
+                              "warehouseid" : "30",
+                              "warehousedescription" : "Millington, TN",
+                              "availablequantity" : 0,
+                              "onorderquantity" : 0,
+                              "onholdquantity" : 0
+                            }, {
+                              "warehouseid" : "80",
+                              "warehousedescription" : "Jonestown, PA",
+                              "availablequantity" : 0,
+                              "onorderquantity" : 0,
+                              "onholdquantity" : 0
+                            }, {
+                              "warehouseid" : "40",
+                              "warehousedescription" : "Carol Stream, IL",
+                              "availablequantity" : 0,
+                              "onorderquantity" : 0,
+                              "onholdquantity" : 1
+                            }, {
+                              "warehouseid" : "17",
+                              "warehousedescription" : "Miami, FL",
+                              "availablequantity" : 0,
+                              "onorderquantity" : 0,
+                              "onholdquantity" : 0
+                            }, {
+                              "warehouseid" : "10",
+                              "warehousedescription" : "Mira Loma, CA",
+                              "availablequantity" : 0,
+                              "onorderquantity" : 0,
+                              "onholdquantity" : 0
+                            }, {
+                              "warehouseid" : "20",
+                              "warehousedescription" : "Carrolton, TX",
+                              "availablequantity" : 0,
+                              "onorderquantity" : 0,
+                              "onholdquantity" : 0
+                            } ]
+                          } ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Product Catalog v5" ],
+        "summary" : "Find availability of upto 50 SKUs",
+        "operationId" : "MultiSKUPriceAndStock",
+        "parameters" : [ ],
+        "security" : [ {
+          "application" : [ "read" ]
+        } ]
+      }
+    },
+    "/resellers/v5/Catalog" : {
+      "get" : {
+        "summary" : "Search Product Catalog",
+        "tags" : [ "Product Catalog v5" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/productSearchResponse"
+                },
+                "examples" : {
+                  "Using Ingram part number" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "requeststatus" : "SUCCESS",
+                          "returncode" : "200",
+                          "returnmessage" : "Data Available"
+                        },
+                        "productsearchresponse" : [ {
+                          "responseflag" : "1",
+                          "partnumbers" : [ {
+                            "ingrampartnumber" : "3AR598",
+                            "manufacturerpartnumber" : "NP940X5N-X01US",
+                            "upccode" : "0887276244266",
+                            "productdescription" : "NOTEBOOK 9 PRO 15IN 2018 I7-8550U 256GB SSD",
+                            "currency" : "USD",
+                            "haswarranty" : "false"
+                          } ]
+                        } ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId" : "get-v5-catalog-productsearch",
+        "description" : "Search the Ingram Micro product catalog using customerNumber, isoCountryCode and partNumber.<ul><li>customerNumber and isoCountryCode fields are required.</li><li>The PartNumber field accepts the following:<ul><li>Ingram part number</li><li>Vendor part number</li><li>Customer part number</li><li>UPC (Universal Product Code)</li></ul></li></ul>",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "schema" : {
+            "type" : "string",
+            "default" : "20-222222"
+          },
+          "in" : "query",
+          "name" : "customerNumber",
+          "required" : true,
+          "description" : "Your unique Ingram Micro customer number"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "default" : "US"
+          },
+          "in" : "query",
+          "name" : "isoCountryCode",
+          "required" : true,
+          "description" : "2 chars country code"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "default" : "1AQ821"
+          },
+          "in" : "query",
+          "name" : "partNumber",
+          "description" : "Part Number can be ingram part number or vendor part number or customer part number or UPC",
+          "required" : true
+        } ]
+      }
+    },
+    "/resellers/v5/quote/search" : {
+      "post" : {
+        "summary" : "Search Quotes",
+        "operationId" : "post-v5-quotes-search",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/quoteListResponse"
+                },
+                "examples" : {
+                  "Success" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "responsestatus" : "SUCCESS"
+                        },
+                        "orderdetailresponse" : {
+                          "ordernumber" : "10-12345",
+                          "customerordernumber" : "test order",
+                          "enduserponumber" : "ABC",
+                          "orderstatus" : "INVOICED",
+                          "entrytimestamp" : "2018-07-15T04:31:42-07:00",
+                          "entrymethoddescription" : "XML/PCG",
+                          "fulfilmentordercode" : "Y",
+                          "ordertotalvalue" : 3907.38,
+                          "ordersubtotal" : 3907.38,
+                          "freightamount" : 141.34,
+                          "currencycode" : "USD",
+                          "totalweight" : "86",
+                          "totaltax" : "0",
+                          "billtoaddress" : {
+                            "suffix" : "000",
+                            "name" : "Ingram Micro",
+                            "addressline1" : "123 Ingram Way",
+                            "addressline2" : null,
+                            "addressline3" : null,
+                            "city" : "Irvine",
+                            "state" : "CA",
+                            "postalcode" : "12345000",
+                            "countrycode" : "US"
+                          },
+                          "shiptoaddress" : {
+                            "name" : "Mr Customer",
+                            "addressline1" : "123 Main St",
+                            "city" : "Anywhere",
+                            "state" : "CA",
+                            "postalcode" : "12345000",
+                            "countrycode" : "US"
+                          },
+                          "lines" : [ {
+                            "globallinenumber" : "001",
+                            "ordersuffix" : "11",
+                            "linestatus" : "INVOICED",
+                            "partnumber" : "3AM612",
+                            "manufacturerpartnumber" : "QN75Q8FNBFXZA",
+                            "vendorname" : "SAMSUNG - CONSUMER TV",
+                            "partdescription1" : "75IN Q8 FLAT 4K UHD HDR SMARTTV",
+                            "partdescription2" : "FULL ARRAY BACKLIGHTIN CLEAN CABLE",
+                            "freeitempromoflag" : "false",
+                            "unitweight" : "75",
+                            "unitprice" : 50000.48,
+                            "foreignunitprice" : 0,
+                            "extendedprice" : 5000.48,
+                            "foreignextendedprice" : 0,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "promisedate" : "2018-07-15",
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipmentdate" : "2018-07-16",
+                              "shipfromwarehouseid" : "40",
+                              "warehousename" : "Carol Stream, IL",
+                              "invoicenumber" : "1234511",
+                              "invoicedate" : "2018-07-16",
+                              "status" : "I",
+                              "statusdescription" : "INVOICED",
+                              "shippeddate" : "2018-07-16",
+                              "carriercode" : "AY",
+                              "carriername" : "ORD4708752",
+                              "packagedetails" : {
+                                "trackingnumber" : 6838019,
+                                "packageweight" : 80,
+                                "cartonnumber" : "001",
+                                "quantityinbox" : "0000001"
+                              }
+                            } ],
+                            "erpordernumber" : "10-12345-11",
+                            "vendorcode" : "Q012",
+                            "isacopapplied" : "N",
+                            "adjustedcost" : "5000.09",
+                            "serialnumberdetails" : {
+                              "serialnumber" : "07AS3CAK500682"
+                            },
+                            "productextendedspecs" : {
+                              "attributename" : "commenttext",
+                              "attributevalue" : "FULL ARRAY BACKLIGHTIN CLEAN CABLE"
+                            }
+                          }, {
+                            "globallinenumber" : "002",
+                            "ordersuffix" : "21",
+                            "linestatus" : "INVOICED",
+                            "partnumber" : "2GH590",
+                            "manufacturerpartnumber" : "F-ADT-STR-KT-1",
+                            "vendorname" : "SAMSUNG - SMART THINGS",
+                            "partdescription1" : "ADT HOME SECURITY STARTER KIT",
+                            "partdescription2" : "SECURITY STARTER KIT",
+                            "freeitempromoflag" : "false",
+                            "unitweight" : "5.15",
+                            "unitprice" : 500.9,
+                            "foreignunitprice" : 0,
+                            "extendedprice" : 500.9,
+                            "foreignextendedprice" : 0,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "promisedate" : "2018-07-15",
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipmentdate" : "2018-07-17",
+                              "shipfromwarehouseid" : "80",
+                              "warehousename" : "Jonestown, PA",
+                              "invoicenumber" : "1234521",
+                              "invoicedate" : "2018-07-16",
+                              "status" : "I",
+                              "statusdescription" : "INVOICED",
+                              "shippeddate" : "2018-07-17",
+                              "carriercode" : "RG",
+                              "carriername" : "FEDEX GROUND",
+                              "packagedetails" : {
+                                "trackingnumber" : "017136225260674",
+                                "packageweight" : "000000006",
+                                "cartonnumber" : "001",
+                                "quantityinbox" : "0000001"
+                              }
+                            } ],
+                            "erpordernumber" : "10-12345-21",
+                            "vendorcode" : "QG64",
+                            "isacopapplied" : "N",
+                            "adjustedcost" : "400.99",
+                            "productextendedspecs" : {
+                              "attributename" : "commenttext",
+                              "attributevalue" : "SECURITY STARTER KIT"
+                            }
+                          } ],
+                          "extendedspecs" : [ {
+                            "attributename" : "termscode",
+                            "attributevalue" : "300"
+                          }, {
+                            "attributename" : "termsdescription",
+                            "attributevalue" : "NET 30 DAYS"
+                          }, {
+                            "attributename" : "commenttext",
+                            "attributevalue" : "PHONE:7148675309"
+                          }, {
+                            "attributename" : "commenttext",
+                            "attributevalue" : "PHONE:7148675309"
+                          } ],
+                          "ordertype" : "S",
+                          "erpid" : null
+                        }
+                      }
+                    }
+                  },
+                  "Customer not found" : {
+                    "value" : {
+                      "quoteSearchResponse" : {
+                        "responsePreamble" : {
+                          "responseStatus" : "Failed",
+                          "responseStatusCode" : "400",
+                          "responseMessage" : "Customer Not Found"
+                        },
+                        "totalCount" : 0
+                      }
+                    }
+                  },
+                  "Invalid sort column" : {
+                    "value" : {
+                      "quoteSearchResponse" : {
+                        "responsePreamble" : {
+                          "responseStatus" : "Failed",
+                          "responseStatusCode" : "400",
+                          "responseMessage" : "Provide valid sort column name"
+                        },
+                        "totalCount" : 0
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description" : "This endpoint enables the retrieval and filtering of relevant quote list key criteria data, such as quote number, special bid numbers, end user name, status, and date ranges from the Ingram Micro system. By default, the Quotes endpoint retrieves quotes modified or created within the last 30 days.\n\n Observe these additional parameters:<ul><li>Only active quotes are available through this API.</li><li>Quotes older than 365 days are excluded by default.</li><li>You can use date range filters to retrieve quotes older than 30 days and up to 365 days.</li><li>Quotes that are in draft and closed states are excluded, and are not accessible through this API.</li></ul>",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/quoteListRequest"
+              },
+              "examples" : {
+                "Example" : {
+                  "value" : {
+                    "quoteSearchRequest" : {
+                      "requestPreamble" : {
+                        "customerNumber" : "20-222222",
+                        "customerContact" : "customer@im.com",
+                        "isoCountryCode" : "US"
+                      },
+                      "retrieveQuoteRequest" : {
+                        "fromDate" : "2019-08-01",
+                        "toDate" : "2019-11-01",
+                        "pageIndex" : 1,
+                        "recordsPerPage" : 5,
+                        "sorting" : "desc",
+                        "sortingColumnName" : "createdon",
+                        "thirdPartySource" : "3RDPIDCONWISE"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Quotes v5" ]
+      },
+      "parameters" : [ ]
+    },
+    "/resellers/v5/quote/{quoteNumber}" : {
+      "get" : {
+        "summary" : "Get Quote Details",
+        "tags" : [ "Quotes v5" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/quoteDetails"
+                },
+                "examples" : {
+                  "Example" : {
+                    "value" : {
+                      "quoteDetailResponse" : {
+                        "responsePreamble" : {
+                          "responseStatus" : "Passed",
+                          "statusCode" : 200,
+                          "responseMessage" : "Records Found"
+                        },
+                        "retrieveQuoteResponse" : {
+                          "quoteGuid" : "bfce8c7f-de74-ea11-a811-000d3a32deaa",
+                          "quoteName" : "USName53",
+                          "quoteNumber" : "QUO-25576-C8S2W7",
+                          "quoteExpiryDate" : "2020-08-13",
+                          "revisionNumber" : "0",
+                          "introPreamble" : "Thank you for contacting Ingram Micro. We value your business greatly and will continue to deliver the services you need to retain it. This quote is not intended to represent the entire conversation; only what was relevant to the solution you requested. We make every effort to provide a complete and correct solution. However, the accuracy of the solution provided is dependent on the information gathered. If relevant information is not provided by our customer, Ingram Micro cannot be held responsible. We urge you to review this quote fully, to ensure it reflects all of your required specifications. If you have additional questions, please contact your designated Ingram Micro contact. Remember to reference your Quote Number.Call reference    To ensure fastest and most accurate processing of your order, please provide the quote at the time of purchase",
+                          "purchaseInstructions" : "For specific pricing and to order the above products, you may : Some product may be orderable on Imonline at http://us-new.ingrammicro.com : Call the Ingram Micro Sales department at 1.800.456.8000; Your PO number;End User; Your fax number; Shipping instructions; End user PO number; End user license, contract or authorization number Thank you for your order!",
+                          "legalTerms" : "This offer to sell the listed product(s) is subject to product availability and Ingram Micro's standard terms and conditions that are published on http://www.ingrammicro.com prices are subject to change without notice. Please contact the Ingram Micro Sales desk at 1.800.456.8000 if you have any additional questions.",
+                          "accountInfo" : {
+                            "accountName" : "INGRAM MICRO CAPS TEST ACCOUNT",
+                            "bcn" : "20222222",
+                            "phone" : "7166333600"
+                          },
+                          "contactInfo" : {
+                            "contactName" : "test9 user9",
+                            "contactEmail" : null
+                          },
+                          "currencyCode" : "USD",
+                          "priceDeviationId" : null,
+                          "customerNeed" : null,
+                          "solutionProposed" : null,
+                          "status" : "Active",
+                          "created" : "2020-04-02",
+                          "modified" : "2020-04-02",
+                          "vendorAttributes" : {
+                            "estimateId" : "FT93031874YX",
+                            "dealId" : "41168951",
+                            "vendorName" : "CISCO - HW SWITCHES DT",
+                            "vendorSettingMessage" : null
+                          },
+                          "endUser" : {
+                            "endUserName" : "WAKE FOREST UNIVERSITY",
+                            "endUserAddress" : "391 TECHNOLOGY WAY",
+                            "endUserAddress2" : null,
+                            "endUserAddress3" : null,
+                            "endUserCity" : "WINSTON SALEM",
+                            "endUserState" : "NC",
+                            "endUserEmail" : null,
+                            "endUserPhone" : null,
+                            "endUserZipCode" : "27101",
+                            "endUserContactName" : null,
+                            "endUserMarketSegment" : null
+                          },
+                          "leasingCalculations" : "Lease Rate 2000",
+                          "leasingInstructions" : "<font>Win more opportunities by offering your customers flexible financing solutions with Ingram Micro Financial Solutions.</font>#####<ul><li><a href='https://us-new.ingrammicro.com/Pages/sales_support_financial_services_leasing.aspx'><font color='DarkBlue'>Learn more</font></a> about Ingram Micro Leasing Program</li></ul>#####<ul><li>Contact a leasing specialist today at 877-877-0035 or email <a href='mailto:financialsolutions@ingrammicro.com'><font color='DarkBlue'>financialsolutions@ingrammicro.com</font></a></li></ul>#####<font color='Gray'>Lease pricing is intended to be a good faith estimate and is being used for marketing purposes only. The actual rate and payment amount may vary, and is subject to credit approval in addition to any terms and conditions that may be required.</font>"
+                        },
+                        "quoteProductList" : [ {
+                          "quoteProductGuid" : "cfce8c7f-de74-ea11-a811-000d3a32deaa",
+                          "quantity" : "1.0",
+                          "comments" : null,
+                          "sku" : "9Y6780",
+                          "lineNumber" : "1.0",
+                          "price" : {
+                            "quotePrice" : "1401.85",
+                            "msrp" : "2645.00",
+                            "extendedMsrp" : "2645.00",
+                            "extendedQuotePrice" : "1401.85"
+                          },
+                          "description" : "Catalyst 9300 8 x 10GE Network Module, spare",
+                          "vendorPartNumber" : "C9300-NM-8X=",
+                          "weight" : "1.35",
+                          "isSuggestionProduct" : "false",
+                          "vpnCategory" : "hwsw",
+                          "quoteProductsSupplierPartAuxiliaryId" : "69479607572;0;;",
+                          "quoteProductsVendor" : "CISCO - HW SWITCHES DT"
+                        } ],
+                        "totalQuoteProductCount" : "1",
+                        "totalExtendedMsrp" : "2645.00",
+                        "totalQuantity" : 1,
+                        "totalExtendedQuotePrice" : "1401.85"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId" : "get-v5-quotes-details",
+        "description" : "The quote details API provides all quote details associated with the quote number provided.\n\n The “<strong>quoteNumber</strong>”, “<strong>isoCountryCode</strong>” and “<strong>customerNumber</strong>” parameters are required.",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "parameters" : [ {
+          "schema" : {
+            "type" : "string",
+            "default" : "20-222222"
+          },
+          "in" : "query",
+          "name" : "customerNumber",
+          "required" : true,
+          "description" : "Your Ingram Micro unique customer number"
+        }, {
+          "schema" : {
+            "type" : "string",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "default" : "US"
+          },
+          "in" : "query",
+          "name" : "isoCountryCode",
+          "required" : true,
+          "description" : ""
+        }, {
+          "schema" : {
+            "type" : "string",
+            "default" : "customer"
+          },
+          "in" : "query",
+          "description" : "Unique identifier used to identify the third party source accessing the services",
+          "name" : "thirdPartySource"
+        } ]
+      },
+      "parameters" : [ {
+        "schema" : {
+          "type" : "string",
+          "default" : "QUO-25576-C8S2W7"
+        },
+        "name" : "quoteNumber",
+        "in" : "path",
+        "required" : true,
+        "description" : "Ingram Micro Quote Number"
+      }, {
+        "schema" : {
+          "type" : "string"
+        },
+        "name" : "thirdPartySource",
+        "in" : "query",
+        "required" : false,
+        "description" : "Unique identifier used to identify the third party source accessing the services        "
+      } ]
+    },
+    "/products/v4/multiskupriceandstock" : {
+      "post" : {
+        "description" : "Find price and availability of up to 50 SKUs in a single request. As you increase the number of items in the request response time will be extended. This transaction must not be used as a continuous cyclical call to populate availability and pricing for your full catalog. Customers that perform this activity will lose access to price and availability.\n\nIngram can provide a Price catalog file and an Inventory file in flat file format, which can be obtained through FTP download. Please contact 1800-616-4665 or Electronic.Services@ingrammicro.com for more information on these files.",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/multiSKUPriceAndStockRequest"
+              },
+              "examples" : {
+                "Ingram Part Number" : {
+                  "value" : "{  \n   \"servicerequest\":{\n        \"requestpreamble\":{  \n         \"customernumber\":\"20-222222\",\n         \"isocountrycode\":\"US\"\n      },\n      \"priceandstockrequest\":{  \n         \"showwarehouseavailability\":\"True\",\n         \"extravailabilityflag\":\"Y\",\n         \"item\":[  \n           {\"ingrampartnumber\":\"TB6489\",\"quantity\":1}\n         ],\n         \"includeallsystems\":false\n      }\n   }\n}"
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/multiSKUPriceAndStockResponse"
+                },
+                "examples" : { }
+              }
+            }
+          }
+        },
+        "tags" : [ "Product Catalog v4" ],
+        "summary" : "Product availability for upto 50 SKUs",
+        "operationId" : "post-v4-multiskupriceandstock",
+        "parameters" : [ ],
+        "security" : [ {
+          "application" : [ "read" ]
+        } ]
+      }
+    },
+    "/products/v4/productsearch" : {
+      "post" : {
+        "description" : "A real time search that provides the Ingram Micro part number using the manufacturer part number.  This API is helpful to eliminate any errors when a manufactuer has the same part number and Ingram Micro has had to create multiple sku numbers ",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/productSearchRequest"
+              },
+              "examples" : {
+                "Ingram Part Number" : {
+                  "value" : {
+                    "servicerequest" : {
+                      "requestpreamble" : {
+                        "customernumber" : "20-222222",
+                        "isocountrycode" : "US"
+                      },
+                      "productsearchrequest" : {
+                        "searchcriteria" : {
+                          "ingrampartnumber" : "TSXML3"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/productSearchResponse"
+                },
+                "examples" : {
+                  "SKU found" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "requeststatus" : "SUCCESS",
+                          "returnmessage" : "Details Found"
+                        },
+                        "productsearchresponse" : [ {
+                          "partnumbers" : [ {
+                            "ingrampartnumber" : "TSXML3",
+                            "manufacturerpartnumber" : "TESTXMLSKU3"
+                          } ]
+                        } ]
+                      }
+                    }
+                  },
+                  "SKU Not Found" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "requeststatus" : "FAILED",
+                          "returnmessage" : "PART-NOT-FOUND"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Product Catalog v4" ],
+        "summary" : "Real-time Product Search",
+        "parameters" : [ ],
+        "operationId" : "post-v4-productsearch",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ]
+      }
+    },
+    "/invoices/v4/invoicedetails" : {
+      "post" : {
+        "summary" : "Get Invoice Details",
+        "operationId" : "post-v4-invoicedetails",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/invoiceDetailResponse"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/invoiceDetailRequest"
+              },
+              "examples" : {
+                "Test" : {
+                  "value" : {
+                    "servicerequest" : {
+                      "requestpreamble" : {
+                        "isocountrycode" : "US",
+                        "customernumber" : "20-222222"
+                      },
+                      "invoicedetailrequest" : {
+                        "invoicenumber" : "30-13649-13",
+                        "customerponumber" : "DH-200732"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description" : "A real-time request that allows the customer to query Ingram Micro for Invoice information for a specific open or shipped order (in the past 9 months). Orders are searched using Ingram Micro Sales Order Number.",
+        "tags" : [ "Invoices v4" ]
+      },
+      "parameters" : [ ]
+    },
+    "/orders/v4/ordermodify" : {
+      "post" : {
+        "summary" : "Modify an Existing Order",
+        "operationId" : "post-v4-ordermodify",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/orderModifyResponse"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "application" : [ "read", "write" ]
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/orderModifyRequest"
+              }
+            }
+          }
+        },
+        "tags" : [ "Orders v4" ],
+        "description" : "The order modify transaction allows for changes to be made after the order creation process but before the order is released to Ingram Micro’s warehouse system.  Order modify transaction submitted after the order is released will be rejected and will not be applied.\n\nTypes of modifications allowable: Order release, add comment, and carrier change.\nNOTE - Direct Ship orders cannot be modified.\n"
+      }
+    },
+    "/orders/v4/orderlookup" : {
+      "post" : {
+        "summary" : "Order Search",
+        "operationId" : "post-v4-ordersearch",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/orderSearchResponse"
+                }
+              }
+            }
+          }
+        },
+        "description" : "Search your orders using various search parameters",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/orderSearchRequest"
+              }
+            }
+          }
+        },
+        "tags" : [ "Orders v4" ]
+      }
+    },
+    "/orders/v4/orderdetails" : {
+      "post" : {
+        "summary" : "Get Order Details",
+        "operationId" : "post-v4-orderdetails",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/orderDetailResponse"
+                },
+                "examples" : {
+                  "Sample" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "responsestatus" : "SUCCESS"
+                        },
+                        "orderdetailresponse" : {
+                          "ordernumber" : "10-12345",
+                          "customerordernumber" : "test order",
+                          "enduserponumber" : "ABC",
+                          "orderstatus" : "INVOICED",
+                          "entrytimestamp" : "2018-07-15T04:31:42-07:00",
+                          "entrymethoddescription" : "XML/PCG",
+                          "fulfilmentordercode" : "Y",
+                          "ordertotalvalue" : 3907.38,
+                          "ordersubtotal" : 3907.38,
+                          "freightamount" : 141.34,
+                          "currencycode" : "USD",
+                          "totalweight" : "86",
+                          "totaltax" : "0",
+                          "billtoaddress" : {
+                            "suffix" : "000",
+                            "name" : "Ingram Micro",
+                            "addressline1" : "123 Ingram Way",
+                            "addressline2" : null,
+                            "addressline3" : null,
+                            "city" : "Irvine",
+                            "state" : "CA",
+                            "postalcode" : "12345000",
+                            "countrycode" : "US"
+                          },
+                          "shiptoaddress" : {
+                            "name" : "Mr Customer",
+                            "addressline1" : "123 Main St",
+                            "city" : "Anywhere",
+                            "state" : "CA",
+                            "postalcode" : "12345000",
+                            "countrycode" : "US"
+                          },
+                          "lines" : [ {
+                            "globallinenumber" : "001",
+                            "ordersuffix" : "11",
+                            "linestatus" : "INVOICED",
+                            "partnumber" : "3AM612",
+                            "manufacturerpartnumber" : "QN75Q8FNBFXZA",
+                            "vendorname" : "SAMSUNG - CONSUMER TV",
+                            "partdescription1" : "75IN Q8 FLAT 4K UHD HDR SMARTTV",
+                            "partdescription2" : "FULL ARRAY BACKLIGHTIN CLEAN CABLE",
+                            "freeitempromoflag" : "false",
+                            "unitweight" : "75",
+                            "unitprice" : 50000.48,
+                            "foreignunitprice" : 0,
+                            "extendedprice" : 5000.48,
+                            "foreignextendedprice" : 0,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "promisedate" : "2018-07-15",
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipmentdate" : "2018-07-16",
+                              "shipfromwarehouseid" : "40",
+                              "warehousename" : "Carol Stream, IL",
+                              "invoicenumber" : "1234511",
+                              "invoicedate" : "2018-07-16",
+                              "status" : "I",
+                              "statusdescription" : "INVOICED",
+                              "shippeddate" : "2018-07-16",
+                              "carriercode" : "AY",
+                              "carriername" : "ORD4708752",
+                              "packagedetails" : {
+                                "trackingnumber" : 6838019,
+                                "packageweight" : 80,
+                                "cartonnumber" : "001",
+                                "quantityinbox" : "0000001"
+                              }
+                            } ],
+                            "erpordernumber" : "10-12345-11",
+                            "vendorcode" : "Q012",
+                            "isacopapplied" : "N",
+                            "adjustedcost" : "5000.09",
+                            "serialnumberdetails" : {
+                              "serialnumber" : "07AS3CAK500682"
+                            },
+                            "productextendedspecs" : {
+                              "attributename" : "commenttext",
+                              "attributevalue" : "FULL ARRAY BACKLIGHTIN CLEAN CABLE"
+                            }
+                          }, {
+                            "globallinenumber" : "002",
+                            "ordersuffix" : "21",
+                            "linestatus" : "INVOICED",
+                            "partnumber" : "2GH590",
+                            "manufacturerpartnumber" : "F-ADT-STR-KT-1",
+                            "vendorname" : "SAMSUNG - SMART THINGS",
+                            "partdescription1" : "ADT HOME SECURITY STARTER KIT",
+                            "partdescription2" : "SECURITY STARTER KIT",
+                            "freeitempromoflag" : "false",
+                            "unitweight" : "5.15",
+                            "unitprice" : 500.9,
+                            "foreignunitprice" : 0,
+                            "extendedprice" : 500.9,
+                            "foreignextendedprice" : 0,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "promisedate" : "2018-07-15",
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipmentdate" : "2018-07-17",
+                              "shipfromwarehouseid" : "80",
+                              "warehousename" : "Jonestown, PA",
+                              "invoicenumber" : "1234521",
+                              "invoicedate" : "2018-07-16",
+                              "status" : "I",
+                              "statusdescription" : "INVOICED",
+                              "shippeddate" : "2018-07-17",
+                              "carriercode" : "RG",
+                              "carriername" : "FEDEX GROUND",
+                              "packagedetails" : {
+                                "trackingnumber" : "017136225260674",
+                                "packageweight" : "000000006",
+                                "cartonnumber" : "001",
+                                "quantityinbox" : "0000001"
+                              }
+                            } ],
+                            "erpordernumber" : "10-12345-21",
+                            "vendorcode" : "QG64",
+                            "isacopapplied" : "N",
+                            "adjustedcost" : "400.99",
+                            "productextendedspecs" : {
+                              "attributename" : "commenttext",
+                              "attributevalue" : "SECURITY STARTER KIT"
+                            }
+                          } ],
+                          "extendedspecs" : [ {
+                            "attributename" : "termscode",
+                            "attributevalue" : "300"
+                          }, {
+                            "attributename" : "termsdescription",
+                            "attributevalue" : "NET 30 DAYS"
+                          }, {
+                            "attributename" : "commenttext",
+                            "attributevalue" : "PHONE:7148675309"
+                          }, {
+                            "attributename" : "commenttext",
+                            "attributevalue" : "PHONE:7148675309"
+                          } ],
+                          "ordertype" : "S",
+                          "erpid" : null
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Orders v4" ],
+        "description" : "A real-time request that allows the customer to query Ingram Micro for detailed information for a specific open or shipped order. Orders are searched using Ingram Micro Sales Order Number.",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/orderDetailRequest"
+              },
+              "examples" : {
+                "Sample" : {
+                  "value" : {
+                    "servicerequest" : {
+                      "requestpreamble" : {
+                        "isocountrycode" : "US",
+                        "customernumber" : "20-222222"
+                      },
+                      "orderdetailrequest" : {
+                        "ordernumber" : "20-B2V9H"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters" : [ ]
+    },
+    "/orders/v4/orderdelete" : {
+      "post" : {
+        "summary" : "Delete an Order",
+        "operationId" : "post-v4-orderdelete",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/orderDeleteResponse"
+                },
+                "examples" : {
+                  "Example" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "requestStatus" : "SUCCESS",
+                          "returnCode" : "00",
+                          "returnMessage" : "Order Deleted Successfully"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Orders v4" ],
+        "description" : "A real-time request to delete a previously accepted order must be submitted before the order is released to Ingram Micro’s warehouse. After release the order is no longer eligible for deletion. Order delete transaction submitted after the order is released will be rejected and will not be applied. *Direct ship orders cannot be deleted. Contact your sales rep for assistance.",
+        "security" : [ {
+          "application" : [ "write" ]
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/orderDeleteRequest"
+              },
+              "examples" : {
+                "Example" : {
+                  "value" : {
+                    "servicerequest" : {
+                      "requestpreamble" : {
+                        "isocountrycode" : "US",
+                        "customerumber" : "20-222222"
+                      },
+                      "OrderDeleteRequestDetails" : {
+                        "entryDate" : "2019-01-22",
+                        "orderBranch" : "20",
+                        "orderNumber" : "RC62Z"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters" : [ ]
+    },
+    "/orders/v4/ordercreate" : {
+      "post" : {
+        "summary" : "Create a new Order",
+        "operationId" : "post-v4-ordercreate",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/orderCreateResponse"
+                },
+                "examples" : {
+                  "Sample" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "responsestatus" : "SUCCESS"
+                        },
+                        "ordercreateresponse" : {
+                          "numberoflineswithsuccess" : "1",
+                          "numberoflineswitherror" : "0",
+                          "numberoflineswithwarning" : "0",
+                          "globalorderid" : "20-RBRN9",
+                          "customerponumber" : "H3E",
+                          "ordertype" : "S",
+                          "ordertimestamp" : "2018-07-18",
+                          "invoicingsystemorderid" : "20-RBRN9",
+                          "taxamount" : 0,
+                          "freightamount" : 0,
+                          "totalorderamount" : 0,
+                          "shiptoaddress" : {
+                            "attention" : null,
+                            "name" : null,
+                            "addressline1" : null,
+                            "addressline2" : null,
+                            "addressline3" : null,
+                            "addressline4" : null,
+                            "city" : null,
+                            "state" : null,
+                            "postalcode" : null,
+                            "countrycode" : null
+                          },
+                          "lines" : [ {
+                            "linetype" : "P",
+                            "globallinenumber" : "002",
+                            "partnumber" : "4K9938",
+                            "globalskuid" : "A300-4K9938",
+                            "freeitempromoflag" : "false",
+                            "linenumber" : "4",
+                            "carriercode" : "WC",
+                            "carrierdescription" : "WILL CALL",
+                            "requestedunitprice" : 647.6,
+                            "requestedquantity" : 1,
+                            "confirmedquantity" : 0,
+                            "backorderedquantity" : 1,
+                            "backorderetadate" : "2018-05-15",
+                            "unitproductprice" : 647.6,
+                            "netamount" : 0,
+                            "warehouseid" : "40",
+                            "ordersuffix" : "11",
+                            "isacopapplied" : "Y"
+                          } ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description" : "The order create transaction is a real-time transaction that allows customers to place standard product and direct ship (licensing and warranties) orders with Ingram Micro using API.",
+        "security" : [ {
+          "application" : [ "write" ]
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/orderCreateRequest"
+              },
+              "examples" : {
+                "With Ingram Part Number" : {
+                  "value" : {
+                    "ordercreaterequest" : {
+                      "requestpreamble" : {
+                        "isocountrycode" : "US",
+                        "customernumber" : "20-222222"
+                      },
+                      "ordercreatedetails" : {
+                        "systemid" : "",
+                        "customerponumber" : "TESTAPI10156",
+                        "billtosuffix" : "000",
+                        "shiptoaddress" : {
+                          "attention" : "HARRY WELLS",
+                          "addressline1" : "THE COMPUTER STORE",
+                          "addressline2" : "754 LAS PALMAS DR",
+                          "city" : "IRVINE",
+                          "state" : "CA",
+                          "postalcode" : "926022004",
+                          "countrycode" : "US"
+                        },
+                        "lines" : [ {
+                          "linetype" : "P",
+                          "linenumber" : "001",
+                          "globalskuid" : "",
+                          "quantity" : "1",
+                          "ingrampartnumber" : "NE7872"
+                        } ],
+                        "extendedspecs" : [ {
+                          "attributename" : "entrymethod",
+                          "attributevalue" : "WEBS"
+                        } ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Orders v4" ]
+      },
+      "parameters" : [ ]
+    },
+    "/quotes/v1/quotedetails" : {
+      "post" : {
+        "summary" : "Get Quote Details",
+        "operationId" : "post-v4-quotedetails",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/quoteDetailsResponse"
+                },
+                "examples" : {
+                  "Example" : {
+                    "value" : {
+                      "quoteDetailResponse" : {
+                        "responsePreamble" : {
+                          "responseStatus" : "Passed",
+                          "statusCode" : 200,
+                          "responseMessage" : "Records Found"
+                        },
+                        "retrieveQuoteResponse" : {
+                          "quoteGuid" : "bfce8c7f-de74-ea11-a811-000d3a32deaa",
+                          "quoteName" : "USName53",
+                          "quoteNumber" : "QUO-25576-C8S2W7",
+                          "quoteExpiryDate" : "2020-08-13",
+                          "revisionNumber" : "0",
+                          "introPreamble" : "Thank you for contacting Ingram Micro. We value your business greatly and will continue to deliver the services you need to retain it. This quote is not intended to represent the entire conversation; only what was relevant to the solution you requested. We make every effort to provide a complete and correct solution. However, the accuracy of the solution provided is dependent on the information gathered. If relevant information is not provided by our customer, Ingram Micro cannot be held responsible. We urge you to review this quote fully, to ensure it reflects all of your required specifications. If you have additional questions, please contact your designated Ingram Micro contact. Remember to reference your Quote Number.Call reference    To ensure fastest and most accurate processing of your order, please provide the quote at the time of purchase",
+                          "purchaseInstructions" : "For specific pricing and to order the above products, you may : Some product may be orderable on Imonline at http://us-new.ingrammicro.com : Call the Ingram Micro Sales department at 1.800.456.8000; Your PO number;End User; Your fax number; Shipping instructions; End user PO number; End user license, contract or authorization number Thank you for your order!",
+                          "legalTerms" : "This offer to sell the listed product(s) is subject to product availability and Ingram Micro's standard terms and conditions that are published on http://www.ingrammicro.com prices are subject to change without notice. Please contact the Ingram Micro Sales desk at 1.800.456.8000 if you have any additional questions.",
+                          "accountInfo" : {
+                            "accountName" : "INGRAM MICRO CAPS TEST ACCOUNT",
+                            "bcn" : "20222222",
+                            "phone" : "7166333600"
+                          },
+                          "contactInfo" : {
+                            "contactName" : "test9 user9",
+                            "contactEmail" : null
+                          },
+                          "currencyCode" : "USD",
+                          "priceDeviationId" : null,
+                          "customerNeed" : null,
+                          "solutionProposed" : null,
+                          "status" : "Active",
+                          "created" : "2020-04-02",
+                          "modified" : "2020-04-02",
+                          "vendorAttributes" : {
+                            "estimateId" : "FT93031874YX",
+                            "dealId" : "41168951",
+                            "vendorName" : "CISCO - HW SWITCHES DT",
+                            "vendorSettingMessage" : null
+                          },
+                          "endUser" : {
+                            "endUserName" : "WAKE FOREST UNIVERSITY",
+                            "endUserAddress" : "391 TECHNOLOGY WAY",
+                            "endUserAddress2" : null,
+                            "endUserAddress3" : null,
+                            "endUserCity" : "WINSTON SALEM",
+                            "endUserState" : "NC",
+                            "endUserEmail" : null,
+                            "endUserPhone" : null,
+                            "endUserZipCode" : "27101",
+                            "endUserContactName" : null,
+                            "endUserMarketSegment" : null
+                          },
+                          "leasingCalculations" : "Lease Rate 2000",
+                          "leasingInstructions" : "<font>Win more opportunities by offering your customers flexible financing solutions with Ingram Micro Financial Solutions.</font>#####<ul><li><a href='https://us-new.ingrammicro.com/Pages/sales_support_financial_services_leasing.aspx'><font color='DarkBlue'>Learn more</font></a> about Ingram Micro Leasing Program</li></ul>#####<ul><li>Contact a leasing specialist today at 877-877-0035 or email <a href='mailto:financialsolutions@ingrammicro.com'><font color='DarkBlue'>financialsolutions@ingrammicro.com</font></a></li></ul>#####<font color='Gray'>Lease pricing is intended to be a good faith estimate and is being used for marketing purposes only. The actual rate and payment amount may vary, and is subject to credit approval in addition to any terms and conditions that may be required.</font>"
+                        },
+                        "quoteProductList" : [ {
+                          "quoteProductGuid" : "cfce8c7f-de74-ea11-a811-000d3a32deaa",
+                          "quantity" : "1.0",
+                          "comments" : null,
+                          "sku" : "9Y6780",
+                          "lineNumber" : "1.0",
+                          "price" : {
+                            "quotePrice" : "1401.85",
+                            "msrp" : "2645.00",
+                            "extendedMsrp" : "2645.00",
+                            "extendedQuotePrice" : "1401.85"
+                          },
+                          "description" : "Catalyst 9300 8 x 10GE Network Module, spare",
+                          "vendorPartNumber" : "C9300-NM-8X=",
+                          "weight" : "1.35",
+                          "isSuggestionProduct" : "false",
+                          "vpnCategory" : "hwsw",
+                          "quoteProductsSupplierPartAuxiliaryId" : "69479607572;0;;",
+                          "quoteProductsVendor" : "CISCO - HW SWITCHES DT"
+                        } ],
+                        "totalQuoteProductCount" : "1",
+                        "totalExtendedMsrp" : "2645.00",
+                        "totalQuantity" : 1,
+                        "totalExtendedQuotePrice" : "1401.85"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description" : "A real-time request to delete a previously accepted order must be submitted before the order is released to Ingram Micro’s warehouse. After release the order is no longer eligible for deletion. Order delete transaction submitted after the order is released will be rejected and will not be applied. *Direct ship orders cannot be deleted. Contact your sales rep for assistance.",
+        "security" : [ {
+          "application" : [ "write" ]
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/quoteDetailsRequest"
+              },
+              "examples" : {
+                "Example" : {
+                  "value" : {
+                    "servicerequest" : {
+                      "requestpreamble" : {
+                        "isocountrycode" : "US",
+                        "customerumber" : "20-222222"
+                      },
+                      "OrderDeleteRequestDetails" : {
+                        "entryDate" : "2019-01-22",
+                        "orderBranch" : "20",
+                        "orderNumber" : "RC62Z"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Quotes v4" ]
+      },
+      "parameters" : [ ]
+    },
+    "/quotes/v1/quotes" : {
+      "post" : {
+        "summary" : "Get Quote List",
+        "operationId" : "post-v4-quotesearch",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/quoteListResponse"
+                },
+                "examples" : {
+                  "Sample" : {
+                    "value" : {
+                      "serviceresponse" : {
+                        "responsepreamble" : {
+                          "responsestatus" : "SUCCESS"
+                        },
+                        "orderdetailresponse" : {
+                          "ordernumber" : "10-12345",
+                          "customerordernumber" : "test order",
+                          "enduserponumber" : "ABC",
+                          "orderstatus" : "INVOICED",
+                          "entrytimestamp" : "2018-07-15T04:31:42-07:00",
+                          "entrymethoddescription" : "XML/PCG",
+                          "fulfilmentordercode" : "Y",
+                          "ordertotalvalue" : 3907.38,
+                          "ordersubtotal" : 3907.38,
+                          "freightamount" : 141.34,
+                          "currencycode" : "USD",
+                          "totalweight" : "86",
+                          "totaltax" : "0",
+                          "billtoaddress" : {
+                            "suffix" : "000",
+                            "name" : "Ingram Micro",
+                            "addressline1" : "123 Ingram Way",
+                            "addressline2" : null,
+                            "addressline3" : null,
+                            "city" : "Irvine",
+                            "state" : "CA",
+                            "postalcode" : "12345000",
+                            "countrycode" : "US"
+                          },
+                          "shiptoaddress" : {
+                            "name" : "Mr Customer",
+                            "addressline1" : "123 Main St",
+                            "city" : "Anywhere",
+                            "state" : "CA",
+                            "postalcode" : "12345000",
+                            "countrycode" : "US"
+                          },
+                          "lines" : [ {
+                            "globallinenumber" : "001",
+                            "ordersuffix" : "11",
+                            "linestatus" : "INVOICED",
+                            "partnumber" : "3AM612",
+                            "manufacturerpartnumber" : "QN75Q8FNBFXZA",
+                            "vendorname" : "SAMSUNG - CONSUMER TV",
+                            "partdescription1" : "75IN Q8 FLAT 4K UHD HDR SMARTTV",
+                            "partdescription2" : "FULL ARRAY BACKLIGHTIN CLEAN CABLE",
+                            "freeitempromoflag" : "false",
+                            "unitweight" : "75",
+                            "unitprice" : 50000.48,
+                            "foreignunitprice" : 0,
+                            "extendedprice" : 5000.48,
+                            "foreignextendedprice" : 0,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "promisedate" : "2018-07-15",
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipmentdate" : "2018-07-16",
+                              "shipfromwarehouseid" : "40",
+                              "warehousename" : "Carol Stream, IL",
+                              "invoicenumber" : "1234511",
+                              "invoicedate" : "2018-07-16",
+                              "status" : "I",
+                              "statusdescription" : "INVOICED",
+                              "shippeddate" : "2018-07-16",
+                              "carriercode" : "AY",
+                              "carriername" : "ORD4708752",
+                              "packagedetails" : {
+                                "trackingnumber" : 6838019,
+                                "packageweight" : 80,
+                                "cartonnumber" : "001",
+                                "quantityinbox" : "0000001"
+                              }
+                            } ],
+                            "erpordernumber" : "10-12345-11",
+                            "vendorcode" : "Q012",
+                            "isacopapplied" : "N",
+                            "adjustedcost" : "5000.09",
+                            "serialnumberdetails" : {
+                              "serialnumber" : "07AS3CAK500682"
+                            },
+                            "productextendedspecs" : {
+                              "attributename" : "commenttext",
+                              "attributevalue" : "FULL ARRAY BACKLIGHTIN CLEAN CABLE"
+                            }
+                          }, {
+                            "globallinenumber" : "002",
+                            "ordersuffix" : "21",
+                            "linestatus" : "INVOICED",
+                            "partnumber" : "2GH590",
+                            "manufacturerpartnumber" : "F-ADT-STR-KT-1",
+                            "vendorname" : "SAMSUNG - SMART THINGS",
+                            "partdescription1" : "ADT HOME SECURITY STARTER KIT",
+                            "partdescription2" : "SECURITY STARTER KIT",
+                            "freeitempromoflag" : "false",
+                            "unitweight" : "5.15",
+                            "unitprice" : 500.9,
+                            "foreignunitprice" : 0,
+                            "extendedprice" : 500.9,
+                            "foreignextendedprice" : 0,
+                            "taxamount" : 0,
+                            "requestedquantity" : "1",
+                            "confirmedquantity" : "1",
+                            "backorderquantity" : "0",
+                            "promisedate" : "2018-07-15",
+                            "shipmentdetails" : [ {
+                              "quantity" : 1,
+                              "shipmentdate" : "2018-07-17",
+                              "shipfromwarehouseid" : "80",
+                              "warehousename" : "Jonestown, PA",
+                              "invoicenumber" : "1234521",
+                              "invoicedate" : "2018-07-16",
+                              "status" : "I",
+                              "statusdescription" : "INVOICED",
+                              "shippeddate" : "2018-07-17",
+                              "carriercode" : "RG",
+                              "carriername" : "FEDEX GROUND",
+                              "packagedetails" : {
+                                "trackingnumber" : "017136225260674",
+                                "packageweight" : "000000006",
+                                "cartonnumber" : "001",
+                                "quantityinbox" : "0000001"
+                              }
+                            } ],
+                            "erpordernumber" : "10-12345-21",
+                            "vendorcode" : "QG64",
+                            "isacopapplied" : "N",
+                            "adjustedcost" : "400.99",
+                            "productextendedspecs" : {
+                              "attributename" : "commenttext",
+                              "attributevalue" : "SECURITY STARTER KIT"
+                            }
+                          } ],
+                          "extendedspecs" : [ {
+                            "attributename" : "termscode",
+                            "attributevalue" : "300"
+                          }, {
+                            "attributename" : "termsdescription",
+                            "attributevalue" : "NET 30 DAYS"
+                          }, {
+                            "attributename" : "commenttext",
+                            "attributevalue" : "PHONE:7148675309"
+                          }, {
+                            "attributename" : "commenttext",
+                            "attributevalue" : "PHONE:7148675309"
+                          } ],
+                          "ordertype" : "S",
+                          "erpid" : null
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description" : "A real-time request that allows the customer to query Ingram Micro for detailed information for a specific open or shipped order. Orders are searched using Ingram Micro Sales Order Number.",
+        "security" : [ {
+          "application" : [ "read" ]
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/quoteListRequest"
+              },
+              "examples" : {
+                "Sample" : {
+                  "value" : {
+                    "servicerequest" : {
+                      "requestpreamble" : {
+                        "isocountrycode" : "US",
+                        "customernumber" : "20-222222"
+                      },
+                      "orderdetailrequest" : {
+                        "ordernumber" : "20-B2V9H"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Quotes v4" ]
+      },
+      "parameters" : [ ]
+    }
+  },
+  "servers" : [ {
+    "url" : "https://api.ingrammicro.com:443/sandbox",
+    "description" : "Sandbox"
+  } ],
+  "components" : {
+    "schemas" : {
+      "OrderCreateRequest" : {
+        "type" : "object",
+        "required" : [ "customerOrderNumber" ],
+        "properties" : {
+          "customerOrderNumber" : {
+            "type" : "string",
+            "maxLength" : 35,
+            "description" : "The reseller's unique PO/Order number."
+          },
+          "endCustomerOrderNumber" : {
+            "type" : "string",
+            "description" : "The end user/customer's Purchase Order number."
+          },
+          "billToAddressId" : {
+            "type" : "string",
+            "maxLength" : 10,
+            "description" : "Suffix used to identify billing address. Created during onboarding. Resellers are provided with one or more address IDs depending on how many bill to addresses they need for various flooring companies they are using for credit."
+          },
+          "specialBidNumber" : {
+            "type" : "string",
+            "description" : "The bid number provided to the reseller by the vendor for special pricing and discounts. Line-level bid numbers take precedence over header-level bid numbers."
+          },
+          "notes" : {
+            "type" : "string",
+            "description" : "Order level notes."
+          },
+          "acceptBackOrder" : {
+            "type" : "boolean",
+            "description" : "ENUM [\"true\",\"false\"] - accept order if this item is backordered. This field along with shipComplete field decides the value of backorderflag. The value of this field is ignored when shipComplete field is present."
+          },
+          "resellerInfo" : {
+            "type" : "object",
+            "description" : "The address and contact information provided by the reseller.",
+            "properties" : {
+              "resellerId" : {
+                "type" : "string",
+                "description" : "The reseller's Id."
+              },
+              "companyName" : {
+                "type" : "string",
+                "description" : "The reseller's company name."
+              },
+              "contact" : {
+                "type" : "string",
+                "description" : "The reseller's contact name."
+              },
+              "addressLine1" : {
+                "type" : "string",
+                "description" : "The reseller's street address."
+              },
+              "addressLine2" : {
+                "type" : "string",
+                "description" : "The reseller's building or apartment number."
+              },
+              "addressLine3" : {
+                "type" : "string",
+                "description" : "The reseller's address line 3."
+              },
+              "city" : {
+                "type" : "string",
+                "description" : "The reseller's city."
+              },
+              "state" : {
+                "type" : "string",
+                "description" : "The reseller's state."
+              },
+              "postalCode" : {
+                "type" : "string",
+                "description" : "The reseller's zip or postal code."
+              },
+              "countryCode" : {
+                "type" : "string",
+                "description" : "The reseller's two-character ISO country code."
+              },
+              "phoneNumber" : {
+                "type" : "integer",
+                "description" : "The reseller's phone number."
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "The reseller's email address."
+              }
+            }
+          },
+          "shipToInfo" : {
+            "type" : "object",
+            "description" : "The shipping information provided by the reseller.",
+            "properties" : {
+              "addressId" : {
+                "type" : "string",
+                "maxLength" : 10,
+                "description" : "The ID references the resellers address in Ingram Micro's system for shipping. Provided to resellers during the onboarding process."
+              },
+              "contact" : {
+                "type" : "string",
+                "maxLength" : 70,
+                "description" : "The company contact provided by the reseller."
+              },
+              "companyName" : {
+                "type" : "string",
+                "maxLength" : 40,
+                "description" : "The name of the company the order will be shipped to."
+              },
+              "name1" : {
+                "type" : "string",
+                "description" : "name1"
+              },
+              "name2" : {
+                "type" : "string",
+                "description" : "name2"
+              },
+              "addressLine1" : {
+                "type" : "string",
+                "maxLength" : 70,
+                "description" : "The street address and building or house number the order will be shipped to."
+              },
+              "addressLine2" : {
+                "type" : "string",
+                "maxLength" : 70,
+                "description" : "The apartment number the order will be shipped to."
+              },
+              "addressLine3" : {
+                "type" : "string",
+                "maxLength" : 70,
+                "description" : "Line 3 of the address the order will be shipped to."
+              },
+              "addressLine4" : {
+                "type" : "string",
+                "description" : "Street address4"
+              },
+              "city" : {
+                "type" : "string",
+                "maxLength" : 25,
+                "description" : "The city the order will be shipped to."
+              },
+              "state" : {
+                "type" : "string",
+                "maxLength" : 3,
+                "description" : "The state the order will be shipped to."
+              },
+              "postalCode" : {
+                "type" : "string",
+                "maxLength" : 10,
+                "description" : "The zip or postal code the order will be shipped to."
+              },
+              "countryCode" : {
+                "type" : "string",
+                "maxLength" : 10,
+                "description" : "The two-character ISO country code the order will be shipped to."
+              },
+              "phoneNumber" : {
+                "type" : "integer",
+                "description" : "The company contact phone number."
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "The company contact email address."
+              }
+            }
+          },
+          "endUserInfo" : {
+            "type" : "object",
+            "description" : "The contact information for the end user/customer provided by the reseller. Used to determine pricing and discounts.",
+            "properties" : {
+              "endUserId" : {
+                "type" : "string",
+                "description" : "ID for the end user/customer in Ingram Micro's system."
+              },
+              "contact" : {
+                "type" : "string",
+                "description" : "The contact name for the end user/customer."
+              },
+              "companyName" : {
+                "type" : "string",
+                "maxLength" : 40,
+                "description" : "The company name for the end user/customer."
+              },
+              "name1" : {
+                "type" : "string",
+                "description" : "name1"
+              },
+              "name2" : {
+                "type" : "string",
+                "description" : "name2"
+              },
+              "addressLine1" : {
+                "type" : "string",
+                "description" : "The end user/customer's street address and building or house number."
+              },
+              "addressLine2" : {
+                "type" : "string",
+                "description" : "The end user/customer's apartment number."
+              },
+              "addressLine3" : {
+                "type" : "string",
+                "description" : "Line 3 of the address for the end user/customer."
+              },
+              "addressLine4" : {
+                "type" : "string",
+                "description" : "Street address4"
+              },
+              "city" : {
+                "type" : "string",
+                "description" : "The end user/customer's city."
+              },
+              "state" : {
+                "type" : "string",
+                "description" : "The end user/customer's state."
+              },
+              "postalCode" : {
+                "type" : "string",
+                "description" : "The end user/customer's zip or postal code."
+              },
+              "countryCode" : {
+                "type" : "string",
+                "description" : "The end user/customer's two-character ISO country code."
+              },
+              "phoneNumber" : {
+                "type" : "integer",
+                "description" : "The end user/customer's phone number."
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "The end user/customer's email."
+              }
+            }
+          },
+          "lines" : {
+            "type" : "array",
+            "description" : "The line-level details of the order.",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "customerLineNumber" : {
+                  "type" : "string",
+                  "maxLength" : 6,
+                  "description" : "The reseller's line item number for reference in their system."
+                },
+                "ingramPartNumber" : {
+                  "type" : "string",
+                  "maxLength" : 18,
+                  "description" : "The unique IngramMicro part number."
+                },
+                "quantity" : {
+                  "type" : "integer",
+                  "description" : "The requested quantity of the line item."
+                },
+                "specialBidNumber" : {
+                  "type" : "string",
+                  "maxLength" : 36,
+                  "description" : "The line-level bid number provided to the reseller by the vendor for special pricing and discounts. Used to track the bid number in the case of split orders or where different line items have different bid numbers. Line-level bid number take precedence over header-level bid numbers."
+                },
+                "notes" : {
+                  "type" : "string",
+                  "description" : "Line-level notes."
+                },
+                "unitPrice" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "The reseller-requested unit price for the line item. The unit price is not guaranteed."
+                },
+                "additionalAttributes" : {
+                  "type" : "array",
+                  "items" : {
+                    "properties" : {
+                      "attributeName" : {
+                        "type" : "string",
+                        "description" : "SAP requested and country-specific line level details."
+                      },
+                      "attributeValue" : {
+                        "type" : "string",
+                        "description" : "Line-level additional attributes."
+                      }
+                    }
+                  }
+                },
+                "endUserInfo" : {
+                  "type" : "array",
+                  "items" : {
+                    "properties" : {
+                      "endUserType" : {
+                        "type" : "string",
+                        "description" : "Specifies the type of endUser. It can be endUser or endUserContact for SAP flow."
+                      },
+                      "endUserId" : {
+                        "type" : "string",
+                        "maxLength" : 10,
+                        "description" : "ID for the end user/customer in Ingram Micro's system."
+                      },
+                      "contact" : {
+                        "type" : "string",
+                        "description" : "The contact name for the end user/customer."
+                      },
+                      "companyName" : {
+                        "type" : "string",
+                        "description" : "The company name for the end user/customer."
+                      },
+                      "name1" : {
+                        "type" : "string",
+                        "maxLength" : 35,
+                        "description" : "name1"
+                      },
+                      "name2" : {
+                        "type" : "string",
+                        "description" : "name2"
+                      },
+                      "addressLine1" : {
+                        "type" : "string",
+                        "description" : "The end user/customer's street address and building or house number."
+                      },
+                      "addressLine2" : {
+                        "type" : "string",
+                        "description" : "The end user/customer's apartment number."
+                      },
+                      "addressLine3" : {
+                        "type" : "string",
+                        "description" : "Line 3 of the address for the end user/customer."
+                      },
+                      "addressLine4" : {
+                        "type" : "string",
+                        "description" : "Street address4"
+                      },
+                      "city" : {
+                        "type" : "string",
+                        "description" : "The end user/customer's city."
+                      },
+                      "state" : {
+                        "type" : "string",
+                        "description" : "The end user/customer's state."
+                      },
+                      "postalCode" : {
+                        "type" : "string",
+                        "description" : "The end user/customer's zip or postal code."
+                      },
+                      "countryCode" : {
+                        "type" : "string",
+                        "maxLength" : 3,
+                        "description" : "The end user/customer's two-character ISO country code."
+                      },
+                      "phoneNumber" : {
+                        "type" : "number",
+                        "maxLength" : 30,
+                        "description" : "The end user/customer's phone number."
+                      },
+                      "email" : {
+                        "type" : "string",
+                        "maxLength" : 241,
+                        "description" : "The end user/customer's email."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "shipmentDetails" : {
+            "type" : "object",
+            "description" : "Shipping details for the order provided by the customer.",
+            "properties" : {
+              "carrierCode" : {
+                "type" : "string",
+                "maxLength" : 10,
+                "description" : "The code for the shipping carrier for the line item."
+              },
+              "freightAccountNumber" : {
+                "type" : "string",
+                "description" : "The reseller 's shipping account number with carrier. Used to bill the shipping carrier directly from the reseller's account with the carrier."
+              },
+              "shipComplete" : {
+                "type" : "string",
+                "maxLength" : 1,
+                "description" : "Specifies whether the shipment will be shipped only when all products are fulfilled. The value of this field along with acceptBackOrder field decides the value of backorderflag. If this field is set, acceptBackOrder field is ignored. Possible values for this field are true, C, P, E, B. \n\n With value as true or C, backorderflag will be set as C. \n\n With value as P, E or B, backorderflag will be set as P, E or B respectively. \n\n C = Ship complete at distribution level. \n\n P = ship complete at line level. \n\n E = ship complete across all distributions. \n\n B = ship consolidated (pulls stock from any DC to where the order is allocated and ships complete)."
+              },
+              "requestedDeliveryDate" : {
+                "type" : "string",
+                "maxLength" : 8,
+                "format" : "date",
+                "description" : "The reseller-requested delivery date in UTC format. Delivery date is not guaranteed."
+              },
+              "signatureRequired" : {
+                "type" : "boolean",
+                "description" : "Specifies whether a signature is required for delivery. Default is False."
+              },
+              "shippingInstructions" : {
+                "type" : "string",
+                "maxLength" : 132
+              }
+            }
+          },
+          "additionalAttributes" : {
+            "type" : "array",
+            "description" : "Shipment-level additional attributes.",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "attributeName" : {
+                  "type" : "string",
+                  "description" : "allowPartialOrder: Allow orders with failed lines. (SAP) Depends on backorder settings. \n\n\nDpasRating: DX rating by Department of Defense is the highest rating by the highest offices and meant to be top priority. DO any other gov offices at the federal level to priotize. \n\n DpasProgramId: Identifies the actual agency that signed off on the DPAS priority. \n\n allowDuplicateCustomerOrderNumber: Allow orders with duplicate customer PO numbers. Enables resellers to have the same PO number for multiple orders. \n \n channelCode: Determine storage location for Markeplace(SAP) for different orderTypes.\n \n customerPOType: Used for pricing, similar to orderType. Possible SAP values- ZXML and ZWEB.\n \n storageLocation: Determine the location of the product stock in SAP for Marketplaces.\n \n soldTo: To be used in cases when Sold-To is different than Customer ID.\n \n orderType: Order Type[SAP]- ZOR and ZLCN.\n \n endUserSearchTerm: Search ID for a end user contact is used in SAP to determine the contact name.\n \n Z101: Used for end customer details such as name, address, phone, etc. This information flows to SAP and is used by warehouse.\n \n euDepId: DEP ID would be the 'End User DEP/ABM Organization ID' up to 32 characters and is assigned by Apple.\n \n depOrderNbr: depordernbr is 'End User PO to reseller' Can appear in message lines or dedicated end user po#.\n \n govtProgramType: Program type, “PA” for government orders, “ED” for education order.\n \n govtEndUserType: Type of end user of the program. F = Federal, S = State, E = Local, K = K-12 school, and H = Higher Education\n \n govtSolicitationNumber: Education order’s contract number\n \n govtPublicPrivateCode: Determines TAX / NO TAX.   'P' PUBLIC SECTOR,   'R' PRIVATE SECTOR.  Value needs only to be provided for EDUCATION order.\n \n govtEndUserData: Name of the End user of the program. For example, STATE OF OHIO, CHICAGO SCHOOLDISTRICT etc.\n \n govtEndUserPostalCode: 9 CHAR FIELD / Zip Code of the End user of the order"
+                },
+                "attributeValue" : {
+                  "type" : "string",
+                  "description" : "attributefield data"
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrderCreateResponse" : {
+        "type" : "object",
+        "properties" : {
+          "customerOrderNumber" : {
+            "type" : "string",
+            "description" : "The reseller's unique PO/Order number."
+          },
+          "endCustomerOrderNumber" : {
+            "type" : "string",
+            "description" : "The end user/customer's Purchase Order number."
+          },
+          "billToAddressId" : {
+            "type" : "string",
+            "description" : "Suffix used to identify billing address. Created during onboarding. Resellers are provided with one or more address IDs depending on how many bill to addresses they need for various flooring companies they are using for credit"
+          },
+          "specialBidNumber" : {
+            "type" : "string",
+            "description" : "The bid number provided to the reseller by the vendor for special pricing and discounts. Line-level bid numbers take precedence over header-level bid numbers."
+          },
+          "orderSplit" : {
+            "type" : "boolean",
+            "description" : "true for multiple orders"
+          },
+          "processedPartially" : {
+            "type" : "boolean",
+            "description" : "true for partial order succesfully placed"
+          },
+          "purchaseOrderTotal" : {
+            "type" : "number",
+            "format" : "decimal",
+            "description" : "Total of all the orders including taxes and fees."
+          },
+          "shipToInfo" : {
+            "type" : "object",
+            "description" : "The shipping information provided by the reseller.",
+            "properties" : {
+              "addressId" : {
+                "type" : "string",
+                "description" : "The ID references the resellers address in Ingram Micro's system for shipping. Provided to resellers during the onboarding process."
+              },
+              "contact" : {
+                "type" : "string",
+                "description" : "The company contact provided by the reseller."
+              },
+              "companyName" : {
+                "type" : "string",
+                "description" : "The name of the company the order will be shipped to."
+              },
+              "name1" : {
+                "type" : "string",
+                "description" : "name1"
+              },
+              "name2" : {
+                "type" : "string",
+                "description" : "name2"
+              },
+              "addressLine1" : {
+                "type" : "string",
+                "description" : "The street address and building or house number the order will be shipped to."
+              },
+              "addressLine2" : {
+                "type" : "string",
+                "description" : "The apartment number the order will be shipped to."
+              },
+              "addressLine3" : {
+                "type" : "string",
+                "description" : "Line 3 of the address the order will be shipped to."
+              },
+              "addressLine4" : {
+                "type" : "string",
+                "description" : "Street address4"
+              },
+              "city" : {
+                "type" : "string",
+                "description" : "The city the order will be shipped to."
+              },
+              "state" : {
+                "type" : "string",
+                "description" : "The state the order will be shipped to."
+              },
+              "postalCode" : {
+                "type" : "string",
+                "description" : "The zip or postal code the order will be shipped to."
+              },
+              "countryCode" : {
+                "type" : "string",
+                "description" : "The two-character ISO country code the order will be shipped to."
+              },
+              "phoneNumber" : {
+                "type" : "string",
+                "description" : "The company contact phone number."
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "The company contact email address."
+              }
+            }
+          },
+          "endUserInfo" : {
+            "type" : "object",
+            "description" : "The contact information for the end user/customer provided by the reseller. Used to determine pricing and discounts.",
+            "properties" : {
+              "endUserId" : {
+                "type" : "string",
+                "description" : "The unique ID provided by the reseller for the end user/customer."
+              },
+              "contact" : {
+                "type" : "string",
+                "description" : "The contact name for the end user/customer."
+              },
+              "companyName" : {
+                "type" : "string",
+                "description" : "The company name for the end user/customer."
+              },
+              "name1" : {
+                "type" : "string",
+                "description" : "name1"
+              },
+              "name2" : {
+                "type" : "string",
+                "description" : "name2"
+              },
+              "addressLine1" : {
+                "type" : "string",
+                "description" : "The street adress and building or house number for the end user/customer."
+              },
+              "addressLine2" : {
+                "type" : "string",
+                "description" : "The apartment number for the end user/customer."
+              },
+              "addressLine3" : {
+                "type" : "string",
+                "description" : "Line 3 of the address for the end user/customer."
+              },
+              "addressLine4" : {
+                "type" : "string",
+                "description" : "Street address4"
+              },
+              "city" : {
+                "type" : "string",
+                "description" : "The end user/customer's city."
+              },
+              "state" : {
+                "type" : "string",
+                "description" : "The end user/customer's state."
+              },
+              "postalCode" : {
+                "type" : "string",
+                "description" : "The end user/customer's zip or postal code."
+              },
+              "countryCode" : {
+                "type" : "string",
+                "description" : "The end user/customer's two-character ISO country code."
+              },
+              "phoneNumber" : {
+                "type" : "string",
+                "description" : "The end user/customer's phone number."
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "The end user/customer's email."
+              }
+            }
+          },
+          "orders" : {
+            "type" : "array",
+            "description" : "Order-level details.",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "numberOfLinesWithSuccess" : {
+                  "type" : "integer",
+                  "description" : "The number of lines in the order that were successful."
+                },
+                "numberOfLinesWithError" : {
+                  "type" : "integer",
+                  "description" : "The number of lines in the order that have errors."
+                },
+                "numberOfLinesWithWarning" : {
+                  "type" : "integer",
+                  "description" : "The number of lines in the order that have a warning."
+                },
+                "ingramOrderNumber" : {
+                  "type" : "string",
+                  "description" : "The Ingram Micro order number."
+                },
+                "ingramOrderDate" : {
+                  "type" : "string",
+                  "description" : "The date in UTC format that the order was created in Ingram Micro's system."
+                },
+                "notes" : {
+                  "type" : "string",
+                  "description" : "Order-level notes."
+                },
+                "orderType" : {
+                  "type" : "string",
+                  "description" : "The order typer. One of: S=Stocked PO D=Direct Ship PO"
+                },
+                "orderTotal" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "The total price for the order."
+                },
+                "freightCharges" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "The total freight charges for the order."
+                },
+                "totalTax" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "The total tax for the order."
+                },
+                "currencyCode" : {
+                  "type" : "string",
+                  "description" : "The country-specific three character ISO 4217 currency code used for the order."
+                },
+                "lines" : {
+                  "type" : "array",
+                  "description" : "The line-level details for the order.",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "subOrderNumber" : {
+                        "type" : "string",
+                        "description" : "The sub order number. The two-digit prefix is the warehouse code of the warehouse nearest the reseller. The middle number is the order number. The two-digit suffix is the sub order number."
+                      },
+                      "ingramLineNumber" : {
+                        "type" : "string",
+                        "description" : "The Ingram Micro line number for the product."
+                      },
+                      "customerLineNumber" : {
+                        "type" : "string",
+                        "description" : "The reseller's line number for reference in their system."
+                      },
+                      "lineStatus" : {
+                        "type" : "string",
+                        "description" : "The status for the line item in the order. One of: Backordered, Open"
+                      },
+                      "ingramPartNumber" : {
+                        "type" : "string",
+                        "description" : "The Ingram Micro part number for the line item."
+                      },
+                      "vendorPartNumber" : {
+                        "type" : "string",
+                        "description" : "The vendor part number for the line item."
+                      },
+                      "unitPrice" : {
+                        "type" : "number",
+                        "format" : "decimal",
+                        "description" : "The unit price for the line item."
+                      },
+                      "extendedUnitPrice" : {
+                        "type" : "number",
+                        "format" : "decimal",
+                        "description" : "The extended list price (unit price X quantity) for the line item."
+                      },
+                      "quantityOrdered" : {
+                        "type" : "integer",
+                        "description" : "The quantity of the line item ordered."
+                      },
+                      "quantityConfirmed" : {
+                        "type" : "integer",
+                        "description" : "The quantity of the line item that has been confirmed."
+                      },
+                      "quantityBackOrdered" : {
+                        "type" : "integer",
+                        "description" : "The quantity of the line item that is backordered."
+                      },
+                      "specialBidNumber" : {
+                        "type" : "string",
+                        "description" : "The bid number for the line item provided to the reseller by the vendor for special pricing and discounts. Line-level bid numbers take precedence over header-level bid numbers."
+                      },
+                      "notes" : {
+                        "type" : "string",
+                        "description" : "Line-level notes."
+                      },
+                      "shipmentDetails" : {
+                        "type" : "array",
+                        "description" : "The shipment details for the line item.",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "carrierCode" : {
+                              "type" : "string",
+                              "description" : "The code for the shipping carrier for the line item."
+                            },
+                            "carrierName" : {
+                              "type" : "string",
+                              "description" : "The name of the shipping carrier for the line item."
+                            },
+                            "shipFromWarehouseId" : {
+                              "type" : "string",
+                              "description" : "The ID of the warehouse the line item will ship from."
+                            },
+                            "shipFromLocation" : {
+                              "type" : "string",
+                              "description" : "Location from which order is shipped."
+                            },
+                            "freightAccountNumber" : {
+                              "type" : "string",
+                              "description" : "The reseller's shipping account number with carrier. Used to bill the shipping carrier directly from the reseller's account with the carrier."
+                            },
+                            "signatureRequired" : {
+                              "type" : "string",
+                              "description" : "Specifies whether a signature is required for delivery. Default is False."
+                            },
+                            "shippingInstructions" : {
+                              "type" : "string",
+                              "description" : "The shipping instructions for the order."
+                            }
+                          }
+                        }
+                      },
+                      "additionalAttributes" : {
+                        "type" : "array",
+                        "description" : "SAP requested and country-specific line level details.",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "attributeName" : {
+                              "type" : "string"
+                            },
+                            "attributeValue" : {
+                              "type" : "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "miscellaneousCharges" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "subOrderNumber" : {
+                        "type" : "string",
+                        "description" : "The sub order number. The two-digit prefix is the warehouse code of the warehouse nearest the reseller. The middle number is the order number. The two-digit suffix is the sub order number."
+                      },
+                      "chargeLineReference" : {
+                        "type" : "string",
+                        "description" : "Impulse line number for the miscellaneous charge."
+                      },
+                      "chargeDescription" : {
+                        "type" : "string",
+                        "description" : "Description of the miscellaneous charges for the order."
+                      },
+                      "chargeAmount" : {
+                        "type" : "number",
+                        "format" : "decimal",
+                        "description" : "The total amount of miscellaneous charges for the order."
+                      }
+                    }
+                  }
+                },
+                "links" : {
+                  "type" : "array",
+                  "description" : "Link to Order Details for the order(s).",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "description" : "Provides the details of the orders."
+                      },
+                      "href" : {
+                        "type" : "string",
+                        "description" : "The URL endpoint for accessing the relevant data."
+                      },
+                      "type" : {
+                        "type" : "string",
+                        "description" : "The type of call that can be made to the href link (GET, POST, Etc.)."
+                      }
+                    }
+                  }
+                },
+                "rejectedLineItems" : {
+                  "type" : "array",
+                  "description" : "A list of rejected line items.",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "customerLinenumber" : {
+                        "type" : "string",
+                        "description" : "The reseller's line item number of the rejected item for their reference. Number"
+                      },
+                      "ingramPartNumber" : {
+                        "type" : "string",
+                        "description" : "The Ingram Micro part number for the rejected line item."
+                      },
+                      "vendorPartNumber" : {
+                        "type" : "string",
+                        "description" : "The vendor part number for the rejected line item."
+                      },
+                      "quantityOrdered" : {
+                        "type" : "integer",
+                        "description" : "The quantity ordered of the rejected line item."
+                      },
+                      "rejectCode" : {
+                        "type" : "string",
+                        "description" : "The rejection code for the rejected line item. Ex: 'EN' "
+                      },
+                      "rejectReason" : {
+                        "type" : "string",
+                        "description" : "The rejection reason for the rejected line item. Ex: 'SKU-NOTFOUND    DF41281' "
+                      }
+                    }
+                  }
+                },
+                "additionalAttributes" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "attributeName" : {
+                        "type" : "string",
+                        "description" : " allowPartialOrder: Allow orders with failed lines. (SAP) Depends on backorder settings.\n\n\ndpasRating: DX rating by Department of Defense is the highest rating by the highest offices and meant to be top priority. DO any other gov offices at the federal level to priotize.\n\n\ndpasProgramId: Identifies the actual agency that signed off on the DPAS priority. \n\nstorageLocation: Determine the location of the product stock in SAP for Marketplaces.\n\nsoldTo: To be used in cases when Sold-To is different than Customer ID.\n\nZ101: Used for end customer details such as name, address, phone, etc. This information flows to SAP and is used by warehouse.\n\neuDepId: DEP ID would be the 'End User DEP/ABM Organization ID' up to 32 characters and is assigned by Apple.\n\ndepOrderNbr: depordernbr is 'End User PO to reseller' Can appear in message lines or dedicated end user po#.\n "
+                      },
+                      "attributeValue" : {
+                        "type" : "string",
+                        "description" : "Attribute value"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrderModifyRequest" : {
+        "type" : "object",
+        "properties" : {
+          "notes" : {
+            "type" : "string",
+            "description" : "Shipment-level notes.",
+            "maxLength" : 132
+          },
+          "shipToInfo" : {
+            "type" : "object",
+            "description" : "The shipping information provided by the reseller.",
+            "properties" : {
+              "addressId" : {
+                "type" : "string",
+                "maxLength" : 10,
+                "description" : "Suffix used to identify billing address. Created during onboarding. Resellers are provided with one or more address IDs depending on how many bill to addresses they need for various flooring companies they are using for credit."
+              },
+              "contact" : {
+                "type" : "string",
+                "maxLength" : 40,
+                "description" : "The company contact provided by the reseller."
+              },
+              "companyName" : {
+                "type" : "string",
+                "maxLength" : 40,
+                "description" : "The name of the company the order will be shipped to."
+              },
+              "name1" : {
+                "type" : "string",
+                "maxLength" : 40,
+                "description" : "name1."
+              },
+              "name2" : {
+                "type" : "string",
+                "maxLength" : 40,
+                "description" : "name2."
+              },
+              "addressLine1" : {
+                "type" : "string",
+                "maxLength" : 60,
+                "description" : "The street address and building or house number the order will be shipped to."
+              },
+              "addressLine2" : {
+                "type" : "string",
+                "maxLength" : 40,
+                "description" : "The apartment number the order will be shipped to."
+              },
+              "addressLine3" : {
+                "type" : "string",
+                "maxLength" : 40,
+                "description" : "Line 3 of the address the order will be shipped to."
+              },
+              "city" : {
+                "type" : "string",
+                "maxLength" : 25,
+                "description" : "The city the order will be shipped to."
+              },
+              "state" : {
+                "type" : "string",
+                "maxLength" : 3,
+                "description" : "The state the order will be shipped to."
+              },
+              "postalCode" : {
+                "type" : "string",
+                "maxLength" : 10,
+                "description" : "The zip or postal code the order will be shipped to."
+              },
+              "countryCode" : {
+                "type" : "string",
+                "maxLength" : 3,
+                "description" : "The two-character ISO country code the order will be shipped to."
+              },
+              "phoneNumber" : {
+                "type" : "string",
+                "maxLength" : 30,
+                "description" : "The company contact phone number."
+              },
+              "email" : {
+                "type" : "string",
+                "maxLength" : 241,
+                "description" : "The company contact email address."
+              }
+            }
+          },
+          "lines" : {
+            "type" : "array",
+            "description" : "The order line items.",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "ingramPartNumber" : {
+                  "type" : "string",
+                  "maxLength" : 18,
+                  "description" : "The unique IngramMicro part number."
+                },
+                "ingramLineNumber" : {
+                  "type" : "string",
+                  "maxLength" : 6,
+                  "description" : "The IngramMicro line number."
+                },
+                "customerLineNumber" : {
+                  "type" : "string",
+                  "maxLength" : 6,
+                  "description" : "The reseller's line number for reference in their system."
+                },
+                "addUpdateDeleteLine" : {
+                  "type" : "string",
+                  "description" : "The line number that was added, updated, or deleted.",
+                  "enum" : [ "UPDATE", "DELETE", "ADD" ]
+                },
+                "quantity" : {
+                  "type" : "integer",
+                  "description" : "The quantity of the line item."
+                },
+                "notes" : {
+                  "type" : "string",
+                  "maxLength" : 132,
+                  "description" : "The line-level notes."
+                }
+              }
+            }
+          },
+          "additionalAttributes" : {
+            "type" : "array",
+            "description" : "Header-level additional attributes.",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "attributeName" : {
+                  "type" : "string",
+                  "description" : "Example values are 'entryMethod', 'enableCommentsAsLines', 'regionCode'"
+                },
+                "attributeValue" : {
+                  "type" : "string",
+                  "description" : "Attribute Value"
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrderModifyResponse" : {
+        "type" : "object",
+        "properties" : {
+          "ingramOrderNumber" : {
+            "type" : "string",
+            "description" : "The IngramMicro order number."
+          },
+          "changeDescription" : {
+            "type" : "string",
+            "description" : "The description of the change."
+          },
+          "orderModifiedDate" : {
+            "type" : "string",
+            "description" : "The date the order was modified."
+          },
+          "customerOrderNumber" : {
+            "type" : "string",
+            "description" : "The reseller's order number for reference in their system."
+          },
+          "endCustomerOrderNumber" : {
+            "type" : "string",
+            "description" : "The end user/customer's order number for reference in their system."
+          },
+          "orderTotal" : {
+            "type" : "number",
+            "format" : "decimal",
+            "description" : "The total for the order."
+          },
+          "notes" : {
+            "type" : "string",
+            "description" : "Order-level notes."
+          },
+          "orderSubTotal" : {
+            "type" : "number",
+            "format" : "decimal",
+            "description" : "The sub total for the order."
+          },
+          "freightCharges" : {
+            "type" : "number",
+            "format" : "decimal",
+            "description" : "The freight charges for the order."
+          },
+          "totalTax" : {
+            "type" : "number",
+            "format" : "decimal",
+            "description" : "The total tax for the order."
+          },
+          "orderStatus" : {
+            "type" : "string",
+            "description" : "The status of the order. One of the following. Backordered, In Progress, Shipped, Delivered, Canceled, On Hold"
+          },
+          "billToAddressId" : {
+            "type" : "string",
+            "description" : "Suffix used to identify billing address. Created during onboarding. Resellers are provided with one or more address IDs depending on how many bill to addresses they need for various flooring companies they are using for credit."
+          },
+          "shipToInfo" : {
+            "type" : "object",
+            "description" : "The shipping information for the order provided by the reseller.",
+            "properties" : {
+              "addressId" : {
+                "type" : "string",
+                "description" : "Suffix used to identify shipping address. Created during onboarding. Resellers are provided with one or more address IDs depending on how many bill to addresses they need for various flooring companies they are using for credit."
+              },
+              "contact" : {
+                "type" : "string",
+                "description" : "The company contact provided by the reseller."
+              },
+              "companyName" : {
+                "type" : "string",
+                "description" : "The name of the company the order will be shipped to."
+              },
+              "addressLine1" : {
+                "type" : "string",
+                "description" : "The street address and building or house number the order will be shipped to."
+              },
+              "addressLine2" : {
+                "type" : "string",
+                "description" : "The apartment number the order will be shipped to."
+              },
+              "addressLine3" : {
+                "type" : "string",
+                "description" : "Line 3 of the address the order will be shipped to."
+              },
+              "city" : {
+                "type" : "string",
+                "description" : "The city the order will be shipped to."
+              },
+              "state" : {
+                "type" : "string",
+                "description" : "The state the order will be shipped to."
+              },
+              "postalCode" : {
+                "type" : "string",
+                "description" : "The zip or postal code the order will be shipped to."
+              },
+              "countryCode" : {
+                "type" : "string",
+                "description" : "The two-character ISO country code the order will be shipped to."
+              },
+              "phoneNumber" : {
+                "type" : "string",
+                "description" : "The company contact phone number."
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "The company contact email address."
+              }
+            }
+          },
+          "lines" : {
+            "type" : "array",
+            "description" : "The line-level details for the order.",
+            "items" : {
+              "properties" : {
+                "subOrderNumber" : {
+                  "type" : "string",
+                  "description" : "The sub order number. The two-digit prefix is the warehouse code of the warehouse nearest the reseller. The middle number is the order number. The two-digit suffix is the sub order number."
+                },
+                "ingramLineNumber" : {
+                  "type" : "string",
+                  "description" : "The IngramMicro line number."
+                },
+                "customerLineNumber" : {
+                  "type" : "string",
+                  "description" : "The reseller's line number for reference in their system."
+                },
+                "ingramPartNumber" : {
+                  "type" : "string",
+                  "description" : "The unique IngramMicro part number for the line item."
+                },
+                "vendorPartNumber" : {
+                  "type" : "string",
+                  "description" : "The vendor's part number for the line item."
+                },
+                "quantityOrdered" : {
+                  "type" : "integer",
+                  "description" : "The quantity ordered of the line item."
+                },
+                "quantityConfirmed" : {
+                  "type" : "integer",
+                  "description" : "The quantity confirmed of the line item."
+                },
+                "quantityBackOrdered" : {
+                  "type" : "integer",
+                  "description" : "The quantity backordered of the line item."
+                },
+                "shipmentDetails" : {
+                  "type" : "object",
+                  "description" : "Shipping details for the order provided by the reseller.",
+                  "properties" : {
+                    "carrierCode" : {
+                      "type" : "string",
+                      "description" : "The carrier code for the shipment containing the line item."
+                    },
+                    "carrierName" : {
+                      "type" : "string",
+                      "description" : "The name of the carrier of the shipment containing the line item."
+                    },
+                    "freightAccountNumber" : {
+                      "type" : "string",
+                      "description" : "The reseller's shipping account number with carrier. Used to bill the shipping carrier directly from the reseller's account with the carrier."
+                    }
+                  }
+                },
+                "additionalAttributes" : {
+                  "type" : "array",
+                  "description" : "SAP requested and country-specific line level details.",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "attributeName" : {
+                        "type" : "string",
+                        "description" : "Attribute Name."
+                      },
+                      "attributeValue" : {
+                        "type" : "string",
+                        "description" : "Attribute Value."
+                      }
+                    }
+                  }
+                },
+                "notes" : {
+                  "type" : "string",
+                  "description" : "Line-level notes for the order."
+                }
+              }
+            }
+          },
+          "rejectedLineItems" : {
+            "type" : "array",
+            "description" : "Details for failed lines in the order.",
+            "items" : {
+              "properties" : {
+                "ingramLineNumber" : {
+                  "type" : "string",
+                  "description" : "The IngramMicro line number for the failed line item."
+                },
+                "customerLineNumber" : {
+                  "type" : "string",
+                  "description" : "The reseller's line number of the failed line item for reference in their system."
+                },
+                "ingramPartNumber" : {
+                  "type" : "string",
+                  "description" : "The IngramMicro part number for the failed line item."
+                },
+                "vendorPartNumber" : {
+                  "type" : "string",
+                  "description" : "The vendor's part number for the failed line item."
+                },
+                "quantityOrdered" : {
+                  "type" : "integer",
+                  "description" : "The quantity ordered of the failed line item."
+                },
+                "rejectCode" : {
+                  "type" : "string",
+                  "description" : "The rejection code for the failed line item."
+                },
+                "rejectReason" : {
+                  "type" : "string",
+                  "description" : "The rejection reason for the failed line item."
+                }
+              }
+            }
+          },
+          "additionalAttributes" : {
+            "type" : "array",
+            "description" : "Header-level additional attributes.",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "attributeName" : {
+                  "type" : "string",
+                  "description" : "Attribute Name."
+                },
+                "attributeValue" : {
+                  "type" : "string",
+                  "description" : "Attribute Value."
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrderDetailResponse" : {
+        "type" : "object",
+        "x-tags" : [ "Orders" ],
+        "properties" : {
+          "ingramOrderNumber" : {
+            "type" : "string",
+            "description" : "The IngramMicro sales order number."
+          },
+          "ingramOrderDate" : {
+            "type" : "string",
+            "description" : "The date and time in UTC format that the order was created."
+          },
+          "orderType" : {
+            "type" : "string",
+            "description" : "The order type. One of B = Branch Transfer, C = COD, D = Direct Ship, F = Future Order, P = Special Order, M = Memo, Q = Quote, S = Sales Order."
+          },
+          "customerOrderNumber" : {
+            "type" : "string",
+            "description" : "The reseller's order number for reference in their system."
+          },
+          "endCustomerOrderNumber" : {
+            "type" : "string",
+            "description" : "The end user/customer's order number for reference in their system."
+          },
+          "vendorSalesOrderNumber" : {
+            "type" : "string",
+            "description" : "The vendor's order number for reference in their system."
+          },
+          "orderStatus" : {
+            "type" : "string",
+            "description" : "The header-level status of the order. One of- Shipped, Canceled, Backordered, Processing, On Hold, Delivered."
+          },
+          "orderTotal" : {
+            "type" : "number",
+            "format" : "decimal",
+            "description" : "The total cost for the order, includes subtotal, freight charges, and tax."
+          },
+          "orderSubTotal" : {
+            "type" : "number",
+            "format" : "decimal",
+            "description" : "The sub total cost for the order, not including tax and freight."
+          },
+          "freightCharges" : {
+            "type" : "number",
+            "format" : "decimal",
+            "description" : "The freight charges for the order."
+          },
+          "currencyCode" : {
+            "type" : "string",
+            "description" : "The country-specific three digit ISO 4217 currency code for the order."
+          },
+          "totalWeight" : {
+            "type" : "number",
+            "format" : "decimal",
+            "description" : "The total weight of the order. Pounds in North America, KG in all other countries."
+          },
+          "totalTax" : {
+            "type" : "number",
+            "format" : "decimal",
+            "description" : "The total tax for the order."
+          },
+          "paymentTerms" : {
+            "type" : "string",
+            "description" : "The payment terms of the order. (Ex- Net 30 days)."
+          },
+          "notes" : {
+            "type" : "string",
+            "description" : "The header-level notes for the order."
+          },
+          "billToInfo" : {
+            "type" : "object",
+            "description" : "The billing information provided by the reseller.",
+            "properties" : {
+              "contact" : {
+                "type" : "string",
+                "description" : "The company contact provided by the reseller."
+              },
+              "companyName" : {
+                "type" : "string",
+                "description" : "The name of the company the order will be billed to."
+              },
+              "name1" : {
+                "type" : "string",
+                "description" : "First name."
+              },
+              "name2" : {
+                "type" : "string",
+                "description" : "Last name."
+              },
+              "addressLine1" : {
+                "type" : "string",
+                "description" : "The street address and building or house number the order will be billed to."
+              },
+              "addressLine2" : {
+                "type" : "string",
+                "description" : "The apartment number the order will be billed to."
+              },
+              "addressLine3" : {
+                "type" : "string",
+                "description" : "Address line 3."
+              },
+              "city" : {
+                "type" : "string",
+                "description" : "The city the order will be billed to."
+              },
+              "state" : {
+                "type" : "string",
+                "description" : "The state the order will be billed to."
+              },
+              "postalCode" : {
+                "type" : "string",
+                "description" : "The zip or postal code the order will be billed to."
+              },
+              "countryCode" : {
+                "type" : "string",
+                "description" : "The two-character ISO country code the order will be billed to."
+              },
+              "phoneNumber" : {
+                "type" : "string",
+                "description" : "The company contact phone number."
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "The company contact email address."
+              }
+            }
+          },
+          "shipToInfo" : {
+            "type" : "object",
+            "description" : "The shipping information provided by the reseller for order delivery.",
+            "properties" : {
+              "contact" : {
+                "type" : "string",
+                "description" : "The company contact provided by the reseller."
+              },
+              "companyName" : {
+                "type" : "string",
+                "description" : "The name of the company the order will be shipped to."
+              },
+              "name1" : {
+                "type" : "string",
+                "description" : "First name."
+              },
+              "name2" : {
+                "type" : "string",
+                "description" : "Last name."
+              },
+              "addressLine1" : {
+                "type" : "string",
+                "description" : "The street address the order will be shipped to."
+              },
+              "addressLine2" : {
+                "type" : "string",
+                "description" : "The building or apartment number the order will be shipped to."
+              },
+              "addressLine3" : {
+                "type" : "string",
+                "description" : "Line 3 of the address the order will be shipped to."
+              },
+              "city" : {
+                "type" : "string",
+                "description" : "The city the order will be shipped to."
+              },
+              "state" : {
+                "type" : "string",
+                "description" : "The state the order will be shipped to."
+              },
+              "postalCode" : {
+                "type" : "string",
+                "description" : "The zip or postal code the order will be shipped to."
+              },
+              "countryCode" : {
+                "type" : "string",
+                "description" : "The two-character ISO country code the order will be shipped to."
+              },
+              "phoneNumber" : {
+                "type" : "string",
+                "description" : "The company contact phone number."
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "The company contact email address."
+              }
+            }
+          },
+          "endUserInfo" : {
+            "type" : "object",
+            "description" : "The contact information for the end user/customer provided by the reseller. Used to determine pricing and discounts.",
+            "properties" : {
+              "contact" : {
+                "type" : "string",
+                "description" : "The contact name for the end user/customer."
+              },
+              "companyName" : {
+                "type" : "string",
+                "description" : "The company name for the end user/customer."
+              },
+              "name1" : {
+                "type" : "string",
+                "description" : "First name."
+              },
+              "name2" : {
+                "type" : "string",
+                "description" : "Last name."
+              },
+              "addressLine1" : {
+                "type" : "string",
+                "description" : "The street adress and building or house number for the end user/customer."
+              },
+              "addressLine2" : {
+                "type" : "string",
+                "description" : "The apartment number for the end user/customer."
+              },
+              "addressLine3" : {
+                "type" : "string",
+                "description" : "Line 3 of the address for the end user/customer."
+              },
+              "city" : {
+                "type" : "string",
+                "description" : "The end user/customer's city."
+              },
+              "state" : {
+                "type" : "string",
+                "description" : "The end user/customer's state."
+              },
+              "postalCode" : {
+                "type" : "string",
+                "description" : "The end user/customer's zip or postal code."
+              },
+              "countryCode" : {
+                "type" : "string",
+                "description" : "The end user/customer's two character ISO country code."
+              },
+              "phoneNumber" : {
+                "type" : "string",
+                "description" : "The end user/customer's phone number."
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "The end user/customer's email."
+              }
+            }
+          },
+          "lines" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "subOrderNumber" : {
+                  "type" : "string",
+                  "description" : "The sub order number. The two-digit prefix is the warehouse code of the warehouse nearest the reseller. The middle number is the order number. The two-digit suffix is the sub order number."
+                },
+                "ingramOrderLineNumber" : {
+                  "type" : "string",
+                  "description" : "Unique Ingram Micro line number. Starts with 001."
+                },
+                "vendorSalesOrderLineNumber" : {
+                  "type" : "string",
+                  "description" : "The vendor's sales order line number."
+                },
+                "customerLinenumber" : {
+                  "type" : "string",
+                  "description" : "The reseller's line item number for reference in their system."
+                },
+                "lineStatus" : {
+                  "type" : "string",
+                  "description" : "The status for the line item in the order. One of- Backordered, In Progress, Shipped, Delivered, Canceled, On Hold"
+                },
+                "ingramPartNumber" : {
+                  "type" : "string",
+                  "description" : "Unique IngramMicro part number."
+                },
+                "vendorPartNumber" : {
+                  "type" : "string",
+                  "description" : "The vendor's part number for the line item."
+                },
+                "vendorName" : {
+                  "type" : "string",
+                  "description" : "The vendor's name for the part in their system."
+                },
+                "partDescription" : {
+                  "type" : "string",
+                  "description" : "The vendor's description of the part in their system."
+                },
+                "unitWeight" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "The unit weight of the line item."
+                },
+                "weightUom" : {
+                  "type" : "string",
+                  "description" : "The unit of measure for the line item."
+                },
+                "unitPrice" : {
+                  "type" : "integer",
+                  "description" : "The unit price of the line item."
+                },
+                "upcCode" : {
+                  "type" : "string",
+                  "description" : "The UPC code of a product."
+                },
+                "extendedPrice" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "Unit price X quantity for the line item."
+                },
+                "taxAmount" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "The tax amount for the line item."
+                },
+                "currencyCode" : {
+                  "type" : "string",
+                  "description" : "The country-specific three character ISO 4217 currency code for the line item."
+                },
+                "quantityOrdered" : {
+                  "type" : "integer",
+                  "description" : "The quantity ordered of the line item."
+                },
+                "quantityConfirmed" : {
+                  "type" : "integer",
+                  "description" : "The quantity confirmed for the line item."
+                },
+                "quantityBackOrdered" : {
+                  "type" : "integer",
+                  "description" : "The quantity backordered for the line item."
+                },
+                "specialBidNumber" : {
+                  "type" : "string",
+                  "description" : "The line-level bid number provided to the reseller by the vendor for special pricing and discounts. Used to track the bid number in the case of split orders or where different line items have different bid numbers. Line-level bid numbers take precedence over header-level bid numbers."
+                },
+                "requestedDeliveryDate" : {
+                  "type" : "string",
+                  "format" : "date",
+                  "description" : "Reseller-requested delivery date. Delivery date is not guaranteed."
+                },
+                "promisedDeliveryDate" : {
+                  "type" : "string",
+                  "format" : "date",
+                  "description" : "The delivery date promised by IngramMicro."
+                },
+                "lineNotes" : {
+                  "type" : "string",
+                  "description" : "Line-level notes for the order."
+                },
+                "shipmentDetails" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "description" : "Shipping details for the line item.",
+                    "properties" : {
+                      "quantity" : {
+                        "type" : "integer",
+                        "description" : "The quantity shipped of the line item."
+                      },
+                      "estimatedShipDate" : {
+                        "type" : "string",
+                        "format" : "date",
+                        "description" : "The estimated ship date for the line item."
+                      },
+                      "shippedDate" : {
+                        "type" : "string",
+                        "format" : "date",
+                        "description" : "The date the line item was shipped."
+                      },
+                      "estimatedDeliveryDate" : {
+                        "type" : "string",
+                        "format" : "date",
+                        "description" : "The date the line item is expected to be delivered."
+                      },
+                      "deliveredDate" : {
+                        "type" : "string",
+                        "format" : "date",
+                        "description" : "The actual date of delivery of the line item."
+                      },
+                      "shipFromWarehouseId" : {
+                        "type" : "string",
+                        "description" : "The ID of the warehouse the product will ship from."
+                      },
+                      "shipFromLocation" : {
+                        "type" : "string",
+                        "description" : "The city and state the line item ships from."
+                      },
+                      "invoiceNumber" : {
+                        "type" : "string",
+                        "description" : "The Ingram Micro invoice number for the line item."
+                      },
+                      "invoiceDate" : {
+                        "type" : "string",
+                        "format" : "date",
+                        "description" : "The date the IngramMicro invoice was created for the line item."
+                      },
+                      "carrierDetails" : {
+                        "type" : "object",
+                        "description" : "The shipment carrier details for the line item.",
+                        "properties" : {
+                          "carrierCode" : {
+                            "type" : "string",
+                            "description" : "The carrier code for the shipment containing the line item."
+                          },
+                          "carrierName" : {
+                            "type" : "string",
+                            "description" : "The name of the carrier of the shipment containing the line item."
+                          },
+                          "trackingDetails" : {
+                            "type" : "array",
+                            "items" : {
+                              "type" : "object",
+                              "description" : "The tracking details for the shipment containing the line item.",
+                              "properties" : {
+                                "trackingNumber" : {
+                                  "type" : "string",
+                                  "description" : "The tracking number for the shipment containing the line item."
+                                },
+                                "trackingUrl" : {
+                                  "type" : "string",
+                                  "description" : "The tracking URL for the shipment containing the line item."
+                                },
+                                "packageWeight" : {
+                                  "type" : "string",
+                                  "description" : "The weight of the package for the line item."
+                                },
+                                "cartonNumber" : {
+                                  "type" : "string",
+                                  "description" : "The shipment carton number that contains the line item."
+                                },
+                                "quantityInBox" : {
+                                  "type" : "string",
+                                  "description" : "The quantity of line items in the box."
+                                },
+                                "SerialNumbers" : {
+                                  "type" : "array",
+                                  "items" : {
+                                    "type" : "object",
+                                    "description" : "A list of serial numbers of the line items contained in the shipment.",
+                                    "properties" : {
+                                      "serialNumber" : {
+                                        "type" : "string",
+                                        "description" : "The serial number for the line item."
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "additionalAttributes" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "attributeName" : {
+                        "type" : "string",
+                        "description" : "Line level custom field names."
+                      },
+                      "attributeValue" : {
+                        "type" : "string",
+                        "description" : "Value of the custom fields."
+                      }
+                    }
+                  }
+                },
+                "links" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "description" : "Link to Order Details for the line item.",
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "description" : "Provides the details of the line item."
+                      },
+                      "href" : {
+                        "type" : "string",
+                        "description" : "The API endpoint for accessing the relevant data."
+                      },
+                      "type" : {
+                        "type" : "string",
+                        "description" : "The type of call that can be made to the href link(GET,POST etc)."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "miscellaneousCharges" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "subOrderNumber" : {
+                  "type" : "string",
+                  "description" : "The sub order number. The two-digit prefix is the warehouse code of the warehouse nearest the reseller. The middle number is the order number. The two-digit suffix is the sub order number."
+                },
+                "chargeLineReference" : {
+                  "type" : "string",
+                  "description" : "Impulse line number for the miscellaneous charge."
+                },
+                "chargeDescription" : {
+                  "type" : "string",
+                  "description" : "Description of the miscellaneous charges."
+                },
+                "chargeAmount" : {
+                  "type" : "number",
+                  "format" : "double",
+                  "description" : "The amount of miscellaneous charges."
+                }
+              }
+            }
+          },
+          "additionalAttributes" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "attributeName" : {
+                  "type" : "string",
+                  "description" : "Line level custom field names."
+                },
+                "attributeValue" : {
+                  "type" : "string",
+                  "description" : "Value of the custom fields."
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrderSearch_Response" : {
+        "type" : "object",
+        "properties" : {
+          "recordsFound" : {
+            "type" : "integer",
+            "description" : "No of recourds found for the search."
+          },
+          "pageSize" : {
+            "type" : "integer",
+            "description" : "No of results per page.(default is 25)"
+          },
+          "pageNumber" : {
+            "type" : "integer",
+            "description" : "Current page number.(default is 1)"
+          },
+          "orders" : {
+            "type" : "array",
+            "description" : "The details for the order.",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "ingramOrderNumber" : {
+                  "type" : "string",
+                  "description" : "The Ingram Micro order number."
+                },
+                "ingramOrderDate" : {
+                  "type" : "string",
+                  "description" : "The date the order was created(UTC)."
+                },
+                "customerOrderNumber" : {
+                  "type" : "string",
+                  "description" : "The reseller's order number for reference in their system."
+                },
+                "vendorSalesOrderNumber" : {
+                  "type" : "string",
+                  "description" : "The vendor's order number.(only for D-Type Orders)"
+                },
+                "vendorName" : {
+                  "type" : "string",
+                  "description" : "The name of the vendor."
+                },
+                "endUserCompanyName" : {
+                  "type" : "string",
+                  "description" : "The company name of the end user/customer."
+                },
+                "orderTotal" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "The total of the order."
+                },
+                "orderStatus" : {
+                  "type" : "string",
+                  "description" : "The header-level status of the order.(OPEN/CLOSED/CANCELLED)"
+                },
+                "subOrders" : {
+                  "type" : "array",
+                  "description" : "Individual Ingram Micro order numbers associated with a single reseller PO.",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "subOrderNumber" : {
+                        "type" : "string",
+                        "description" : "The sub order number. The two-digit prefix is the warehouse code of the warehouse nearest to the reseller. The middle number is the order number. The two-digit suffix is the sub order number."
+                      },
+                      "subOrderTotal" : {
+                        "type" : "number",
+                        "format" : "decimal",
+                        "description" : "The total for the suborder."
+                      },
+                      "subOrderStatus" : {
+                        "type" : "string",
+                        "description" : "The status of the suborder. One of:- Shipped, Canceled, Backordered, Processing, On Hold, Delivered"
+                      },
+                      "links" : {
+                        "type" : "array",
+                        "description" : "Link to Order Details for the sub order(s).",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "topic" : {
+                              "type" : "string",
+                              "description" : "For orders or invoices. For orders the link provides details of the order. For invoices the link provides details of the invoice."
+                            },
+                            "href" : {
+                              "type" : "string",
+                              "description" : "The URL endpoint for accessing the relevant data."
+                            },
+                            "type" : {
+                              "type" : "string",
+                              "description" : "The type of call that can be made to the href link (GET, POST, Etc.)."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "links" : {
+                  "type" : "object",
+                  "description" : "Link to Order Details for the order(s).",
+                  "properties" : {
+                    "topic" : {
+                      "type" : "string",
+                      "description" : "Provides the details of the orders."
+                    },
+                    "href" : {
+                      "type" : "string",
+                      "description" : "The URL endpoint for accessing the relevant data."
+                    },
+                    "type" : {
+                      "type" : "string",
+                      "description" : "The type of call that can be made to the href link (GET, POST, Etc.)."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "nextPage" : {
+            "type" : "string",
+            "description" : "link/URL for accessing next page."
+          },
+          "previousPage" : {
+            "type" : "string",
+            "description" : "link/URL for accessing previous page."
+          }
+        }
+      },
+      "PriceAndAvailabilityRequest" : {
+        "type" : "object",
+        "properties" : {
+          "showAvailableDiscounts" : {
+            "type" : "boolean",
+            "description" : "Boolean value that will display Discount details in the response when true."
+          },
+          "showReserveInventoryDetails" : {
+            "type" : "boolean",
+            "description" : "Boolean value that will display reserve inventory details in the response when true."
+          },
+          "specialBidNumber" : {
+            "type" : "string",
+            "description" : "Pre-approved special pricing/bid number provided to the reseller by the vendor for special pricing and discounts. Used to track the bid number where different line items have different bid numbers."
+          },
+          "availabilityByWarehouse" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "availabilityByWarehouseId" : {
+                  "type" : "string",
+                  "description" : "Plant/warehouse Id of a particular location in order to get just the inventory of that location."
+                },
+                "availabilityForAllLocation" : {
+                  "type" : "boolean",
+                  "description" : "Pass boolean value as input, if true the response will contain warehouse location details, if false the response will not hold warehouse location details. By default value is true."
+                }
+              }
+            }
+          },
+          "products" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "ingramPartNumber" : {
+                  "type" : "string",
+                  "description" : "Ingram Micro unique part number for the product."
+                },
+                "vendorPartNumber" : {
+                  "type" : "string",
+                  "description" : "Vendor’s part number for the product."
+                },
+                "customerPartNumber" : {
+                  "type" : "string",
+                  "description" : "Reseller/end-user’s part number for the product."
+                },
+                "upc" : {
+                  "type" : "string",
+                  "description" : "The UPC code for the product. Consists of 12 numeric digits that are uniquely assigned to each trade item."
+                },
+                "quantityRequested" : {
+                  "type" : "string",
+                  "description" : "Number of quantity of the Product."
+                },
+                "additionalAttributes" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "attributeName" : {
+                        "type" : "string",
+                        "description" : "governmentprogramcode: Special Discount details will be provided based on the governmentprogramcode if available.\nshiptostatebrazil: Attribute Specific to Brazil.\nshipfrombranchnumber: If provided, displays only the availability of the specified branch number."
+                      },
+                      "attributeValue" : {
+                        "type" : "string",
+                        "description" : "key value pair -key value."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "additionalAttributes" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "attributeName" : {
+                  "type" : "string",
+                  "description" : "key value pair -key Name."
+                },
+                "attributeValue" : {
+                  "type" : "string",
+                  "description" : "key value pair -key value."
+                }
+              }
+            }
+          }
+        }
+      },
+      "PriceAndAvailabilityResponse" : {
+        "type" : "array",
+        "items" : {
+          "type" : "object",
+          "properties" : {
+            "productStatusCode" : {
+              "type" : "string",
+              "description" : "Codes signifying whether the sku is active or not."
+            },
+            "productStatusMessage" : {
+              "type" : "string",
+              "description" : "Message returned saying whether sku is active."
+            },
+            "ingramPartNumber" : {
+              "type" : "string",
+              "description" : "Ingram Micro unique part number for the product."
+            },
+            "vendorPartNumber" : {
+              "type" : "string",
+              "description" : "Vendor’s part number for the product."
+            },
+            "customerPartNumber" : {
+              "type" : "string",
+              "description" : "Reseller / end-user’s part number for the product."
+            },
+            "upc" : {
+              "type" : "string",
+              "description" : "The UPC code for the product. Consists of 12 numeric digits that are uniquely assigned to each trade item."
+            },
+            "partNumberType" : {
+              "type" : "string",
+              "description" : "**************"
+            },
+            "vendorName" : {
+              "type" : "string",
+              "description" : "Vendor name for the order."
+            },
+            "vendorNumber" : {
+              "type" : "string",
+              "description" : "Vendor number that identifies the product."
+            },
+            "description" : {
+              "type" : "string",
+              "description" : "The description given for the product."
+            },
+            "productClass" : {
+              "type" : "string",
+              "description" : "Indicates whether the product is directly shipped from the vendor’s warehouse or if the product ships from Ingram Micro’s warehouse. Class Codes are Ingram classifications on how skus are stocked\nA = Product that is stocked usually in all IM warehouses and replenished on a regular basis.\nB = Product that is stocked in limited IM warehouses and replenished on a regular basis\nC = Product that is stocked in fewer IM warehouses and replenished on a regular basis.\nD = Product that Ingram Micro has elected to discontinue.\nE = Product that will be phased out later, according to the vendor. You may not want to replenish this product, but instead sell down what is in stock.\nF = Product that we carry for a specific customer or supplier under a contractual agreement.\nN = New Sku. Classification before first receipt\nO = Discontinued product to be liquidated\nS= Order for Specialized Demand (Order to backorder)\nX= direct ship from Vendor\nV = product that vendor has elected to discontinue."
+            },
+            "UOM" : {
+              "type" : "string",
+              "description" : "The description given for the product."
+            },
+            "productStatus" : {
+              "type" : "string",
+              "description" : "Status that gives whether the product is Active."
+            },
+            "acceptBackOrder" : {
+              "type" : "boolean",
+              "description" : "Boolean that indicates if the product accepts backorder."
+            },
+            "productAuthorized" : {
+              "type" : "boolean",
+              "description" : "Boolean that indicates whether a product is authorized."
+            },
+            "returnableProduct" : {
+              "type" : "boolean",
+              "description" : "Boolean that indicates if the product can be returned."
+            },
+            "endUserInfoRequired" : {
+              "type" : "boolean",
+              "description" : "Boolean that indicates  if end user information is required."
+            },
+            "govtSpecialPriceAvailable" : {
+              "type" : "boolean",
+              "description" : "Boolean that indicates if special pricing is available for the product."
+            },
+            "govtProgramType" : {
+              "type" : "string",
+              "description" : "*******"
+            },
+            "govtEndUserType" : {
+              "type" : "string",
+              "description" : "*******"
+            },
+            "availability" : {
+              "type" : "object",
+              "properties" : {
+                "available" : {
+                  "type" : "boolean",
+                  "description" : "Boolean that indicates if the product ordered is available"
+                },
+                "totalAvailability" : {
+                  "type" : "integer",
+                  "description" : "The total amount of available products"
+                },
+                "availabilityByWarehouse" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "location" : {
+                        "type" : "string",
+                        "description" : "Indicates where (location) the product is available."
+                      },
+                      "warehouseId" : {
+                        "type" : "string",
+                        "description" : "Indicates where (Ingram Warehouse Id) the product is available."
+                      },
+                      "quantityAvailable" : {
+                        "type" : "integer",
+                        "description" : "The quantity of the product available in a given warehouse."
+                      },
+                      "quantityBackordered" : {
+                        "type" : "integer",
+                        "description" : "The quantity of a product backordered in a given warehouse."
+                      },
+                      "quantityBackorderedEta" : {
+                        "type" : "string",
+                        "description" : "The estimated time of arrival of a product that has been backordered in a given warehouse."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "reserveInventoryDetails" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "quantityReserved" : {
+                    "type" : "integer",
+                    "description" : "The quantity of the product reserved for the customer."
+                  },
+                  "quantityAvailable" : {
+                    "type" : "integer",
+                    "description" : "The availability of the product reserved."
+                  },
+                  "effectivedate" : {
+                    "type" : "string",
+                    "description" : "The reservation date for the product in UTC format.",
+                    "format" : "Date"
+                  },
+                  "expirydate" : {
+                    "type" : "string",
+                    "description" : "The expiration date for the reservation of the product in UTC format.",
+                    "format" : "Date"
+                  }
+                }
+              }
+            },
+            "pricing" : {
+              "type" : "object",
+              "properties" : {
+                "currencyCode" : {
+                  "type" : "string",
+                  "description" : "The 3-digit ISO currency code."
+                },
+                "retailPrice" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "The retail price of the product."
+                },
+                "mapPrice" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "Minimum Advertised Price (MAP). If required by the vendor, resellers can not sell below MAP price."
+                },
+                "customerPrice" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "The price customer pays after all special pricing and discounts have been applied."
+                },
+                "specialBidPricingAvailable" : {
+                  "type" : "boolean",
+                  "description" : "Boolean values specifies whether special Bid discounts are available for the product."
+                },
+                "webDiscountsAvailable" : {
+                  "type" : "boolean",
+                  "description" : "Boolean values specifies whether web Discounts are available for the product."
+                }
+              }
+            },
+            "discounts" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "specialPricing" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "discountType" : {
+                          "type" : "string",
+                          "description" : "The type of discount being given to the customer.",
+                          "example" : "Special Bid, Promo Discount"
+                        },
+                        "specialBidNumer" : {
+                          "type" : "string",
+                          "description" : "Pre-approved special pricing/bid number provided to the reseller by the vendor for special pricing and discounts. Used to track the bid number where different line items have different bid numbers. Line-level bid numbers take precedence over header-level bid numbers."
+                        },
+                        "specialPricingDiscount" : {
+                          "type" : "number",
+                          "format" : "decimal",
+                          "description" : "Special pricing discount amount given to the customer."
+                        },
+                        "specialPricingEffectiveDate" : {
+                          "type" : "string",
+                          "format" : "date",
+                          "description" : "The effective date of the special pricing available to the customer."
+                        },
+                        "specialPricingExpirationDate" : {
+                          "type" : "string",
+                          "format" : "date",
+                          "description" : "The expiration date of the special pricing available to the customer."
+                        },
+                        "specialPricingAvailableQuantity" : {
+                          "type" : "integer",
+                          "description" : "The available quantity of products with discounts."
+                        },
+                        "specialPricingMinQuantity" : {
+                          "type" : "integer",
+                          "description" : "The minimum quantity of products that have to be purchased to ensure the discount is applied."
+                        }
+                      }
+                    }
+                  },
+                  "quantityDiscounts" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "conditionType" : {
+                          "type" : "string",
+                          "description" : "Indicates when the discount is applied after ordering the product.",
+                          "example" : "Total fee"
+                        },
+                        "currencyCode" : {
+                          "type" : "string",
+                          "description" : "The country-specific three digit ISO 4217 currency code for the order."
+                        },
+                        "currencyType" : {
+                          "type" : "string",
+                          "description" : "********"
+                        },
+                        "quantity" : {
+                          "type" : "integer",
+                          "description" : "The total discounted quantity of the product."
+                        },
+                        "amount" : {
+                          "type" : "number",
+                          "format" : "decimal",
+                          "description" : "The total price of all the discounts applied."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ProductSearch_Response" : {
+        "type" : "object",
+        "properties" : {
+          "recordsFound" : {
+            "type" : "integer",
+            "description" : "The number of recourds found for the search."
+          },
+          "pageSize" : {
+            "type" : "integer",
+            "description" : "The number of results per page. Default is 25."
+          },
+          "pageNumber" : {
+            "type" : "integer",
+            "description" : "current page number default is 1"
+          },
+          "catalog" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "description" : {
+                  "type" : "string",
+                  "description" : "The description of the product."
+                },
+                "category" : {
+                  "type" : "string",
+                  "description" : "The category of the product. Example: Displays."
+                },
+                "subCategory" : {
+                  "type" : "string",
+                  "description" : "The sub category for the product. Example: ComputernMonitors."
+                },
+                "productType" : {
+                  "type" : "string",
+                  "description" : "The product type of the product. Example: LCD Monitors."
+                },
+                "ingramPartNumber" : {
+                  "type" : "string",
+                  "description" : "The Unique IngramMicro part number for the product."
+                },
+                "vendorPartNumber" : {
+                  "type" : "string",
+                  "description" : "The vendor part number for the product."
+                },
+                "upcCode" : {
+                  "type" : "string",
+                  "description" : "The UPC code for the product. Consists of 12 numeric digits that are uniquly assigned to each trade item."
+                },
+                "vendorName" : {
+                  "type" : "string",
+                  "description" : "The name of the vendor/manufacturer of the product."
+                },
+                "endUserRequired" : {
+                  "type" : "string",
+                  "description" : "Indicates whether the contact information for the end user/customer is required, which determines pricing and discounts."
+                },
+                "hasDiscounts" : {
+                  "type" : "string",
+                  "description" : "Specifies if there are discounts available for the product."
+                },
+                "type" : {
+                  "type" : "string",
+                  "description" : "The SKU type of product. One of Physical, Digital, or Any."
+                },
+                "discontinued" : {
+                  "type" : "string",
+                  "description" : "Indicates if the product has been discontinued."
+                },
+                "newProduct" : {
+                  "type" : "string",
+                  "description" : "Indicates if the product is new. For digital products, newer than 10 days. For physical products, newer than 150 days."
+                },
+                "directShip" : {
+                  "type" : "string",
+                  "description" : "Indicates if the product will be shipped directly to the reseller or end user from the vendor/manufacturer."
+                },
+                "hasWarranty" : {
+                  "type" : "string",
+                  "description" : "Indicates if the product has a warranty."
+                },
+                "links" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "description" : "HATEOAS links for the price and availability of the sku.",
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "description" : "Provides the details of the product."
+                      },
+                      "href" : {
+                        "type" : "string",
+                        "description" : "The URL endpoint for accessing the relevant data.."
+                      },
+                      "type" : {
+                        "type" : "string",
+                        "description" : "The type of call that can be made to the href link(GET)"
+                      }
+                    }
+                  }
+                },
+                "extraDescription" : {
+                  "type" : "string",
+                  "description" : "The extended description of the product."
+                },
+                "replacementSku" : {
+                  "type" : "string",
+                  "description" : "Identifies a SKU that is a comparable subsititution of the current SKU if available."
+                },
+                "authorizedToPurchase" : {
+                  "type" : "string",
+                  "description" : "It is true when it exists in matched queries field of ealstic search API."
+                }
+              }
+            }
+          },
+          "nextPage" : {
+            "type" : "string",
+            "description" : "link/URL for accessing next page."
+          },
+          "previousPage" : {
+            "type" : "string",
+            "description" : "link/URL for accessing previous page."
+          }
+        }
+      },
+      "QuoteSearchResponse" : {
+        "type" : "object",
+        "properties" : {
+          "recordsFound" : {
+            "type" : "integer",
+            "description" : "Total count of quotes retrieved in the request response."
+          },
+          "pageSize" : {
+            "type" : "integer",
+            "description" : "Number of records (quotes) displayed per page in the quote list."
+          },
+          "pageNumber" : {
+            "type" : "integer",
+            "description" : "Page index or page number for the list of quotes being returned."
+          },
+          "quotes" : {
+            "type" : "array",
+            "description" : "The quote details for the requested criteria.",
+            "items" : {
+              "properties" : {
+                "quoteName" : {
+                  "type" : "string",
+                  "description" : "Quote Name given to quote by sales team or system generated.  Generally used as a reference to identify the quote."
+                },
+                "quoteNumber" : {
+                  "type" : "string",
+                  "description" : "Unique identifier generated by Ingram Micros CRM specific to each quote.  When applying a filter to the quoteNumber and including a partial quote number in the filter, all quotes containing any information included in the filter can be retrieved as a subset of all available customer quotes."
+                },
+                "revision" : {
+                  "type" : "string",
+                  "description" : "When a quote has been revised and updated, the quote number remains the same throughout the lifecycle of the quote, however, a Revision number is updated for each revision of the quote.  The revision numbers is associated with the Unique Quote Number."
+                },
+                "endUserContact" : {
+                  "type" : "string",
+                  "description" : "End User Name is the end customer name that is associated with a quote in Ingram Micros CRM."
+                },
+                "specialBidNumber" : {
+                  "type" : "string",
+                  "description" : "Special Pricing Bid Number, also refers to as Dart Number relates to a unique pricing deal associated with a vendor for the quote."
+                },
+                "quoteTotal" : {
+                  "type" : "number",
+                  "format" : "decimal",
+                  "description" : "Total amount of quoted price for all products in the quote."
+                },
+                "quoteStatus" : {
+                  "type" : "string",
+                  "description" : "This refers to the primary status of the quote."
+                },
+                "ingramQuoteDate" : {
+                  "type" : "string",
+                  "description" : "Date the Quote was initially Created."
+                },
+                "lastModifiedDate" : {
+                  "type" : "string",
+                  "description" : "Date the Quote was last updated or modified."
+                },
+                "ingramQuoteExpiryDate" : {
+                  "type" : "string",
+                  "description" : "Date the Quote Expires."
+                }
+              }
+            }
+          }
+        }
+      },
+      "QuoteDetailsResponse" : {
+        "type" : "object",
+        "properties" : {
+          "quoteName" : {
+            "type" : "string",
+            "description" : "Quote Name given to quote by sales team or system generated.  Generally used as a reference to identify the quote."
+          },
+          "quoteNumber" : {
+            "type" : "string",
+            "description" : "Unique identifier generated by Ingram Micro's CRM specific to each quote.  When applying a filter to the quoteNumber and including a partial quote number in the filter, all quotes containing any information included in the filter can be retrieved as a subset of all available customer quotes."
+          },
+          "revision" : {
+            "type" : "string",
+            "description" : "When a quote has been revised and updated, the quote number remains the same throughout the lifecycle of the quote, however, a Revision number is updated for each revision of the quote.  The revision numbers is associated with the Unique Quote Number."
+          },
+          "ingramQuoteDate" : {
+            "type" : "string",
+            "description" : "Date the Quote was initially Created."
+          },
+          "lastModifiedDate" : {
+            "type" : "string",
+            "description" : "Date the Quote was last updated or modified."
+          },
+          "ingramQuoteExpiryDate" : {
+            "type" : "string",
+            "description" : "Quote expiration date."
+          },
+          "currencyCode" : {
+            "type" : "string",
+            "description" : "Three letter currency code."
+          },
+          "specialBidId" : {
+            "type" : "string",
+            "description" : "Price discount identifyer to specify  a pricing discount that has been applied to the quote. If present - the priceDeviationStartDate and priceDeviationExpiryDate must be presented. Cisco refers to this as a Dart"
+          },
+          "specialBidEffectiveDate" : {
+            "type" : "string",
+            "description" : "If price discount has been applied to the quote - the starting date the discount begins."
+          },
+          "specialBidExpirationDate" : {
+            "type" : "string",
+            "description" : "If a price discount has been applied to the quote - The date the discount expires and will no longer be applicable."
+          },
+          "status" : {
+            "type" : "string",
+            "description" : "This refers to the primary status of the quote.  API responses will return"
+          },
+          "customerNeed" : {
+            "type" : "string",
+            "description" : "Details related to the customer's request for the quote entered by the sales representative or system generated."
+          },
+          "proposedSolution" : {
+            "type" : "string",
+            "description" : "Ingram Micro proposed solution and summary of quote."
+          },
+          "introPreamble" : {
+            "type" : "string",
+            "description" : "Introductory paragraph included in each quote.  Legally required - must be included when presenting the quote details."
+          },
+          "purchaseInstructions" : {
+            "type" : "string",
+            "description" : "Purchase instructions.  Legally required - must be included when presenting the quote details."
+          },
+          "legalTerms" : {
+            "type" : "string",
+            "description" : "Legal terms -  Legally required - must be included when presenting the quote details."
+          },
+          "resellerInfo" : {
+            "type" : "object",
+            "properties" : {
+              "contact" : {
+                "type" : "string",
+                "description" : "Contact Name"
+              },
+              "companyName" : {
+                "type" : "string",
+                "description" : "Ingram Micro Customer's Account Name"
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "Account Contact Email Address"
+              },
+              "phoneNumber" : {
+                "type" : "string",
+                "description" : "Account Phone Number"
+              }
+            }
+          },
+          "endUserInfo" : {
+            "type" : "object",
+            "properties" : {
+              "contact" : {
+                "type" : "string",
+                "description" : "End User Name"
+              },
+              "companyName" : {
+                "type" : "string",
+                "description" : "Contact name  of end user associated with the quote."
+              },
+              "addressLine1" : {
+                "type" : "string",
+                "description" : "Address line 1 for end user associated with the quote"
+              },
+              "addressLine2" : {
+                "type" : "string",
+                "description" : "Address line 2 for end user associated with the quote."
+              },
+              "addressLine3" : {
+                "type" : "string",
+                "description" : "Address line 3 for end user associated with the quote."
+              },
+              "city" : {
+                "type" : "string",
+                "description" : "City for end user associated with the quote"
+              },
+              "state" : {
+                "type" : "string",
+                "description" : "Two letter state abreviation for end user associated with the quote"
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "Email of end user the quote associated with the quote."
+              },
+              "phoneNumber" : {
+                "type" : "string",
+                "description" : "Phone number of end user associated with the quote."
+              },
+              "postalCode" : {
+                "type" : "string",
+                "description" : "Zip code of end user associated with the quote."
+              },
+              "marketSegment" : {
+                "type" : "string",
+                "description" : "Market Segment of end user associated with the quote. End user market segment is included when end user is included in specific market segments like Educational, Government, Military, Medical - that may receive special pricing due to their segmentation."
+              }
+            }
+          },
+          "products" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "quoteProductGuid" : {
+                  "type" : "string",
+                  "description" : "Quote Product GUID  is the primary quote key in Ingram Micro's CRM - needed to retrieve quote details."
+                },
+                "lineNumber" : {
+                  "type" : "string",
+                  "description" : "Line number which the product will appear in the quote.  Line number is manditory when unique configurations are included in a quote and mainting the item line order is required."
+                },
+                "quantity" : {
+                  "type" : "integer",
+                  "description" : "Quantity of product line item quoted."
+                },
+                "notes" : {
+                  "type" : "string",
+                  "description" : "Product line item comments."
+                },
+                "ingramPartNumber" : {
+                  "type" : "string",
+                  "description" : "Ingram Micro SKU (stock keeping unit). An identification, usually alphanumeric, of a particular product that allows it to be tracked for inventory purposes"
+                },
+                "vendorPartNumber" : {
+                  "type" : "string",
+                  "description" : "Vendor Part Number"
+                },
+                "description" : {
+                  "type" : "string",
+                  "description" : "Product description.  Note - The quote view api returns only the product short description as maintained in Ingram Micro's crm system.  For long descriptions, please refer to alternative information sources."
+                },
+                "weight" : {
+                  "type" : "integer",
+                  "description" : "Weight is provided based on country standard.  For countries following Imperial standards - weight is presented as pounds with decimal.  In countries following metric standards, weight is provided as kilograms with decimal."
+                },
+                "weightUom" : {
+                  "type" : "string",
+                  "description" : "Unit of measure"
+                },
+                "isSuggestionProduct" : {
+                  "type" : "boolean",
+                  "description" : "Flag to indicate if a product line item is a suggested product.  The suggested product is provided in addition to the requested quoted products and a suggested option.  Suggested products are grouped together for subtotal and total calculations."
+                },
+                "vpnCategory" : {
+                  "type" : "string",
+                  "description" : "Vendor product category specific to Cisco. HWDW (hardware) or service."
+                },
+                "quoteProductsSupplierPartAuxiliaryId" : {
+                  "type" : "string",
+                  "description" : "Vendor product configuration ID specific to Cisco."
+                },
+                "vendorName" : {
+                  "type" : "string",
+                  "description" : "Vendor name of the product"
+                },
+                "price" : {
+                  "type" : "object",
+                  "properties" : {
+                    "quotePrice" : {
+                      "type" : "integer",
+                      "description" : "Ingram Micro quoted price specific to the reseller and quote."
+                    },
+                    "msrp" : {
+                      "type" : "integer",
+                      "description" : "Manufacturer Suggested Retail Price"
+                    },
+                    "extendedMsrp" : {
+                      "type" : "integer",
+                      "description" : "Extended MSRP - Manufacturer Suggested Retail Price X Quantity"
+                    },
+                    "extendedQuotePrice" : {
+                      "type" : "integer",
+                      "description" : "Extended reseller quoted price (cost to reseller) X Quantity"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "productsCount" : {
+            "type" : "integer",
+            "description" : "Total number of products included in the quote"
+          },
+          "extendedMsrpTotal" : {
+            "type" : "integer",
+            "description" : "Total extended MSRP for all products included in the quote"
+          },
+          "quantityTotal" : {
+            "type" : "integer",
+            "description" : "Total quantity of all items in the quote."
+          },
+          "extendedQuotePriceTotal" : {
+            "type" : "integer",
+            "description" : "Total amount of quoted price for all products in the quote including both solution products and suggested products."
+          },
+          "additionalAttributes" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "attributeName" : {
+                  "type" : "string",
+                  "description" : "estimateId - is the identification number for an estimate provided by Cisco for a quote.\n\ndealId - is the identification number for the specific deal pricing related to a Cisco quote\n\nvendorName - Name of Vendor associated with the quote.\n\nvendorMessage - Vendor Message is associated with primary vendor in the quote.  In cases where a vendor requires a message be presented in the quote, the vendor name and message will be retreived and must be included in the quote vendor message fields."
+                },
+                "attributeValue" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "AvailabilityAsyncNotificationRequest" : {
+        "type" : "object",
+        "required" : [ "customerOrderNumber" ],
+        "properties" : {
+          "topic" : {
+            "type" : "string",
+            "description" : "Field for identifying whether it is a reseller or vendor event. For eg, resellers/orders"
+          },
+          "event" : {
+            "type" : "string",
+            "description" : "The event sent in the request. For eg, im::create."
+          },
+          "eventTimeStamp" : {
+            "type" : "string",
+            "description" : "The timestamp at which the event was sent."
+          },
+          "eventId" : {
+            "type" : "string",
+            "description" : "A unique id used as identifier for the sepcific event and used for generating the x-hub signature."
+          },
+          "resource" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "eventType" : {
+                  "type" : "string",
+                  "description" : "The event name sent in the event request."
+                },
+                "ingramPartNumber" : {
+                  "type" : "string",
+                  "description" : "The Unique IngramMicro part number for the product."
+                },
+                "vendorPartNumber" : {
+                  "type" : "string",
+                  "description" : "The vendors part number for the product."
+                },
+                "vendorName" : {
+                  "type" : "string",
+                  "description" : "The name of the vendor/manufacturer of the product."
+                },
+                "upcCode" : {
+                  "type" : "string",
+                  "description" : "The UPC code for the product. Consists of 12 numeric digits that are uniquly assigned to each trade item."
+                },
+                "skuStatus" : {
+                  "type" : "string",
+                  "description" : "Status returned saying whether sku is active."
+                },
+                "backOrderFlag" : {
+                  "type" : "string",
+                  "description" : "Backordered Flag."
+                },
+                "totalAvailability" : {
+                  "type" : "string",
+                  "description" : "totalAvailability."
+                },
+                "links" : {
+                  "type" : "array",
+                  "description" : "Link to Order Details for the order(s).",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "description" : "Provides the details of the orders."
+                      },
+                      "href" : {
+                        "type" : "string",
+                        "description" : "The URL endpoint for accessing the relevant data."
+                      },
+                      "type" : {
+                        "type" : "string",
+                        "description" : "The type of call that can be made to the href link (GET, POST, Etc.).            "
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrderStatusAsyncNotificationRequest" : {
+        "type" : "object",
+        "required" : [ "customerOrderNumber" ],
+        "properties" : {
+          "topic" : {
+            "type" : "string",
+            "description" : "Field for identifying whether it is a reseller or vendor event. For eg, resellers/orders"
+          },
+          "event" : {
+            "type" : "string",
+            "description" : "The event sent in the request. For eg, im::create."
+          },
+          "eventTimeStamp" : {
+            "type" : "string",
+            "description" : "The timestamp at which the event was sent."
+          },
+          "eventId" : {
+            "type" : "string",
+            "description" : "A unique id used as identifier for the sepcific event and used for generating the x-hub signature."
+          },
+          "resource" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "eventType" : {
+                  "type" : "string",
+                  "description" : "The event name sent in the event request."
+                },
+                "orderNumber" : {
+                  "type" : "string",
+                  "description" : "The Ingram Micro order number."
+                },
+                "customerOrderNumber" : {
+                  "type" : "string",
+                  "description" : "The reseller's unique PO/Order number."
+                },
+                "orderEntryTimeStamp" : {
+                  "type" : "string",
+                  "description" : "The timestamp at which the order was created."
+                },
+                "lines" : {
+                  "type" : "array",
+                  "description" : "The line-level details for the order.",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "LineNumber" : {
+                        "type" : "string",
+                        "description" : "The Ingram Micro line number for the product"
+                      },
+                      "subOrderNumber" : {
+                        "type" : "string",
+                        "description" : "The sub order number. The two-digit prefix is the warehouse code of the warehouse nearest the reseller. The middle number is the order number. The two-digit suffix is the sub order number."
+                      },
+                      "lineStatus" : {
+                        "type" : "string",
+                        "description" : "The status for the line item in the order. One of: Backordered, Open, Shipped"
+                      },
+                      "ingramPartNumber" : {
+                        "type" : "string",
+                        "description" : "The Ingram Micro part number for the line item."
+                      },
+                      "vendorPartNumber" : {
+                        "type" : "string",
+                        "description" : "The vendor part number for the line item."
+                      },
+                      "requestedQuantity" : {
+                        "type" : "string",
+                        "description" : "The quantity of the line item requested."
+                      },
+                      "shippedQuantity" : {
+                        "type" : "string",
+                        "description" : "The quantity of the line item that has been shipped."
+                      },
+                      "backorderedQuantity" : {
+                        "type" : "string",
+                        "description" : "The quantity of the line item that is backordered."
+                      },
+                      "shipmentDetails" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "shipmentDate" : {
+                              "type" : "string",
+                              "description" : "The date the line item was shipped."
+                            },
+                            "shipFromWarehouseId" : {
+                              "type" : "string",
+                              "description" : "The ID of the warehouse the product will ship from."
+                            },
+                            "warehouseName" : {
+                              "type" : "string",
+                              "description" : "\"\""
+                            },
+                            "carrierCode" : {
+                              "type" : "string",
+                              "description" : "The carrier code for the shipment containing the\n line item."
+                            },
+                            "carrierName" : {
+                              "type" : "string",
+                              "description" : "The name of the carrier of the shipment containing\n  the line item."
+                            },
+                            "packageDetails" : {
+                              "type" : "array",
+                              "items" : {
+                                "type" : "object",
+                                "properties" : {
+                                  "cartonNumber" : {
+                                    "type" : "string",
+                                    "description" : "The shipment carton number that contains the line item."
+                                  },
+                                  "quantityInbox" : {
+                                    "type" : "string",
+                                    "description" : "The quantity of line items in the box."
+                                  },
+                                  "trackingNumber" : {
+                                    "type" : "string",
+                                    "description" : "The tracking number for the shipment containing the line item."
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "serialNumberDetails" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "serialNumber" : {
+                              "type" : "string",
+                              "description" : "The serial number for the line item.                  "
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "links" : {
+                  "type" : "array",
+                  "description" : "Link to Order Details for the order(s).",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "description" : "Provides the details of the orders."
+                      },
+                      "href" : {
+                        "type" : "string",
+                        "description" : "The URL endpoint for accessing the relevant data."
+                      },
+                      "type" : {
+                        "type" : "string",
+                        "description" : "The type of call that can be made to the href link (GET, POST, Etc.).                    "
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "InvoiceSearchResponse" : {
+        "type" : "object",
+        "properties" : {
+          "recordsFound" : {
+            "type" : "integer",
+            "description" : "Total count of quotes retrieved in the request response."
+          },
+          "pageSize" : {
+            "type" : "integer",
+            "description" : "Number of records (quotes) displayed per page in the quote list."
+          },
+          "pageNumber" : {
+            "type" : "integer",
+            "description" : "Page index or page number for the list of quotes being returned."
+          },
+          "invoices" : {
+            "type" : "array",
+            "description" : "The Invoices details for the requested criteria.",
+            "items" : {
+              "properties" : {
+                "paymentTermsDueDate" : {
+                  "type" : "string",
+                  "description" : "Payment Terms Due date."
+                },
+                "erpOrderNumber" : {
+                  "type" : "string",
+                  "description" : "Order number"
+                },
+                "invoiceNumber" : {
+                  "type" : "string",
+                  "description" : "Invoice no."
+                },
+                "invoiceStatus" : {
+                  "type" : "string",
+                  "description" : "Invoice Status."
+                },
+                "invoiceDate" : {
+                  "type" : "string",
+                  "description" : "Invoice Date."
+                },
+                "invoiceDueDate" : {
+                  "type" : "string",
+                  "description" : "Invoice Due Date."
+                },
+                "invoicedAmountDue" : {
+                  "type" : "string",
+                  "description" : "Invoice Amount."
+                },
+                "customerOrderNumber" : {
+                  "type" : "string",
+                  "description" : "Customer Order No."
+                },
+                "orderCreateDate" : {
+                  "type" : "string",
+                  "description" : "Order Create Date."
+                },
+                "endCustomerOrderNumber" : {
+                  "type" : "string",
+                  "description" : "End Customer Order number."
+                }
+              }
+            }
+          }
+        }
+      },
+      "InvoiceDetailResponse" : {
+        "title" : "invoiceDetails.Response",
+        "type" : "object",
+        "x-tags" : [ "invoices" ],
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responsestatus" : {
+                    "type" : "string"
+                  },
+                  "statuscode" : {
+                    "type" : "string"
+                  },
+                  "responsemessage" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "invoicedetailresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "customernumber" : {
+                    "type" : "string"
+                  },
+                  "invoicenumber" : {
+                    "type" : "string"
+                  },
+                  "invoicedate" : {
+                    "type" : "string",
+                    "format" : "date"
+                  },
+                  "invoicetype" : {
+                    "type" : "string"
+                  },
+                  "customerordernumber" : {
+                    "type" : "string"
+                  },
+                  "customerfreightamount" : {
+                    "type" : "string",
+                    "format" : "double"
+                  },
+                  "customerforeignfrightamt" : {
+                    "type" : "string",
+                    "format" : "float"
+                  },
+                  "totaltaxamount" : {
+                    "type" : "string",
+                    "format" : "double"
+                  },
+                  "totalamount" : {
+                    "type" : "string",
+                    "format" : "double"
+                  },
+                  "shiptosuffix" : {
+                    "type" : "string"
+                  },
+                  "billtosuffix" : {
+                    "type" : "string"
+                  },
+                  "freightamount" : {
+                    "type" : "string",
+                    "format" : "double",
+                    "description" : "May not be available in all countries"
+                  },
+                  "paymentterms" : {
+                    "type" : "string"
+                  },
+                  "orderdate" : {
+                    "type" : "string",
+                    "format" : "date"
+                  },
+                  "carrier" : {
+                    "type" : "string"
+                  },
+                  "carrierdescription" : {
+                    "type" : "string"
+                  },
+                  "discountamount" : {
+                    "type" : "number",
+                    "format" : "double"
+                  },
+                  "taxtype" : {
+                    "type" : "string"
+                  },
+                  "enduserponumber" : {
+                    "type" : "string"
+                  },
+                  "freightforwardercode" : {
+                    "type" : "string"
+                  },
+                  "creditmemoreasoncode" : {
+                    "type" : "string"
+                  },
+                  "fulfillmentflag" : {
+                    "type" : "string"
+                  },
+                  "holdreason" : {
+                    "type" : "string"
+                  },
+                  "shipcomplete" : {
+                    "type" : "string"
+                  },
+                  "shipdate" : {
+                    "type" : "string",
+                    "format" : "date"
+                  },
+                  "companycurrency" : {
+                    "type" : "string"
+                  },
+                  "currencycode" : {
+                    "type" : "string"
+                  },
+                  "currencyrate" : {
+                    "type" : "string"
+                  },
+                  "globalorderid" : {
+                    "type" : "string"
+                  },
+                  "originalshipcode" : {
+                    "type" : "string"
+                  },
+                  "ordertype" : {
+                    "type" : "string"
+                  },
+                  "orderstatus" : {
+                    "type" : "string"
+                  },
+                  "totalotherfees" : {
+                    "type" : "number"
+                  },
+                  "totalsales" : {
+                    "type" : "string"
+                  },
+                  "weight" : {
+                    "type" : "string"
+                  },
+                  "shippableswitch" : {
+                    "type" : "string"
+                  },
+                  "soldto" : {
+                    "$ref" : "#/components/schemas/addressType"
+                  },
+                  "billto" : {
+                    "$ref" : "#/components/schemas/addressType"
+                  },
+                  "shoptoaddress" : {
+                    "$ref" : "#/components/schemas/addressType"
+                  },
+                  "lines" : {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/components/schemas/productLineType"
+                    }
+                  },
+                  "extendedspecs" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "attributename" : {
+                          "type" : "string"
+                        },
+                        "attributevalue" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  },
+                  "miscfeeline" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "code" : {
+                          "type" : "string"
+                        },
+                        "description" : {
+                          "type" : "string"
+                        },
+                        "chargeamount" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "invoiceDetails" : {
+        "title" : "invoiceDetails.Response",
+        "type" : "object",
+        "x-tags" : [ "invoices" ],
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responsestatus" : {
+                    "type" : "string"
+                  },
+                  "statuscode" : {
+                    "type" : "string"
+                  },
+                  "responsemessage" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "invoicedetailresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "customernumber" : {
+                    "type" : "string"
+                  },
+                  "invoicenumber" : {
+                    "type" : "string"
+                  },
+                  "invoicedate" : {
+                    "type" : "string",
+                    "format" : "date"
+                  },
+                  "invoicetype" : {
+                    "type" : "string"
+                  },
+                  "customerordernumber" : {
+                    "type" : "string"
+                  },
+                  "customerfreightamount" : {
+                    "type" : "string",
+                    "format" : "double"
+                  },
+                  "customerforeignfrightamt" : {
+                    "type" : "string",
+                    "format" : "float"
+                  },
+                  "totaltaxamount" : {
+                    "type" : "string",
+                    "format" : "double"
+                  },
+                  "totalamount" : {
+                    "type" : "string",
+                    "format" : "double"
+                  },
+                  "shiptosuffix" : {
+                    "type" : "string"
+                  },
+                  "billtosuffix" : {
+                    "type" : "string"
+                  },
+                  "freightamount" : {
+                    "type" : "string",
+                    "format" : "double",
+                    "description" : "May not be available in all countries"
+                  },
+                  "paymentterms" : {
+                    "type" : "string"
+                  },
+                  "orderdate" : {
+                    "type" : "string",
+                    "format" : "date"
+                  },
+                  "carrier" : {
+                    "type" : "string"
+                  },
+                  "carrierdescription" : {
+                    "type" : "string"
+                  },
+                  "discountamount" : {
+                    "type" : "number",
+                    "format" : "double"
+                  },
+                  "taxtype" : {
+                    "type" : "string"
+                  },
+                  "enduserponumber" : {
+                    "type" : "string"
+                  },
+                  "freightforwardercode" : {
+                    "type" : "string"
+                  },
+                  "creditmemoreasoncode" : {
+                    "type" : "string"
+                  },
+                  "fulfillmentflag" : {
+                    "type" : "string"
+                  },
+                  "holdreason" : {
+                    "type" : "string"
+                  },
+                  "shipcomplete" : {
+                    "type" : "string"
+                  },
+                  "shipdate" : {
+                    "type" : "string",
+                    "format" : "date"
+                  },
+                  "companycurrency" : {
+                    "type" : "string"
+                  },
+                  "currencycode" : {
+                    "type" : "string"
+                  },
+                  "currencyrate" : {
+                    "type" : "string"
+                  },
+                  "globalorderid" : {
+                    "type" : "string"
+                  },
+                  "originalshipcode" : {
+                    "type" : "string"
+                  },
+                  "ordertype" : {
+                    "type" : "string"
+                  },
+                  "orderstatus" : {
+                    "type" : "string"
+                  },
+                  "totalotherfees" : {
+                    "type" : "number"
+                  },
+                  "totalsales" : {
+                    "type" : "string"
+                  },
+                  "weight" : {
+                    "type" : "string"
+                  },
+                  "shippableswitch" : {
+                    "type" : "string"
+                  },
+                  "soldto" : {
+                    "$ref" : "#/components/schemas/addressType"
+                  },
+                  "billto" : {
+                    "$ref" : "#/components/schemas/addressType"
+                  },
+                  "shoptoaddress" : {
+                    "$ref" : "#/components/schemas/addressType"
+                  },
+                  "lines" : {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/components/schemas/productLineType"
+                    }
+                  },
+                  "extendedspecs" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "attributename" : {
+                          "type" : "string"
+                        },
+                        "attributevalue" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  },
+                  "miscfeeline" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "code" : {
+                          "type" : "string"
+                        },
+                        "description" : {
+                          "type" : "string"
+                        },
+                        "chargeamount" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "addressType" : {
+        "title" : "invoiceDetails.addressType.Response",
+        "type" : "object",
+        "properties" : {
+          "attention" : {
+            "type" : "string"
+          },
+          "name1" : {
+            "type" : "string"
+          },
+          "name2" : {
+            "type" : "string"
+          },
+          "addressline1" : {
+            "type" : "string"
+          },
+          "addressline2" : {
+            "type" : "string"
+          },
+          "addressline3" : {
+            "type" : "string"
+          },
+          "city" : {
+            "type" : "string"
+          },
+          "state" : {
+            "type" : "string"
+          },
+          "postalcode" : {
+            "type" : "string"
+          },
+          "countrycode" : {
+            "type" : "string"
+          },
+          "fax" : {
+            "type" : "string"
+          },
+          "phonenumber" : {
+            "type" : "string"
+          },
+          "email" : {
+            "type" : "string"
+          }
+        },
+        "description" : "Address type object",
+        "x-tags" : [ "invoices" ]
+      },
+      "productLineType" : {
+        "title" : "invoiceDetails.productLineType.Response",
+        "type" : "object",
+        "description" : "Product line items object under each invoice",
+        "x-tags" : [ "invoices" ],
+        "properties" : {
+          "linenumber" : {
+            "type" : "string"
+          },
+          "linetype" : {
+            "type" : "string"
+          },
+          "partnumber" : {
+            "type" : "string"
+          },
+          "vendorpartnumber" : {
+            "type" : "string"
+          },
+          "partdescription" : {
+            "type" : "string"
+          },
+          "shipfrombranch" : {
+            "type" : "string"
+          },
+          "shippedquantity" : {
+            "type" : "string"
+          },
+          "orderedquantity" : {
+            "type" : "string"
+          },
+          "marginpercent" : {
+            "type" : "string"
+          },
+          "backorderquantity" : {
+            "type" : "string"
+          },
+          "backorderetadate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "extendedprice" : {
+            "type" : "string"
+          },
+          "specialbidnumber" : {
+            "type" : "string"
+          },
+          "ordersuffix" : {
+            "type" : "string"
+          },
+          "isacopapplied" : {
+            "type" : "string"
+          },
+          "unitprice" : {
+            "type" : "string"
+          },
+          "unitofmeasure" : {
+            "type" : "string"
+          },
+          "serialnumberdetails" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "serialnumber" : {
+                  "type" : "string"
+                },
+                "deliverynumber" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "trackingnumberdetails" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "trackingnumber" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "productextendedspecs" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "attributename" : {
+                  "type" : "string"
+                },
+                "attributevalue" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ErrorResponse" : {
+        "type" : "object",
+        "properties" : {
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "id" : {
+                  "type" : "string",
+                  "description" : "Unique Id to identify error."
+                },
+                "type" : {
+                  "type" : "string",
+                  "description" : "Describes the type of the error."
+                },
+                "message" : {
+                  "type" : "string",
+                  "description" : "Describes the error message."
+                },
+                "fields" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "field" : {
+                        "type" : "string",
+                        "description" : "Contains the name of the field."
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "description" : "Value sent in the input for the specific field."
+                      },
+                      "message" : {
+                        "type" : "string",
+                        "description" : "Gives the description of the field message."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "orderCreateRequest" : {
+        "title" : "orderCreate.Request",
+        "type" : "object",
+        "x-examples" : { },
+        "x-tags" : [ "orders" ],
+        "description" : "Request schema for order create endpoint",
+        "properties" : {
+          "ordercreaterequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "required" : [ "isocountrycode", "customernumber" ],
+                "properties" : {
+                  "isocountrycode" : {
+                    "type" : "string",
+                    "description" : "2 digit ISO country code"
+                  },
+                  "customernumber" : {
+                    "type" : "string",
+                    "description" : "Your unique Ingram Micro customer number",
+                    "example" : "10-123456 or 123456"
+                  }
+                }
+              },
+              "ordercreatedetails" : {
+                "type" : "object",
+                "properties" : {
+                  "customerponumber" : {
+                    "type" : "string",
+                    "minLength" : 1,
+                    "maxLength" : 18,
+                    "description" : "The customers unique Purchase Order number. Keep it unique to retrieve order information"
+                  },
+                  "ordertype" : {
+                    "type" : "string",
+                    "enum" : [ "Standard", "Direct Ship" ],
+                    "description" : "Order Type - Standard orders, Direct ship orders"
+                  },
+                  "enduserordernumber" : {
+                    "type" : "string",
+                    "description" : "Customers End-user PO number",
+                    "minLength" : 0,
+                    "maxLength" : 18
+                  },
+                  "billtosuffix" : {
+                    "type" : "string",
+                    "description" : "Designates flooring acct to be used",
+                    "maxLength" : 3
+                  },
+                  "shiptosuffix" : {
+                    "type" : "string",
+                    "description" : "Applies to customers with multiple ship to locations (store locations)",
+                    "maxLength" : 3
+                  },
+                  "shiptoaddress" : {
+                    "type" : "object",
+                    "required" : [ "addressline1", "addressline2", "city", "state", "postalcode" ],
+                    "properties" : {
+                      "attention" : {
+                        "type" : "string",
+                        "description" : "Customer contact name",
+                        "example" : "“Mr. Customer”",
+                        "maxLength" : 35
+                      },
+                      "addressline1" : {
+                        "type" : "string",
+                        "description" : "Company Name or person to deliver.\n*If there isn’t an attention line please add the company name on address line 1.   UPS and FedEx will create surcharges if address line 1 contains a physical address.",
+                        "example" : "“Ingram Micro”",
+                        "maxLength" : 35
+                      },
+                      "addressline2" : {
+                        "type" : "string",
+                        "description" : "Street address for delivery",
+                        "example" : "3351 Michelson Dr",
+                        "maxLength" : 35
+                      },
+                      "addressline3" : {
+                        "type" : "string",
+                        "description" : "Continuation of address line 2",
+                        "example" : "Ste 100 or ship to phone number",
+                        "maxLength" : 35
+                      },
+                      "city" : {
+                        "type" : "string",
+                        "example" : "Irvine",
+                        "maxLength" : 21,
+                        "description" : "Ship to city"
+                      },
+                      "state" : {
+                        "type" : "string",
+                        "example" : "CA",
+                        "maxLength" : 2,
+                        "description" : "Ship to State or Region"
+                      },
+                      "postalcode" : {
+                        "type" : "string",
+                        "description" : "Ship to Zip code or Postal code",
+                        "example" : "92712",
+                        "maxLength" : 9
+                      },
+                      "countrycode" : {
+                        "type" : "string",
+                        "description" : "Ship to country",
+                        "example" : "US",
+                        "maxLength" : 2
+                      }
+                    }
+                  },
+                  "carriercode" : {
+                    "type" : "string",
+                    "description" : "A customer can dictate what carrier to use for their shipment (Ingram 2-digit carrier code is required). Our recommendation is leave this field blank which will allow Ingram Micro to choose the best carrier to gain the best freight rates.",
+                    "maxLength" : 2
+                  },
+                  "thirdpartyfreightaccountnumber" : {
+                    "type" : "string",
+                    "description" : "Refers to a third-party freight account number for charging freight against. The account number should be passed within this field and the appropriate carrier code should be supplied within the carrier code tags. Prior to sending your request containing the third-party account number, it must be first entered into our system. Your Ingram Micro Sales Representative can action this for you. If submitted within an order without this preapproval the third-party account number will be ignored.\n\nNote: USA partners- For FedEx Air only (carrier codes F1, FO, F2, FG.), please send three leading zeros before your third-party freight account number (i.e.: 000999999999.) "
+                  },
+                  "specialbidnumber" : {
+                    "type" : "string",
+                    "description" : "This is the special quote number given to a customer either by a vendor for special pricing or by Ingram Micro. To receive the special pricing assigned to this number it must be included on the order."
+                  },
+                  "lines" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "linetype" : {
+                          "type" : "string",
+                          "description" : "Values are “P” for product or “C” for comments. This can be left blank when ordering product and a “P” will be assumed.  If you are adding a COMMENT, then this value must be “C”.\n\nExtended spec for comments:  \nAttribute Name: “commenttext”\nAttribute Value: “thank you for the order” \nTo make the comment invisible to the packing slip place “///” in front of the comment in the Attribute Value field.  This will allow the Ingram sales rep to see the comment on the order but will not forward on to shipping documents.",
+                          "enum" : [ "P", "C" ]
+                        },
+                        "linenumber" : {
+                          "type" : "string",
+                          "description" : "This is used when a partner wants to use their own line number. Can be left blank."
+                        },
+                        "ingrampartnumber" : {
+                          "type" : "string",
+                          "description" : "This is the Ingram sku number to be used for placing an order."
+                        },
+                        "quantity" : {
+                          "type" : "string",
+                          "description" : "The quantity that is to be ordered."
+                        },
+                        "vendorpartnumber" : {
+                          "type" : "string",
+                          "description" : "The Manufacturer part number. Can be used to place an order instead of the Ingram sku.  If there are multiple Ingram part numbers to one vendor part number.  The order will be rejected."
+                        },
+                        "customerpartnumber" : {
+                          "type" : "string",
+                          "description" : "This is the Customers unique part numbers that must be crossed referenced to the Ingram Micro Sku before it can be used.  Please contact your sales rep for additional information on how to set this up."
+                        },
+                        "UPCCode" : {
+                          "type" : "string"
+                        },
+                        "warehouseid" : {
+                          "type" : "string"
+                        },
+                        "unitprice" : {
+                          "type" : "string",
+                          "description" : "This is a requested price from the customer. Pre-approval is necessary before using this feature.  A methodology called price variance to manage requested pricing needs to be setup in advance by your sales rep.\n\nIf unit price is provided without this advanced setup the unit price will be ignored and standard Ingram Micro pricing will apply."
+                        },
+                        "enduser" : {
+                          "type" : "object",
+                          "properties" : {
+                            "id" : {
+                              "type" : "string"
+                            },
+                            "addressline1" : {
+                              "type" : "string"
+                            },
+                            "addressline2" : {
+                              "type" : "string"
+                            },
+                            "addressline3" : {
+                              "type" : "string"
+                            },
+                            "city" : {
+                              "type" : "string"
+                            },
+                            "state" : {
+                              "type" : "string"
+                            },
+                            "postalcode" : {
+                              "type" : "string"
+                            },
+                            "countrycode" : {
+                              "type" : "string"
+                            },
+                            "phonenumber" : {
+                              "type" : "string"
+                            },
+                            "extensionnumber" : {
+                              "type" : "string"
+                            },
+                            "faxnumber" : {
+                              "type" : "string"
+                            },
+                            "email" : {
+                              "type" : "string",
+                              "format" : "email"
+                            }
+                          }
+                        },
+                        "productextendedspecs" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "properties" : {
+                              "attributename" : {
+                                "type" : "string",
+                                "enum" : [ "shipfrom", "specialprice", "authbidnumber", "commenttext", "serialnumber", "contactnumber", "shipnotestxt" ]
+                              },
+                              "attributevalue" : {
+                                "type" : "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required" : [ "quantity" ]
+                    }
+                  },
+                  "extendedspecs" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "description" : "Attribute Name and Value: This field identifies if your order is a DIRECT SHIP order (license / warranty) or how you want your Backorders managed as well as other process options like placing your order on hold or adding a comment. ",
+                      "properties" : {
+                        "attributename" : {
+                          "type" : "string",
+                          "enum" : [ "Isdirectshiporder", "emailaddress", "Isbackorderflagallowed", "placeoncustomerhold", "signaturerequired", "commenttext", "resellerctacemail", "duplicatecustomerordernumbervalidate", "quotenumber", "shipctacphone", "vendauthnumber", "continueonerror" ]
+                        },
+                        "attributevalue" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "required" : [ "customerponumber", "ordertype", "shiptoaddress", "lines" ]
+              }
+            },
+            "required" : [ "requestpreamble" ]
+          }
+        }
+      },
+      "orderCreateResponse" : {
+        "title" : "orderCreate.Response",
+        "type" : "object",
+        "x-tags" : [ "orders" ],
+        "description" : "Response schema for order create endpoint",
+        "x-examples" : { },
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responsestatus" : {
+                    "type" : "string"
+                  },
+                  "statuscode" : {
+                    "type" : "string"
+                  },
+                  "responsemessage" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "ordersummary" : {
+                "type" : "object",
+                "properties" : {
+                  "customerponumber" : {
+                    "type" : "string"
+                  },
+                  "totalorderamount" : {
+                    "type" : "string",
+                    "description" : "Total of all the orders including taxes and fees"
+                  },
+                  "totalordercreated" : {
+                    "type" : "string",
+                    "description" : "Number of orders created, in some cases we may create more than one order."
+                  },
+                  "shiptoaddress" : {
+                    "type" : "object",
+                    "properties" : {
+                      "attention" : {
+                        "type" : "string"
+                      },
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "addressline1" : {
+                        "type" : "string"
+                      },
+                      "addressline2" : {
+                        "type" : "string"
+                      },
+                      "addressline3" : {
+                        "type" : "string"
+                      },
+                      "city" : {
+                        "type" : "string"
+                      },
+                      "state" : {
+                        "type" : "string"
+                      },
+                      "postalcode" : {
+                        "type" : "string"
+                      },
+                      "countrycode" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "ordercreateresponse" : {
+                "type" : "array",
+                "description" : "Collection of orders",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "numberoflineswithsuccess" : {
+                      "type" : "string",
+                      "description" : "Number of line items that were successful"
+                    },
+                    "numberoflineswitherror" : {
+                      "type" : "string",
+                      "description" : "Number of line items with error"
+                    },
+                    "numberoflineswithwarning" : {
+                      "type" : "string",
+                      "description" : "Number of line items with warnings"
+                    },
+                    "globalorderid" : {
+                      "type" : "string",
+                      "description" : "Ingram sales order number"
+                    },
+                    "ordertype" : {
+                      "type" : "string",
+                      "description" : "S=Stocked PO D=Direct Ship PO",
+                      "enum" : [ "S", "D" ]
+                    },
+                    "ordertimestamp" : {
+                      "type" : "string",
+                      "description" : "Time order received"
+                    },
+                    "invoicingsystemorderid" : {
+                      "type" : "string",
+                      "description" : "Ingram Micro generated order number"
+                    },
+                    "taxamount" : {
+                      "type" : "number"
+                    },
+                    "freightamount" : {
+                      "type" : "number",
+                      "description" : "Freight amount customer pays for freight"
+                    },
+                    "orderamount" : {
+                      "type" : "number",
+                      "description" : "Total amount of order with freight and taxes"
+                    },
+                    "Lines" : {
+                      "type" : "array",
+                      "description" : "Collection of lines",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "linetype" : {
+                            "type" : "string",
+                            "description" : "“P”-Line or SKU Number “C”-Comment Line"
+                          },
+                          "globallinenumber" : {
+                            "type" : "string",
+                            "description" : "Ingram generated line number"
+                          },
+                          "partnumber" : {
+                            "type" : "string",
+                            "description" : "Ingram Micro Sku Number"
+                          },
+                          "globalskuid" : {
+                            "type" : "string"
+                          },
+                          "linenumber" : {
+                            "type" : "string"
+                          },
+                          "carriercode" : {
+                            "type" : "string",
+                            "description" : "Transportation 2 digit codes"
+                          },
+                          "carrierdescription" : {
+                            "type" : "string",
+                            "description" : "Transportation Carrier Name"
+                          },
+                          "requestedunitprice" : {
+                            "type" : "number",
+                            "description" : "Price requested by reseller. Price Variance can be set up by Ingram Micro Sales Rep"
+                          },
+                          "requestedquantity" : {
+                            "type" : "integer",
+                            "description" : "Quanity Requested"
+                          },
+                          "confirmedquantity" : {
+                            "type" : "integer",
+                            "description" : "Quanity Shipped"
+                          },
+                          "backorderedquantity" : {
+                            "type" : "integer",
+                            "description" : "Quanity of units that didn’t ship"
+                          },
+                          "unitproductprice" : {
+                            "type" : "number",
+                            "description" : "Price Per Unit"
+                          },
+                          "netamount" : {
+                            "type" : "number",
+                            "description" : "Total amount. Quantity X Unit Price"
+                          },
+                          "warehouseid" : {
+                            "type" : "string"
+                          },
+                          "ordersuffix" : {
+                            "type" : "string",
+                            "description" : "Use order suffix with the globalorderid for this line item."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "orderDetailResponse" : {
+        "title" : "orderDetail.Response",
+        "type" : "object",
+        "x-tags" : [ "orders" ],
+        "description" : "Response schema for order details endpoint",
+        "x-examples" : {
+          "Example" : {
+            "serviceresponse" : {
+              "responsepreamble" : {
+                "responsestatus" : "SUCCESS"
+              },
+              "orderdetailresponse" : {
+                "ordernumber" : "10-12345",
+                "customerordernumber" : "test order",
+                "enduserponumber" : "ABC",
+                "orderstatus" : "INVOICED",
+                "entrytimestamp" : "2018-07-15T04:31:42-07:00",
+                "entrymethoddescription" : "XML/PCG",
+                "fulfilmentordercode" : "Y",
+                "ordertotalvalue" : 3907.38,
+                "ordersubtotal" : 3907.38,
+                "freightamount" : 141.34,
+                "currencycode" : "USD",
+                "totalweight" : "86",
+                "totaltax" : "0",
+                "billtoaddress" : {
+                  "suffix" : "000",
+                  "name" : "Ingram Micro",
+                  "addressline1" : "123 Ingram Way",
+                  "addressline2" : null,
+                  "addressline3" : null,
+                  "city" : "Irvine",
+                  "state" : "CA",
+                  "postalcode" : "12345000",
+                  "countrycode" : "US"
+                },
+                "shiptoaddress" : {
+                  "name" : "Mr Customer",
+                  "addressline1" : "123 Main St",
+                  "city" : "Anywhere",
+                  "state" : "CA",
+                  "postalcode" : "12345000",
+                  "countrycode" : "US"
+                },
+                "lines" : [ {
+                  "globallinenumber" : "001",
+                  "ordersuffix" : "11",
+                  "linestatus" : "INVOICED",
+                  "partnumber" : "3AM612",
+                  "manufacturerpartnumber" : "QN75Q8FNBFXZA",
+                  "vendorname" : "SAMSUNG - CONSUMER TV",
+                  "partdescription1" : "75IN Q8 FLAT 4K UHD HDR SMARTTV",
+                  "partdescription2" : "FULL ARRAY BACKLIGHTIN CLEAN CABLE",
+                  "freeitempromoflag" : "false",
+                  "unitweight" : "75",
+                  "unitprice" : 50000.48,
+                  "foreignunitprice" : 0,
+                  "extendedprice" : 5000.48,
+                  "foreignextendedprice" : 0,
+                  "taxamount" : 0,
+                  "requestedquantity" : "1",
+                  "confirmedquantity" : "1",
+                  "backorderquantity" : "0",
+                  "promisedate" : "2018-07-15",
+                  "shipmentdetails" : [ {
+                    "quantity" : 1,
+                    "shipmentdate" : "2018-07-16",
+                    "shipfromwarehouseid" : "40",
+                    "warehousename" : "Carol Stream, IL",
+                    "invoicenumber" : "1234511",
+                    "invoicedate" : "2018-07-16",
+                    "status" : "I",
+                    "statusdescription" : "INVOICED",
+                    "shippeddate" : "2018-07-16",
+                    "carriercode" : "AY",
+                    "carriername" : "ORD4708752",
+                    "packagedetails" : {
+                      "trackingnumber" : 6838019,
+                      "packageweight" : 80,
+                      "cartonnumber" : "001",
+                      "quantityinbox" : "0000001"
+                    }
+                  } ],
+                  "erpordernumber" : "10-12345-11",
+                  "vendorcode" : "Q012",
+                  "isacopapplied" : "N",
+                  "adjustedcost" : "5000.09",
+                  "serialnumberdetails" : {
+                    "serialnumber" : "07AS3CAK500682"
+                  },
+                  "productextendedspecs" : {
+                    "attributename" : "commenttext",
+                    "attributevalue" : "FULL ARRAY BACKLIGHTIN CLEAN CABLE"
+                  }
+                }, {
+                  "globallinenumber" : "002",
+                  "ordersuffix" : "21",
+                  "linestatus" : "INVOICED",
+                  "partnumber" : "2GH590",
+                  "manufacturerpartnumber" : "F-ADT-STR-KT-1",
+                  "vendorname" : "SAMSUNG - SMART THINGS",
+                  "partdescription1" : "ADT HOME SECURITY STARTER KIT",
+                  "partdescription2" : "SECURITY STARTER KIT",
+                  "freeitempromoflag" : "false",
+                  "unitweight" : "5.15",
+                  "unitprice" : 500.9,
+                  "foreignunitprice" : 0,
+                  "extendedprice" : 500.9,
+                  "foreignextendedprice" : 0,
+                  "taxamount" : 0,
+                  "requestedquantity" : "1",
+                  "confirmedquantity" : "1",
+                  "backorderquantity" : "0",
+                  "promisedate" : "2018-07-15",
+                  "shipmentdetails" : [ {
+                    "quantity" : 1,
+                    "shipmentdate" : "2018-07-17",
+                    "shipfromwarehouseid" : "80",
+                    "warehousename" : "Jonestown, PA",
+                    "invoicenumber" : "1234521",
+                    "invoicedate" : "2018-07-16",
+                    "status" : "I",
+                    "statusdescription" : "INVOICED",
+                    "shippeddate" : "2018-07-17",
+                    "carriercode" : "RG",
+                    "carriername" : "FEDEX GROUND",
+                    "packagedetails" : {
+                      "trackingnumber" : "017136225260674",
+                      "packageweight" : "000000006",
+                      "cartonnumber" : "001",
+                      "quantityinbox" : "0000001"
+                    }
+                  } ],
+                  "erpordernumber" : "10-12345-21",
+                  "vendorcode" : "QG64",
+                  "isacopapplied" : "N",
+                  "adjustedcost" : "400.99",
+                  "productextendedspecs" : {
+                    "attributename" : "commenttext",
+                    "attributevalue" : "SECURITY STARTER KIT"
+                  }
+                } ],
+                "extendedspecs" : [ {
+                  "attributename" : "termscode",
+                  "attributevalue" : "300"
+                }, {
+                  "attributename" : "termsdescription",
+                  "attributevalue" : "NET 30 DAYS"
+                }, {
+                  "attributename" : "commenttext",
+                  "attributevalue" : "PHONE:7148675309"
+                }, {
+                  "attributename" : "commenttext",
+                  "attributevalue" : "PHONE:7148675309"
+                } ],
+                "ordertype" : "S",
+                "erpid" : null
+              }
+            }
+          }
+        },
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responsestatus" : {
+                    "type" : "string"
+                  },
+                  "statuscode" : {
+                    "type" : "string"
+                  },
+                  "responsemessage" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "orderdetailresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "ordernumber" : {
+                    "type" : "string"
+                  },
+                  "ordertype" : {
+                    "type" : "string",
+                    "description" : "Order Type\t\t\nB - BRANCH TRANSFER\nC - CASH ORDER\nD - DIRECT ORDER\nF - FUTURE ORDER\nP - SPECIAL ORDER\nQ - QUOTE ORDER\nS - STOCK ORDER\nM - MEMO ORDER"
+                  },
+                  "customerordernumber" : {
+                    "type" : "string",
+                    "description" : "Customer PO number"
+                  },
+                  "enduserponumber" : {
+                    "type" : "string",
+                    "description" : "End User PO number"
+                  },
+                  "orderstatus" : {
+                    "type" : "string",
+                    "description" : "Status of order within Ingram system\nS - SALES HOLD\nH - TAG HOLD\nI - INVOICED\nP - PENDING\nE - BILLING ERROR\nF - FORCE BILLING\nV - VOIDED\nT - TRANSFERRED\nD - HOLD SHIPMENT\nR - RELEASED\nO - IM ONLINE HOLD\nU - BILL FOR HISTORY ONLY\nW - ORDER NOT PRINTED\nA - DROP SHIP HOLD\nB - INTERNET CUST ORIG HOLD\n1 - PICKED\n2 - INSPECTED\n3 - PACKED\n4 - SHIPPED\nC - CREDIT HOLD\n9 - CISCO 3A6\nQ - RMA HOLD\nG - CREDIT HOLD\nN - CREDIT HOLD"
+                  },
+                  "entrytimestamp" : {
+                    "type" : "string",
+                    "description" : "Time stamp of the order placed"
+                  },
+                  "entrymethoddescription" : {
+                    "type" : "string",
+                    "description" : "Description of the entry method\t"
+                  },
+                  "ordertotalvalue" : {
+                    "type" : "number",
+                    "description" : "Total order value"
+                  },
+                  "ordersubtotal" : {
+                    "type" : "number",
+                    "description" : "Subtotal order value"
+                  },
+                  "freightamount" : {
+                    "type" : "string",
+                    "description" : "Freight charges"
+                  },
+                  "currencycode" : {
+                    "type" : "string",
+                    "description" : "Country specific currency code"
+                  },
+                  "totalweight" : {
+                    "type" : "string",
+                    "description" : "Total order weight. unit -- North america - Pounds , other countries will be KG"
+                  },
+                  "totaltax" : {
+                    "type" : "string",
+                    "description" : "total tax on the orders placed"
+                  },
+                  "billtoaddress" : {
+                    "type" : "object",
+                    "properties" : {
+                      "suffix" : {
+                        "type" : "string"
+                      },
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "attention" : {
+                        "type" : "string"
+                      },
+                      "addressline1" : {
+                        "type" : "string"
+                      },
+                      "addressline2" : {
+                        "type" : "string"
+                      },
+                      "addressline3" : {
+                        "type" : "string"
+                      },
+                      "city" : {
+                        "type" : "string"
+                      },
+                      "state" : {
+                        "type" : "string"
+                      },
+                      "postalcode" : {
+                        "type" : "string"
+                      },
+                      "countrycode" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "shiptoaddress" : {
+                    "type" : "object",
+                    "properties" : {
+                      "suffix" : {
+                        "type" : "string"
+                      },
+                      "attention" : {
+                        "type" : "string"
+                      },
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "addressline1" : {
+                        "type" : "string"
+                      },
+                      "addressline2" : {
+                        "type" : "string"
+                      },
+                      "addressline3" : {
+                        "type" : "string"
+                      },
+                      "city" : {
+                        "type" : "string"
+                      },
+                      "state" : {
+                        "type" : "string"
+                      },
+                      "postalcode" : {
+                        "type" : "string"
+                      },
+                      "countrycode" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "enduserinfo" : {
+                    "type" : "object",
+                    "properties" : {
+                      "enduserid" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "lines" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "linenumber" : {
+                          "type" : "string",
+                          "description" : "Impulse line number"
+                        },
+                        "globallinenumber" : {
+                          "type" : "string",
+                          "description" : "Line of the Globel Sku / Customer Line Number"
+                        },
+                        "ordersuffix" : {
+                          "type" : "string",
+                          "description" : "Order Suffix"
+                        },
+                        "erpordernumber" : {
+                          "type" : "string",
+                          "description" : "Sales order number"
+                        },
+                        "linestatus" : {
+                          "type" : "string",
+                          "description" : "Status of the line"
+                        },
+                        "partnumber" : {
+                          "type" : "string",
+                          "description" : "Ingram part number"
+                        },
+                        "manufacturerpartnumber" : {
+                          "type" : "string",
+                          "description" : "manufacture number of the product"
+                        },
+                        "vendorname" : {
+                          "type" : "string",
+                          "description" : "name of the vendor"
+                        },
+                        "vendorcode" : {
+                          "type" : "string",
+                          "description" : "Ingram Micro assigned code for the vendor"
+                        },
+                        "partdescription1" : {
+                          "type" : "string"
+                        },
+                        "partdescription2" : {
+                          "type" : "string"
+                        },
+                        "unitweight" : {
+                          "type" : "string",
+                          "description" : "weight of the product unit"
+                        },
+                        "unitprice" : {
+                          "type" : "number",
+                          "description" : "Customer price of the unit"
+                        },
+                        "extendedprice" : {
+                          "type" : "number",
+                          "description" : "extended price of the order"
+                        },
+                        "taxamount" : {
+                          "type" : "number",
+                          "description" : "tax amount for the order"
+                        },
+                        "requestedquantity" : {
+                          "type" : "string",
+                          "description" : "no. of units requested"
+                        },
+                        "confirmedquantity" : {
+                          "type" : "string",
+                          "description" : "no. of units confirmed available"
+                        },
+                        "backorderquantity" : {
+                          "type" : "string",
+                          "description" : "quantity of back order"
+                        },
+                        "serialnumberdetails" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "properties" : {
+                              "serialnumber" : {
+                                "type" : "string",
+                                "description" : "serial number of the ordered SKU"
+                              }
+                            }
+                          }
+                        },
+                        "trackingnumber" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "string",
+                            "description" : "Tracking number of the order. If carriername is LTL then the tracking info is in the \"pronumber\" data field"
+                          }
+                        },
+                        "shipmentdetails" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "properties" : {
+                              "quantity" : {
+                                "type" : "number",
+                                "description" : "quantity shipped"
+                              },
+                              "shipmentdate" : {
+                                "type" : "string",
+                                "description" : "date of shipment"
+                              },
+                              "shipfromwarehouseid" : {
+                                "type" : "string",
+                                "description" : "Warehouse product was shipped from"
+                              },
+                              "warehousename" : {
+                                "type" : "string",
+                                "description" : "name of the warehouse"
+                              },
+                              "invoicenumber" : {
+                                "type" : "string",
+                                "description" : "Invoice Number"
+                              },
+                              "invoicedate" : {
+                                "type" : "string",
+                                "description" : "date on the invoice generated"
+                              },
+                              "status" : {
+                                "type" : "string",
+                                "description" : "code for current Status of the order"
+                              },
+                              "statusdescription" : {
+                                "type" : "string",
+                                "description" : "Description of status"
+                              },
+                              "shippeddate" : {
+                                "type" : "string",
+                                "description" : "date of shipment"
+                              },
+                              "holdreasoncodedescription" : {
+                                "type" : "string",
+                                "description" : "Description of the code if the order is on hold"
+                              },
+                              "ponumber" : {
+                                "type" : "string",
+                                "description" : "Ingram PO Number to vendors for direct ship orders"
+                              },
+                              "carriertype" : {
+                                "type" : "string",
+                                "description" : "Helps to determine shipment type. for e.g. LTL is used for heavy shipment. SML is used for light shipment"
+                              },
+                              "carriercode" : {
+                                "type" : "string",
+                                "description" : ""
+                              },
+                              "carriername" : {
+                                "type" : "string",
+                                "description" : "Name of the carrier. If carriername is LTL then the tracking info is in the \"pronumber\" data field"
+                              },
+                              "pronumber" : {
+                                "type" : "string",
+                                "description" : ""
+                              },
+                              "packagedetails" : {
+                                "type" : "object",
+                                "properties" : {
+                                  "trackingnumber" : {
+                                    "type" : "string"
+                                  },
+                                  "packageweight" : {
+                                    "type" : "string"
+                                  },
+                                  "cartonnumber" : {
+                                    "type" : "string"
+                                  },
+                                  "quantityinbox" : {
+                                    "type" : "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "productextendedspecs" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "properties" : {
+                              "attributename" : {
+                                "type" : "string"
+                              },
+                              "attributevalue" : {
+                                "type" : "string"
+                              }
+                            }
+                          }
+                        },
+                        "backorderetadate" : {
+                          "type" : "string",
+                          "description" : "estimated date of back order"
+                        }
+                      }
+                    }
+                  },
+                  "commentlines" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "commenttext1" : {
+                          "type" : "string"
+                        },
+                        "commenttext2" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  },
+                  "miscfeeline" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "description" : {
+                          "type" : "string",
+                          "description" : "Handling charges/Miscellaneous Fee description"
+                        },
+                        "chargeamount" : {
+                          "type" : "string",
+                          "description" : "Handling charges/ Miscelaneous fee amount"
+                        }
+                      }
+                    }
+                  },
+                  "extendedspecs" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "attributename" : {
+                          "type" : "string",
+                          "description" : "termscode' | 'termsdescription' | 'commenttext' are the atrribute name"
+                        },
+                        "attributevalue" : {
+                          "type" : "string",
+                          "description" : "values of these fields are send . termscode' | 'termsdescription' | 'commenttext' are the atrribute name"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "orderCancelResponse" : {
+        "title" : "orderCancel.Response",
+        "type" : "object",
+        "x-tags" : [ "orders" ],
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "requestStatus" : {
+                    "type" : "string"
+                  },
+                  "returnCode" : {
+                    "type" : "string"
+                  },
+                  "returnMessage" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description" : "Response schema for order delete endpoint",
+        "x-examples" : { }
+      },
+      "orderSearchResponse" : {
+        "title" : "orderSearch.Response",
+        "type" : "object",
+        "description" : "Response schema for order search endpoint",
+        "x-tags" : [ "orders" ],
+        "properties" : {
+          "serviceResponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "requeststatus" : {
+                    "type" : "string"
+                  },
+                  "returnmessage" : {
+                    "type" : "string"
+                  }
+                },
+                "required" : [ "requeststatus", "returnmessage" ]
+              },
+              "ordersearchresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "ordersfound" : {
+                    "type" : "string",
+                    "description" : "Number of records found in the search result"
+                  },
+                  "pagesize" : {
+                    "type" : "string",
+                    "description" : "The submitted pagesize, default is 25"
+                  },
+                  "pagenumber" : {
+                    "type" : "string",
+                    "description" : "The submitted pager number, default is 1"
+                  },
+                  "orders" : {
+                    "type" : "array",
+                    "description" : "An array of orders in the search result",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "ordernumber" : {
+                          "type" : "string",
+                          "description" : "Ingram micro sales order number"
+                        },
+                        "entrytimestamp" : {
+                          "type" : "string",
+                          "description" : "The order creation date-time in UTC format"
+                        },
+                        "customerordernumber" : {
+                          "type" : "string",
+                          "description" : "PO/Order number submitted while creating the order"
+                        },
+                        "suborders" : {
+                          "type" : "array",
+                          "description" : "An order MAY get divided into various sub orders, for example if the SKUs are being shipped from different warehouse.",
+                          "items" : {
+                            "type" : "object",
+                            "properties" : {
+                              "subordernumber" : {
+                                "type" : "string",
+                                "description" : "A sub order number"
+                              },
+                              "statuscode" : {
+                                "type" : "string",
+                                "description" : "Order status code"
+                              },
+                              "status" : {
+                                "type" : "string",
+                                "description" : "Details of the order statuscode - i.e. statuscode = 4 then status = SHIPPED"
+                              },
+                              "holdreasoncode" : {
+                                "type" : "string",
+                                "description" : "Will be returned in case of order on hold"
+                              },
+                              "holdreason" : {
+                                "type" : "string",
+                                "description" : "Reason for order hold - will be returned if the order is on hold"
+                              },
+                              "links" : {
+                                "type" : "array",
+                                "description" : "HATEOAS links for the details and invoices of the sub-orders if available",
+                                "items" : {
+                                  "type" : "object",
+                                  "properties" : {
+                                    "topic" : {
+                                      "type" : "string",
+                                      "enum" : [ "orders", "invoices" ],
+                                      "description" : "topic being orders or invoices, if it is orders then the link will provide details of the order. If its invoices then the link provides details of the invoice"
+                                    },
+                                    "href" : {
+                                      "type" : "string",
+                                      "format" : "uri",
+                                      "description" : "The API endpoint for accessing the relevant data"
+                                    },
+                                    "type" : {
+                                      "type" : "string",
+                                      "enum" : [ "GET", "POST", "PUT" ],
+                                      "description" : "The type of call that can be made to the href link"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "links" : {
+                          "type" : "object",
+                          "description" : "HATEOAS links for the main order",
+                          "properties" : {
+                            "topic" : {
+                              "type" : "string",
+                              "description" : "Topic being orders in this case, if it is orders then the link will provide details of the order.",
+                              "enum" : [ "orders", "invoices" ]
+                            },
+                            "href" : {
+                              "type" : "string",
+                              "description" : "The API endpoint for accessing the relevant data",
+                              "format" : "uri"
+                            },
+                            "type" : {
+                              "type" : "string",
+                              "description" : "The type of call that can be made to the href link",
+                              "enum" : [ "GET", "POST", "PUT" ]
+                            }
+                          }
+                        }
+                      },
+                      "required" : [ "ordernumber", "entrytimestamp" ]
+                    }
+                  }
+                },
+                "required" : [ "ordersfound" ]
+              }
+            }
+          }
+        }
+      },
+      "productSearchResponse" : {
+        "title" : "productSearch.Response",
+        "type" : "object",
+        "description" : "Response object model for the product search endpoint",
+        "x-tags" : [ "product catalog" ],
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "requeststatus" : {
+                    "type" : "string"
+                  },
+                  "returncode" : {
+                    "type" : "string"
+                  },
+                  "returnmessage" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "productsearchresponse" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "responseflag" : {
+                      "type" : "string",
+                      "description" : "Number of records in the search result."
+                    },
+                    "partnumbers" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "ingrampartnumber" : {
+                            "type" : "string",
+                            "description" : "Ingram Part Number"
+                          },
+                          "manufacturerpartnumber" : {
+                            "type" : "string",
+                            "description" : "Vendor or Manufacturer Part Number"
+                          },
+                          "upccode" : {
+                            "type" : "string",
+                            "description" : "UPC"
+                          },
+                          "productdescription" : {
+                            "type" : "string",
+                            "description" : "Product description"
+                          },
+                          "currency" : {
+                            "type" : "string"
+                          },
+                          "haswarranty" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "priceAndAvailabilityRequest" : {
+        "title" : "priceAndAvailability.Request",
+        "type" : "object",
+        "description" : "Request object model for the multi sku price and stock API endpoint",
+        "x-examples" : {
+          "Example" : {
+            "servicerequest" : {
+              "requestpreamble" : {
+                "customernumber" : "20-222222",
+                "isocountrycode" : "US"
+              },
+              "priceandstockrequest" : {
+                "showwarehouseavailability" : "True",
+                "extravailabilityflag" : "Y",
+                "item" : [ {
+                  "ingrampartnumber" : "M93592",
+                  "quantity" : 1
+                } ],
+                "includeallsystems" : false
+              }
+            }
+          }
+        },
+        "x-tags" : [ "product catalog" ],
+        "properties" : {
+          "servicerequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "isocountrycode" : {
+                    "type" : "string",
+                    "description" : "2 Digit ISO country code",
+                    "example" : "US",
+                    "minLength" : 2,
+                    "maxLength" : 2
+                  },
+                  "customernumber" : {
+                    "type" : "string",
+                    "description" : "Your Ingram Micro customer number",
+                    "example" : "12-34567 or 12-345678 or 123456 "
+                  }
+                },
+                "required" : [ "isocountrycode", "customernumber" ]
+              },
+              "priceandstockrequest" : {
+                "type" : "object",
+                "properties" : {
+                  "showwarehouseavailability" : {
+                    "type" : "string",
+                    "description" : "True/false to show the availability of individual warehouses"
+                  },
+                  "extravailabilityflag" : {
+                    "type" : "string",
+                    "description" : "Y/N to show extra availability flag"
+                  },
+                  "includeallsystems" : {
+                    "type" : "boolean",
+                    "description" : "Flag to indicate if the price and stock information is required for all Ingram Micro systems."
+                  },
+                  "item" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "index" : {
+                          "type" : "integer"
+                        },
+                        "ingrampartnumber" : {
+                          "type" : "string",
+                          "description" : "Ingram Micro SKU number"
+                        },
+                        "vendorpartnumber" : {
+                          "type" : "string",
+                          "description" : "Vendor/Manufacture Part Number"
+                        },
+                        "upc" : {
+                          "type" : "string",
+                          "description" : "Universal Product code"
+                        },
+                        "customerpartnumber" : {
+                          "type" : "string",
+                          "description" : "Unique identoifier for the customer, needs custom setup."
+                        },
+                        "warehouseidlist" : {
+                          "type" : "array",
+                          "description" : "Unique identity for Ingram Micro warehouses against which stock details are returned.",
+                          "items" : {
+                            "type" : "string"
+                          }
+                        },
+                        "extendedvendorpartnumber" : {
+                          "type" : "string"
+                        },
+                        "quantity" : {
+                          "type" : "number"
+                        },
+                        "enduserid" : {
+                          "type" : "string"
+                        },
+                        "govtprogramtype" : {
+                          "type" : "string"
+                        },
+                        "govtendusertype" : {
+                          "type" : "string"
+                        },
+                        "specialbidnumber" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "priceAndAvailabilityResponse" : {
+        "title" : "priceAndAvailability.Response",
+        "type" : "object",
+        "x-examples" : {
+          "Success" : {
+            "serviceresponse" : {
+              "responsepreamble" : {
+                "responsestatus" : "SUCCESS",
+                "statuscode" : "200",
+                "responsemessage" : "Data Found"
+              },
+              "priceandstockresponse" : {
+                "details" : [ {
+                  "itemstatus" : "SUCCESS",
+                  "statusmessage" : "A-No qty breaks availa",
+                  "ingrampartnumber" : "TB6489",
+                  "vendorpartnumber" : "H1180HD",
+                  "globalskuid" : "A300-TB6489",
+                  "customerprice" : 850.54,
+                  "currency" : "USD",
+                  "partdescription1" : "H1180HD DLP 3D PROJ 2000L 1080PPROJ",
+                  "partdescription2" : "10000:1 VGA HDMI RCA",
+                  "vendornumber" : "Q680",
+                  "vendorname" : "VIVITEK",
+                  "cpucode" : "DLP-PR",
+                  "class" : "X",
+                  "skustatus" : "ACTIVE",
+                  "mediacpu" : "PROJ  DLP-PR",
+                  "categorysubcategory" : "04  25",
+                  "retailprice" : 899,
+                  "newmedia" : "PROJ",
+                  "backorderflag" : "N",
+                  "skuauthorized" : "Y",
+                  "warehousedetails" : [ {
+                    "warehouseid" : "80",
+                    "warehousedescription" : "Jonestown, PA",
+                    "availablequantity" : 0,
+                    "onorderquantity" : 0
+                  }, {
+                    "warehouseid" : "10",
+                    "warehousedescription" : "Mira Loma, CA",
+                    "availablequantity" : 0,
+                    "onorderquantity" : 0
+                  } ]
+                } ]
+              }
+            }
+          },
+          "Invalid Customer" : {
+            "serviceresponse" : {
+              "responsepreamble" : {
+                "responsestatus" : "FAILED",
+                "statuscode" : "500",
+                "responsemessage" : "Data Not Found"
+              },
+              "priceandstockresponse" : {
+                "details" : [ {
+                  "itemstatus" : "FAILED",
+                  "statusmessage" : "E-INVALID CUSTOMER NUMBER"
+                }, {
+                  "itemstatus" : "FAILED",
+                  "statusmessage" : "E-INVALID CUSTOMER NUMBER"
+                }, {
+                  "itemstatus" : "FAILED",
+                  "statusmessage" : "E-INVALID CUSTOMER NUMBER"
+                } ]
+              }
+            }
+          },
+          "Invalid Country " : {
+            "serviceresponse" : {
+              "responsepreamble" : {
+                "responsestatus" : "SUCCESSWITHERROR",
+                "statuscode" : "046",
+                "responsemessage" : "Partial Data Found"
+              },
+              "priceandstockresponse" : {
+                "details" : [ {
+                  "itemstatus" : "SUCCESS",
+                  "statusmessage" : "edv 2",
+                  "ingrampartnumber" : "NaN",
+                  "vendorpartnumber" : null,
+                  "globalskuid" : "A001-NaN",
+                  "customernumber" : "41-231791",
+                  "quantity" : 0,
+                  "customerprice" : 0,
+                  "vendornumber" : "NaN",
+                  "retailprice" : 0,
+                  "enduserrequired" : "false",
+                  "specialpromoflag" : "false",
+                  "isavailable" : false,
+                  "isstocakable" : false,
+                  "isbom" : false,
+                  "hasquantitybreaks" : false,
+                  "haswebdiscounts" : false,
+                  "issboprice" : false,
+                  "extendednetamount" : 0,
+                  "taxamount" : 0,
+                  "totalfeeamount" : 0,
+                  "totalpromotionamount" : 0,
+                  "totalenvironmentalfees" : 0
+                } ]
+              }
+            }
+          }
+        },
+        "x-tags" : [ "product catalog" ],
+        "description" : "Response object model for the multi sku price and stock API endpoint",
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responsestatus" : {
+                    "type" : "string",
+                    "description" : "SUCCESS or FAILED, sometimes PARTIAL SUCCESS if connection to 1 of the systems fails"
+                  },
+                  "responsemessage" : {
+                    "type" : "string",
+                    "description" : "Overall status message including error message"
+                  },
+                  "statuscode" : {
+                    "type" : "string",
+                    "description" : "Statuscode Message"
+                  }
+                }
+              },
+              "priceandstockresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "details" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "itemstatus" : {
+                          "type" : "string",
+                          "description" : "SUCCESS or FAILED",
+                          "enum" : [ "SUCCESS", "FAILED" ]
+                        },
+                        "statusmessage" : {
+                          "type" : "string",
+                          "description" : "Description of itemstatus"
+                        },
+                        "ingrampartnumber" : {
+                          "type" : "string",
+                          "description" : "Ingram Micro part number"
+                        },
+                        "vendorpartnumber" : {
+                          "type" : "string",
+                          "description" : "Manufacturer/Vendor part number"
+                        },
+                        "globalskuid" : {
+                          "type" : "string"
+                        },
+                        "customerprice" : {
+                          "type" : "number",
+                          "description" : "Customer specific price for the product, excluding taxes"
+                        },
+                        "partdescription1" : {
+                          "type" : "string",
+                          "description" : "Product description part 1"
+                        },
+                        "partdescription2" : {
+                          "type" : "string",
+                          "description" : "Product description part 2"
+                        },
+                        "vendornumber" : {
+                          "type" : "string"
+                        },
+                        "vendorname" : {
+                          "type" : "string",
+                          "description" : "Name of the vendor"
+                        },
+                        "cpucode" : {
+                          "type" : "string"
+                        },
+                        "class" : {
+                          "type" : "string",
+                          "description" : "Ingram Micro assigned product classification - \nA-Stocked product in all IM warehouses, B-Limited stock in IM warehouses, C-Stocked in fewer wareshouses, D-Ingram discontinued, E-Planned to be phased out as per the vendor, F-Carried for specific customer as per the contract, N-New SKU, O-Discontinued to be liquidated, S-Order for specialized demand, V-Discontinued by vendor, X-Direct Ship products from vendor",
+                          "enum" : [ "A", "B", "C", "D", "E", "F", "N", "O", "S", "V", "X" ]
+                        },
+                        "skustatus" : {
+                          "type" : "string",
+                          "description" : "Identifies if the SKU has been discontinued.",
+                          "enum" : [ "ACTIVE" ]
+                        },
+                        "mediacpu" : {
+                          "type" : "string"
+                        },
+                        "categorysubcategory" : {
+                          "type" : "string"
+                        },
+                        "retailprice" : {
+                          "type" : "number"
+                        },
+                        "newmedia" : {
+                          "type" : "string"
+                        },
+                        "enduserrequired" : {
+                          "type" : "string",
+                          "description" : "Y - End user required N - Not required End user",
+                          "enum" : [ "Y", "N" ]
+                        },
+                        "backorderflag" : {
+                          "type" : "string",
+                          "description" : "Y- Allow Backorder Flag N- Not allowed",
+                          "enum" : [ "Y", "N" ]
+                        },
+                        "skuauthorized" : {
+                          "type" : "string"
+                        },
+                        "extendedvendorpartnumber" : {
+                          "type" : "string"
+                        },
+                        "warehousedetails" : {
+                          "type" : "array",
+                          "items" : {
+                            "$ref" : "#/components/schemas/warehouseListType"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "warehouseListType" : {
+        "title" : "priceAndAvailability.warehouseListType.Response",
+        "type" : "object",
+        "properties" : {
+          "warehouseid" : {
+            "type" : "string",
+            "description" : ""
+          },
+          "warehousedescription" : {
+            "type" : "string",
+            "description" : "City of the Ingram Micro warehouse location"
+          },
+          "availablequantity" : {
+            "type" : "integer",
+            "description" : "On hand available quantity"
+          },
+          "onorderquantity" : {
+            "type" : "integer",
+            "description" : "On Order quantity"
+          },
+          "onholdquantity" : {
+            "type" : "integer",
+            "description" : "On hold quantity"
+          },
+          "etadate" : {
+            "type" : "string"
+          }
+        }
+      },
+      "quoteListRequest" : {
+        "title" : "quoteList.Request",
+        "type" : "object",
+        "x-examples" : {
+          "Example" : {
+            "quoteSearchRequest" : {
+              "requestPreamble" : {
+                "customerNumber" : "40006990",
+                "customerContact" : "user.name@ingrampartner.com",
+                "isoCountryCode" : "US"
+              },
+              "retrieveQuoteRequest" : {
+                "quoteNumber" : "QUO-02973-V6H8R6",
+                "bidNumber" : "MDMF-1199371-1811",
+                "endUserName" : "CARESOURCE MANAGEMENT GROUP CO.",
+                "quoteStatus" : "3",
+                "fromDate" : "2019-09-01",
+                "toDate" : "2019-09-11",
+                "pageIndex" : 1,
+                "recordsPerPage" : 25,
+                "sorting" : "desc",
+                "sortingColumnName" : "createdon",
+                "thirdPartySource" : "3RDPIDCONWISE"
+              }
+            }
+          }
+        },
+        "description" : "Request schema for get quote list endpoint",
+        "x-tags" : [ "quotes" ],
+        "properties" : {
+          "quoteSearchRequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestPreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "customerNumber" : {
+                    "type" : "string",
+                    "description" : "Reseller Number (referred to as the account BCN) is the unique identifier for an Ingram Micro customer account.",
+                    "maxLength" : 10
+                  },
+                  "customerContact" : {
+                    "type" : "string",
+                    "description" : "Logged in User's email address.",
+                    "format" : "email"
+                  },
+                  "isoCountryCode" : {
+                    "type" : "string",
+                    "description" : "The ISO country codes are internationally recognized codes designated for each country represented by a two-letter combination (alpha-2).",
+                    "maxLength" : 3
+                  }
+                },
+                "required" : [ "customerNumber", "isoCountryCode" ]
+              },
+              "retrieveQuoteRequest" : {
+                "type" : "object",
+                "properties" : {
+                  "quoteNumber" : {
+                    "type" : "string",
+                    "description" : "Unique identifier generated by Ingram Micro's CRM specific to each quote. When applying a filter to the quoteNumber and including a partial quote number in the filter, all quotes containing any information included in the filter can be retrieved as a subset of all available customer quotes.",
+                    "maxLength" : 100
+                  },
+                  "bidNumber" : {
+                    "type" : "string",
+                    "description" : "Special Pricing Bid Number, also referred to as a Dart Number by some vendors, is a unique identifier associated with vendor specific products and discounts.",
+                    "maxLength" : 100
+                  },
+                  "endUserName" : {
+                    "type" : "string",
+                    "description" : "End User Name is the end customer name that is associated with a quote in Ingram Micro's CRM",
+                    "maxLength" : 300
+                  },
+                  "fromDate" : {
+                    "type" : "string",
+                    "description" : "Filter to select the beginning date of a desired date range. The default filter is set to the date the user is logged-in to request quotes. Date format: YYYY-MM-DD - An incorrect date input will result in a message \"Date must be entered as YYYY-MM-DD\"",
+                    "format" : "date",
+                    "example" : "2019-08-01"
+                  },
+                  "toDate" : {
+                    "type" : "string",
+                    "description" : "Filter to select the end date of a desired date range. The default number of days to request is the previous 30 days from the date user has logged in. Date format: YYYY-MM-DD - An incorrect date input will result in a message \"Date must be entered as YYYY-MM-DD\"",
+                    "format" : "date",
+                    "example" : "2019-11-01"
+                  },
+                  "pageIndex" : {
+                    "type" : "string",
+                    "description" : "Page index or page number for the list of quotes being returned. When less than 25 quotes are returned, the page number will be \"1\". In cases where more than 25 quotes are returned, and the default quotes per page are 25 (see recordPerPage), then the list will continue on subsequent pages."
+                  },
+                  "recordsPerPage" : {
+                    "type" : "string",
+                    "description" : "Number of records (quotes) to display per page in the quote list. The default is 25, but may be increased using the filter by up to 100 records per page. If more than 100 records are requested a message will be returned \"The number of records requested exceeds the 100 record limit.\"\t"
+                  },
+                  "sorting" : {
+                    "type" : "string",
+                    "description" : "Sort applies to the selected column (sortingColumnName) and may be specified in Ascending (asc) or Descending (desc) order. The default sort is Descending (desc) - most recent first.",
+                    "enum" : [ "asc", "desc" ]
+                  },
+                  "sortingColumnName" : {
+                    "type" : "string",
+                    "description" : "Refers to the column selected to apply the sorting criteria. The default column is dateCreated and will sort by the most recently created quote first with the following in descending order. The default filter retrieves quotes created within the last 30 days. Filtering allows user to select a specific column to sort: quoteNumber, createdDate, lastModifiedDate, expiryDate, and endUserName.",
+                    "example" : "toDate",
+                    "maxLength" : 100
+                  },
+                  "thirdPartySource" : {
+                    "type" : "string",
+                    "description" : "Unique identifier used to identify the third party source accessing the services.",
+                    "maxLength" : 100
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "quoteListResponse" : {
+        "title" : "quoteList.Response",
+        "type" : "object",
+        "x-examples" : {
+          "Success" : {
+            "quoteSearchResponse" : {
+              "responsePreamble" : {
+                "responseStatus" : "Passed",
+                "responseStatusCode" : "200",
+                "responseMessage" : "Records Found"
+              },
+              "quotelist" : [ {
+                "quoteGuid" : "dbabb2a5-02ea-e911-a97b-000d3a30e34c",
+                "quoteName" : "TEST-9771006-1920_CW EndUser11",
+                "quoteNumber" : "QUO-11048-S9P1R3",
+                "revisionNumber" : 0,
+                "endUserName" : "CW EndUser11",
+                "bidNumber" : "TEST-9771006-1920",
+                "totalAmount" : "60766.2",
+                "quoteStatus" : "Active",
+                "createdDate" : "2019-10-08",
+                "lastModifiedDate" : "2019-10-08",
+                "quoteExpiryDate" : "0001-01-01"
+              }, {
+                "quoteGuid" : "ec14fd96-02ea-e911-a98d-000d3a30e941",
+                "quoteName" : "TEST-9771006-1920_CW EndUser12",
+                "quoteNumber" : "QUO-11047-M1K1Z6",
+                "revisionNumber" : 0,
+                "endUserName" : "CW EndUser12",
+                "bidNumber" : "TEST-9771006-1920",
+                "totalAmount" : "60766.2",
+                "quoteStatus" : "Active",
+                "createdDate" : "2019-10-08",
+                "lastModifiedDate" : "2019-10-08",
+                "quoteExpiryDate" : "0001-01-01"
+              }, {
+                "quoteGuid" : "f3d7d186-02ea-e911-a98d-000d3a30e941",
+                "quoteName" : "TEST-9771006-1920_CW EndUser10",
+                "quoteNumber" : "QUO-11045-G1X9S8",
+                "revisionNumber" : 0,
+                "endUserName" : "CW EndUser10",
+                "bidNumber" : "TEST-9771006-1920",
+                "totalAmount" : "60766.2",
+                "quoteStatus" : "Active",
+                "createdDate" : "2019-10-08",
+                "lastModifiedDate" : "2019-10-08",
+                "quoteExpiryDate" : "0001-01-01"
+              }, {
+                "quoteGuid" : "43ae3e7f-02ea-e911-a97a-000d3a30eb04",
+                "quoteName" : "TEST-9771006-1920_CW EndUser9",
+                "quoteNumber" : "QUO-11044-V2F8F9",
+                "revisionNumber" : 0,
+                "endUserName" : "CW EndUser9",
+                "bidNumber" : "TEST-9771006-1920",
+                "totalAmount" : "60766.2",
+                "quoteStatus" : "Active",
+                "createdDate" : "2019-10-08",
+                "lastModifiedDate" : "2019-10-08",
+                "quoteExpiryDate" : "0001-01-01"
+              }, {
+                "quoteGuid" : "88062b6f-02ea-e911-a97a-000d3a30eb04",
+                "quoteName" : "TEST-9771006-1920_CW EndUser8",
+                "quoteNumber" : "QUO-11043-W2X1T5",
+                "revisionNumber" : 0,
+                "endUserName" : "CW EndUser8",
+                "bidNumber" : "TEST-9771006-1920",
+                "totalAmount" : "60766.2",
+                "quoteStatus" : "Active",
+                "createdDate" : "2019-10-08",
+                "lastModifiedDate" : "2019-10-08",
+                "quoteExpiryDate" : "0001-01-01"
+              } ],
+              "totalCount" : 5
+            }
+          },
+          "Customer Not Found" : {
+            "quoteSearchResponse" : {
+              "responsePreamble" : {
+                "responseStatus" : "Failed",
+                "responseStatusCode" : "400",
+                "responseMessage" : "Customer Not Found"
+              },
+              "totalCount" : 0
+            }
+          },
+          "Wrong sort column" : {
+            "quoteSearchResponse" : {
+              "responsePreamble" : {
+                "responseStatus" : "Failed",
+                "responseStatusCode" : "400",
+                "responseMessage" : "Provide valid sort column name"
+              },
+              "totalCount" : 0
+            }
+          }
+        },
+        "description" : "Response schema for get quote list endpoint",
+        "x-tags" : [ "quotes" ],
+        "properties" : {
+          "quoteSearchResponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsePreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responseStatus" : {
+                    "type" : "string",
+                    "description" : "Status of the Request - \"Passed\", \"Failed\""
+                  },
+                  "responseStatusCode" : {
+                    "type" : "string",
+                    "description" : "responseStatusCode is the code returned in response to a request. The following Codes are returned: 200 400 500"
+                  },
+                  "responseMessage" : {
+                    "type" : "string",
+                    "description" : "200 = Action was successfully received, understood and accepted. 400 = The request contains bad syntax or can not be fullfilled. This means there is a problem with the request. 500 = The server failed to fulfill an apparently valid request. This is a temporary problem, the request should be resubmitted."
+                  }
+                }
+              },
+              "quoteList" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "quoteName" : {
+                      "type" : "string",
+                      "description" : "Quote Name given to quote by sales team or system generated. Generally used as a reference to identify the quote."
+                    },
+                    "quoteNumber" : {
+                      "type" : "string",
+                      "description" : "Unique identifier generated by Ingram Micro's CRM specific to each quote. When applying a filter to the quoteNumber and including a partial quote number in the filter, all quotes containing any information included in the filter can be retrieved as a subset of all available customer quotes."
+                    },
+                    "revisionNumber" : {
+                      "type" : "integer",
+                      "description" : "When a quote has been revised and updated, the quote number remains the same throughout the lifecycle of the quote, however, a Revision number is updated for each revision of the quote. The revision numbers is associated with the Unique Quote Number."
+                    },
+                    "endUserName" : {
+                      "type" : "string",
+                      "description" : "End User Name is the end customer name that is associated with a quote in Ingram Micro's CRM"
+                    },
+                    "bidNumber" : {
+                      "type" : "string",
+                      "description" : "Special Pricing Bid Number, also refers to as Dart Number relates to a unique pricing deal associated with a vendor for the quote."
+                    },
+                    "totalAmount" : {
+                      "type" : "string",
+                      "description" : "Total amount of quoted price for all products in the quote."
+                    },
+                    "quoteStatus" : {
+                      "type" : "string",
+                      "description" : "This refers to the primary status of the quote. API responses will return: Active"
+                    },
+                    "createdDate" : {
+                      "type" : "string",
+                      "description" : "Date the Quote was initially Created",
+                      "format" : "date",
+                      "example" : "2019-10-08"
+                    },
+                    "lastModifiedDate" : {
+                      "type" : "string",
+                      "description" : "Date the Quote was last updated or modified.",
+                      "format" : "date",
+                      "example" : "2019-10-08"
+                    },
+                    "quoteExpiryDate" : {
+                      "type" : "string",
+                      "description" : "Date the Quote Expires",
+                      "format" : "date",
+                      "example" : "2019-10-08"
+                    }
+                  }
+                }
+              },
+              "totalCount" : {
+                "type" : "integer",
+                "description" : "Total count of quotes retrieved in the request response."
+              }
+            }
+          }
+        }
+      },
+      "quoteDetailsRequest" : {
+        "title" : "quoteDetails.Request",
+        "type" : "object",
+        "properties" : {
+          "quoteProductsRequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "customerNumber" : {
+                    "type" : "string",
+                    "description" : "Reseller Number (referred to as the account BCN) is the unique identifier for an Ingram Micro customer account."
+                  },
+                  "isoCountryCode" : {
+                    "type" : "string",
+                    "description" : "The ISO country codes are internationally recognized codes designated for each country represented by a two-letter combination (alpha-2)."
+                  }
+                },
+                "required" : [ "customerNumber", "isoCountryCode" ]
+              },
+              "retrieveQuoteProductsRequest" : {
+                "type" : "object",
+                "properties" : {
+                  "quoteNumber" : {
+                    "type" : "string",
+                    "description" : "Unique identifier generated by Ingram Micro's CRM specific to each quote. When applying a filter to the quoteNumber and including a partial quote number in the filter, all quotes containing any information included in the filter can be retrieved as a subset of all available customer quotes."
+                  },
+                  "thirdPartySource" : {
+                    "type" : "string",
+                    "description" : "Unique identifier used to identify the third party source accessing the services."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-examples" : {
+          "Example" : {
+            "quoteProductsRequest" : {
+              "requestPreamble" : {
+                "customerNumber" : "21222222",
+                "isoCountryCode" : "US"
+              },
+              "retrieveQuoteProductsRequest" : {
+                "quoteNumber" : "QUO-04959-C3V6L4",
+                "thirdPartySource" : "3RDPIDCONWISE"
+              }
+            }
+          }
+        },
+        "description" : "Request schema for get quote details endpoint",
+        "x-tags" : [ "quotes" ]
+      },
+      "quoteDetails" : {
+        "title" : "quoteDetails.Response",
+        "type" : "object",
+        "x-tags" : [ "quotes" ],
+        "properties" : {
+          "quoteDetailResponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsePreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responseStatus" : {
+                    "type" : "string"
+                  },
+                  "statusCode" : {
+                    "type" : "string"
+                  },
+                  "responseMessage" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "retrieveQuoteResponse" : {
+                "type" : "object",
+                "properties" : {
+                  "quoteGuid" : {
+                    "type" : "string"
+                  },
+                  "quoteName" : {
+                    "type" : "string"
+                  },
+                  "quoteNumber" : {
+                    "type" : "string"
+                  },
+                  "quoteExpiryDate" : {
+                    "type" : "string",
+                    "format" : "date",
+                    "example" : "2020-01-01"
+                  },
+                  "revisionNumber" : {
+                    "type" : "string"
+                  },
+                  "introPreamble" : {
+                    "type" : "string"
+                  },
+                  "purchaseInstructions" : {
+                    "type" : "string"
+                  },
+                  "legalTerms" : {
+                    "type" : "string"
+                  },
+                  "currencyCode" : {
+                    "type" : "string"
+                  },
+                  "priceDeviationId" : {
+                    "type" : "string"
+                  },
+                  "priceDeviationStartDate" : {
+                    "type" : "string",
+                    "format" : "date"
+                  },
+                  "priceDeviationExpiryDate" : {
+                    "type" : "string",
+                    "format" : "date"
+                  },
+                  "customerNeed" : {
+                    "type" : "string"
+                  },
+                  "solutionProposed" : {
+                    "type" : "string"
+                  },
+                  "status" : {
+                    "type" : "string"
+                  },
+                  "created" : {
+                    "type" : "string",
+                    "format" : "date",
+                    "example" : "2019-10-04"
+                  },
+                  "modified" : {
+                    "type" : "string",
+                    "format" : "date",
+                    "example" : "2019-10-04"
+                  },
+                  "leasingCalculations" : {
+                    "type" : "string"
+                  },
+                  "leasingInstructions" : {
+                    "type" : "string"
+                  },
+                  "accountInfo" : {
+                    "type" : "object",
+                    "properties" : {
+                      "accountName" : {
+                        "type" : "string"
+                      },
+                      "bcn" : {
+                        "type" : "string"
+                      },
+                      "phone" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "contactInfo" : {
+                    "type" : "object",
+                    "properties" : {
+                      "contactEmail" : {
+                        "type" : "string"
+                      },
+                      "contactName" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "vendorAttributes" : {
+                    "type" : "object",
+                    "properties" : {
+                      "estimateId" : {
+                        "type" : "string"
+                      },
+                      "dealId" : {
+                        "type" : "string"
+                      },
+                      "vendorName" : {
+                        "type" : "string"
+                      },
+                      "vendorSettingMessage" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "endUser" : {
+                    "type" : "object",
+                    "properties" : {
+                      "endUserName" : {
+                        "type" : "string"
+                      },
+                      "endUserAddress" : {
+                        "type" : "string"
+                      },
+                      "endUserAddress2" : {
+                        "type" : "string"
+                      },
+                      "endUserAddress3" : {
+                        "type" : "string"
+                      },
+                      "endUserCity" : {
+                        "type" : "string"
+                      },
+                      "endUserState" : {
+                        "type" : "string"
+                      },
+                      "endUserEmail" : {
+                        "type" : "string"
+                      },
+                      "endUserPhone" : {
+                        "type" : "string"
+                      },
+                      "endUserZipCode" : {
+                        "type" : "string"
+                      },
+                      "endUserContactName" : {
+                        "type" : "string"
+                      },
+                      "endUserMarketSegment" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "quoteProductList" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/quoteProductList"
+                }
+              },
+              "totalQuoteProductCount" : {
+                "type" : "string"
+              },
+              "totalExtendedMsrp" : {
+                "type" : "string"
+              },
+              "totalQuantity" : {
+                "type" : "integer"
+              },
+              "totalExtendedQuotePrice" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "description" : "Response schema for quote details"
+      },
+      "quoteProductList" : {
+        "title" : "quoteDetails.quoteProductList.Response",
+        "type" : "object",
+        "x-tags" : [ "quotes" ],
+        "properties" : {
+          "quoteProductGuid" : {
+            "type" : "string"
+          },
+          "quantity" : {
+            "type" : "string"
+          },
+          "comments" : {
+            "type" : "string"
+          },
+          "bidStartDate" : {
+            "type" : "string"
+          },
+          "bidExpiryDate" : {
+            "type" : "string"
+          },
+          "sku" : {
+            "type" : "string"
+          },
+          "lineNumber" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "vendorPartNumber" : {
+            "type" : "string"
+          },
+          "weight" : {
+            "type" : "string"
+          },
+          "isSuggestionProduct" : {
+            "type" : "string"
+          },
+          "vpnCategory" : {
+            "type" : "string"
+          },
+          "quoteProductsSupplierPartAuxiliaryId" : {
+            "type" : "string"
+          },
+          "quoteProductsVendor" : {
+            "type" : "string"
+          },
+          "price" : {
+            "type" : "object",
+            "properties" : {
+              "quotePrice" : {
+                "type" : "number"
+              },
+              "msrp" : {
+                "type" : "number"
+              },
+              "extendedMsrp" : {
+                "type" : "number"
+              },
+              "extendedQuotePrice" : {
+                "type" : "number"
+              }
+            }
+          }
+        },
+        "description" : ""
+      },
+      "ProductSearchResponse" : {
+        "title" : "productSearchResponse",
+        "type" : "object",
+        "description" : "Response object model for the product search endpoint",
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsePreamble" : {
+                "type" : "object"
+              },
+              "productsearchresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "numberOfResults" : {
+                    "type" : "string",
+                    "description" : "Number of records in the search result."
+                  },
+                  "product" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "vendor" : {
+                          "type" : "string",
+                          "description" : "Name of the vendor, manufacture or brand."
+                        },
+                        "vendornumber" : {
+                          "type" : "string",
+                          "description" : "4 digit unique vendor # creted by Ingram",
+                          "example" : "4063"
+                        },
+                        "ingrampartnumber" : {
+                          "type" : "string",
+                          "description" : "Unique Ingram part number"
+                        },
+                        "vendorpartnumber" : {
+                          "type" : "string",
+                          "description" : "Vendor provided number"
+                        },
+                        "customerpartnumber" : {
+                          "type" : "string",
+                          "description" : "Customer’s designated part number."
+                        },
+                        "iscustomerauthorized" : {
+                          "type" : "string",
+                          "description" : "Is customer authorized for purchase of this product?"
+                        },
+                        "partdescription" : {
+                          "type" : "string",
+                          "description" : "Part description"
+                        },
+                        "UPC" : {
+                          "type" : "string",
+                          "description" : "Universal Product Code"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-tags" : [ "product catalog" ]
+      },
+      "productSearchRequest" : {
+        "title" : "productSearchRequest",
+        "type" : "object",
+        "properties" : {
+          "servicerequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "isocountrycode" : {
+                    "type" : "string"
+                  },
+                  "customernumber" : {
+                    "type" : "string"
+                  },
+                  "vendornumber" : {
+                    "type" : "string"
+                  }
+                },
+                "required" : [ "isocountrycode", "customernumber" ]
+              },
+              "productsearchrequest" : {
+                "type" : "object",
+                "properties" : {
+                  "searchcriteria" : {
+                    "type" : "object",
+                    "properties" : {
+                      "vendor" : {
+                        "type" : "string",
+                        "description" : "Name of the vendor or manufacturer or brand of the product"
+                      },
+                      "vendorpartnumber" : {
+                        "type" : "string",
+                        "description" : "Vendor provided part number",
+                        "example" : "WKB-1500GB"
+                      },
+                      "partdescription" : {
+                        "type" : "string",
+                        "description" : "This field seraches the decriptioon of the product.",
+                        "example" : "WRLS ERGO KEYBOARD & MOUSE"
+                      },
+                      "UPC" : {
+                        "type" : "string",
+                        "description" : "Universal Product Code",
+                        "example" : "783750005524"
+                      },
+                      "customerpartnumber" : {
+                        "type" : "string",
+                        "description" : "Customer’s designated part number "
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-examples" : {
+          "Using Vendor Part #" : {
+            "servicerequest" : {
+              "requestpreamble" : {
+                "customernumber" : "20-222222",
+                "isocountrycode" : "US"
+              },
+              "productsearchrequest" : {
+                "searchcriteria" : {
+                  "vendorpartnumber" : "TESTE IS"
+                }
+              }
+            }
+          }
+        },
+        "description" : "Request object model for the product search endpoint",
+        "x-tags" : [ "product catalog" ]
+      },
+      "multiSKUPriceAndStockResponse" : {
+        "title" : "multiSKUPriceAndStockResponse",
+        "type" : "object",
+        "x-examples" : {
+          "Success" : {
+            "serviceresponse" : {
+              "responsepreamble" : {
+                "responsestatus" : "SUCCESS",
+                "statuscode" : "200",
+                "responsemessage" : "Data Found"
+              },
+              "priceandstockresponse" : {
+                "details" : [ {
+                  "itemstatus" : "SUCCESS",
+                  "statusmessage" : "A-No qty breaks availa",
+                  "ingrampartnumber" : "TB6489",
+                  "vendorpartnumber" : "H1180HD",
+                  "globalskuid" : "A300-TB6489",
+                  "customerprice" : 850.54,
+                  "currency" : "USD",
+                  "partdescription1" : "H1180HD DLP 3D PROJ 2000L 1080PPROJ",
+                  "partdescription2" : "10000:1 VGA HDMI RCA",
+                  "vendornumber" : "Q680",
+                  "vendorname" : "VIVITEK",
+                  "cpucode" : "DLP-PR",
+                  "class" : "X",
+                  "skustatus" : "ACTIVE",
+                  "mediacpu" : "PROJ  DLP-PR",
+                  "categorysubcategory" : "04  25",
+                  "retailprice" : 899,
+                  "newmedia" : "PROJ",
+                  "backorderflag" : "N",
+                  "skuauthorized" : "Y",
+                  "warehousedetails" : [ {
+                    "warehouseid" : "80",
+                    "warehousedescription" : "Jonestown, PA",
+                    "availablequantity" : 0,
+                    "onorderquantity" : 0
+                  }, {
+                    "warehouseid" : "10",
+                    "warehousedescription" : "Mira Loma, CA",
+                    "availablequantity" : 0,
+                    "onorderquantity" : 0
+                  } ]
+                } ]
+              }
+            }
+          },
+          "Invalid Customer" : {
+            "serviceresponse" : {
+              "responsepreamble" : {
+                "responsestatus" : "FAILED",
+                "statuscode" : "500",
+                "responsemessage" : "Data Not Found"
+              },
+              "priceandstockresponse" : {
+                "details" : [ {
+                  "itemstatus" : "FAILED",
+                  "statusmessage" : "E-INVALID CUSTOMER NUMBER"
+                }, {
+                  "itemstatus" : "FAILED",
+                  "statusmessage" : "E-INVALID CUSTOMER NUMBER"
+                }, {
+                  "itemstatus" : "FAILED",
+                  "statusmessage" : "E-INVALID CUSTOMER NUMBER"
+                } ]
+              }
+            }
+          },
+          "Invalid Country " : {
+            "serviceresponse" : {
+              "responsepreamble" : {
+                "responsestatus" : "SUCCESSWITHERROR",
+                "statuscode" : "046",
+                "responsemessage" : "Partial Data Found"
+              },
+              "priceandstockresponse" : {
+                "details" : [ {
+                  "itemstatus" : "SUCCESS",
+                  "statusmessage" : "edv 2",
+                  "ingrampartnumber" : "NaN",
+                  "vendorpartnumber" : null,
+                  "globalskuid" : "A001-NaN",
+                  "customernumber" : "20-222222",
+                  "quantity" : 0,
+                  "customerprice" : 0,
+                  "vendornumber" : "NaN",
+                  "retailprice" : 0,
+                  "enduserrequired" : "false",
+                  "specialpromoflag" : "false",
+                  "isavailable" : false,
+                  "isstocakable" : false,
+                  "isbom" : false,
+                  "hasquantitybreaks" : false,
+                  "haswebdiscounts" : false,
+                  "issboprice" : false,
+                  "extendednetamount" : 0,
+                  "taxamount" : 0,
+                  "totalfeeamount" : 0,
+                  "totalpromotionamount" : 0,
+                  "totalenvironmentalfees" : 0
+                } ]
+              }
+            }
+          }
+        },
+        "x-tags" : [ "product catalog" ],
+        "description" : "Response object model for the multi sku price and stock API endpoint",
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responsestatus" : {
+                    "type" : "string",
+                    "description" : "SUCCESS or FAILED, sometimes PARTIAL SUCCESS if connection to 1 of the systems fails"
+                  },
+                  "responsemessage" : {
+                    "type" : "string",
+                    "description" : "Overall status message including error message"
+                  },
+                  "statuscode" : {
+                    "type" : "string",
+                    "description" : "Statuscode Message"
+                  }
+                }
+              },
+              "priceandstockresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "details" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "itemstatus" : {
+                          "type" : "string"
+                        },
+                        "statusmessage" : {
+                          "type" : "string"
+                        },
+                        "ingrampartnumber" : {
+                          "type" : "string",
+                          "description" : "SKU number for the product for which order needs to be created with Ingram Micro",
+                          "maxLength" : 6
+                        },
+                        "vendorpartnumber" : {
+                          "type" : "string",
+                          "description" : "Vendor Part number for the product",
+                          "maxLength" : 21
+                        },
+                        "globalskuid" : {
+                          "type" : "string"
+                        },
+                        "customerprice" : {
+                          "type" : "string",
+                          "description" : "Customer specific price for the product, excluding taxes"
+                        },
+                        "partdescription1" : {
+                          "type" : "string",
+                          "description" : "Description on the part number that is being requested"
+                        },
+                        "partdescription2" : {
+                          "type" : "string",
+                          "description" : "Contuiation of description on the part number that is being requested"
+                        },
+                        "vendornumber" : {
+                          "type" : "string",
+                          "description" : "Internal four digit code assigned by Ingram",
+                          "maxLength" : 4
+                        },
+                        "vendorname" : {
+                          "type" : "string",
+                          "description" : "Name of the vendor"
+                        },
+                        "cpucode" : {
+                          "type" : "string",
+                          "description" : "Ingram internal code for a product",
+                          "maxLength" : 6
+                        },
+                        "class" : {
+                          "type" : "string",
+                          "description" : "Ingram Micro assigned product classification.",
+                          "enum" : [ "A-Stocked product in all IM warehouses", "B-Limited stock in IM warehouses", "C-Stocked in fewer wareshouses", "D-Ingram discontinued", "E-Planned to be phased out as per the vendor", "F-Carried for specific customer as per the contract", "N-New SKU", "O-Discontinued to be liquidated", "S-Order for specialized demand", "V-Discontinued by vendor", "X-Direct Ship products from vendor" ],
+                          "maxLength" : 1
+                        },
+                        "skustatus" : {
+                          "type" : "string",
+                          "description" : "Identifies if the SKU has been discontinued. Rules must be defined on the values to be sent out to partner.",
+                          "maxLength" : 1
+                        },
+                        "mediacpu" : {
+                          "type" : "string"
+                        },
+                        "categorysubcategory" : {
+                          "type" : "string",
+                          "description" : "Ingram's internal categorization of the product"
+                        },
+                        "retailprice" : {
+                          "type" : "number",
+                          "description" : "MSRP Price 0.00"
+                        },
+                        "newmedia" : {
+                          "type" : "string",
+                          "description" : "Internal four-digit code assigned by Ingram to represent the item group"
+                        },
+                        "enduserrequired" : {
+                          "type" : "string",
+                          "description" : "Y - End user required N - Not required End user",
+                          "enum" : [ "Y-End user data required", "N-End user data not required" ],
+                          "maxLength" : 1
+                        },
+                        "backorderflag" : {
+                          "type" : "string",
+                          "description" : "Y- Allow Backorder Flag N- Not allowed",
+                          "enum" : [ "Y- Can be backordered", "N-Cannot be backordered" ],
+                          "maxLength" : 1
+                        },
+                        "skuauthorized" : {
+                          "type" : "string"
+                        },
+                        "extendedvendorpartnumber" : {
+                          "type" : "string"
+                        },
+                        "warehousedetails" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "properties" : {
+                              "warehouseid" : {
+                                "type" : "string",
+                                "description" : "Unique 2-digit code of the Ingram Micro warehouse",
+                                "enum" : [ "10-Mira Loma CA", "20-Carrollton TX", "30-Millington TN", "40-Carol Stream IL", "80-Jonestown PA" ]
+                              },
+                              "warehousedescription" : {
+                                "type" : "string",
+                                "description" : "City of the Ingram Micro warehouse location"
+                              },
+                              "availablequantity" : {
+                                "type" : "integer",
+                                "description" : "On hand available quantity"
+                              },
+                              "onorderquantity" : {
+                                "type" : "integer",
+                                "description" : "On Order quantity"
+                              },
+                              "onholdquantity" : {
+                                "type" : "string"
+                              },
+                              "etadate" : {
+                                "type" : "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required" : [ "retailprice" ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "multiSKUPriceAndStockRequest" : {
+        "title" : "multiSKUPriceAndStockRequest",
+        "type" : "object",
+        "description" : "Request object model for the multi sku price and stock API endpoint",
+        "x-examples" : {
+          "Example" : {
+            "servicerequest" : {
+              "requestpreamble" : {
+                "customernumber" : "20-222222",
+                "isocountrycode" : "US"
+              },
+              "priceandstockrequest" : {
+                "showwarehouseavailability" : "True",
+                "extravailabilityflag" : "Y",
+                "item" : [ {
+                  "ingrampartnumber" : "M93592",
+                  "quantity" : 1
+                } ],
+                "includeallsystems" : false
+              }
+            }
+          }
+        },
+        "x-tags" : [ "product catalog" ],
+        "properties" : {
+          "servicerequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "isocountrycode" : {
+                    "type" : "string",
+                    "description" : "2 Digit code\n“US”-United States\n“CA”-Canada",
+                    "example" : "US",
+                    "minLength" : 2,
+                    "maxLength" : 2
+                  },
+                  "customernumber" : {
+                    "type" : "string",
+                    "description" : "Ingram Micro customer number\n10-12389",
+                    "example" : "20-222222"
+                  }
+                },
+                "required" : [ "isocountrycode", "customernumber" ]
+              },
+              "priceandstockrequest" : {
+                "type" : "object",
+                "properties" : {
+                  "showwarehouseavailability" : {
+                    "type" : "string",
+                    "description" : "True/false to show the availability of individual warehouses"
+                  },
+                  "extravailabilityflag" : {
+                    "type" : "string",
+                    "description" : "Y/N to show extra availability flag"
+                  },
+                  "includeallsystems" : {
+                    "type" : "boolean",
+                    "description" : "Flag to indicate if the price and stock information is required for all Ingram Micro systems. If it is set to true, the price and stock details will be returned from all Ingram Micro systems and if false, the price and stock will have returned from the system where the reseller number is set up in."
+                  },
+                  "item" : {
+                    "type" : "object",
+                    "properties" : {
+                      "index" : {
+                        "type" : "integer"
+                      },
+                      "ingrampartnumber" : {
+                        "type" : "string",
+                        "description" : "Ingram Micro system specific SKU number for the product for which the price is requested at Ingram Micro"
+                      },
+                      "vendorpartnumber" : {
+                        "type" : "string",
+                        "description" : "Vendor Part Number for the product for which the price is requested at Ingram Micro"
+                      },
+                      "UPC" : {
+                        "type" : "string",
+                        "description" : "Universal Product code for the product for which the price is requested at Ingram Micro"
+                      },
+                      "customerpartnumber" : {
+                        "type" : "string",
+                        "description" : "Unique identification number of customer. For this option the Ingram Micro Sales rep must set up a cross reference table. "
+                      },
+                      "warehouseidlist" : {
+                        "type" : "string",
+                        "description" : "Unique identity for Ingram Micro warehouses against which stock details are returned."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "invoiceDetailRequest" : {
+        "title" : "invoiceDetailRequest",
+        "type" : "object",
+        "x-tags" : [ "invoices" ],
+        "properties" : {
+          "servicerequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "isocountrycode" : {
+                    "type" : "string"
+                  },
+                  "customernumber" : {
+                    "type" : "string"
+                  }
+                },
+                "required" : [ "isocountrycode", "customernumber" ]
+              },
+              "invoicedetailrequest" : {
+                "type" : "object",
+                "properties" : {
+                  "invoicenumber" : {
+                    "type" : "string"
+                  }
+                },
+                "required" : [ "invoicenumber" ]
+              }
+            }
+          }
+        },
+        "x-examples" : {
+          "Example" : {
+            "servicerequest" : {
+              "requestpreamble" : {
+                "isocountrycode" : "US",
+                "customernumber" : "20-222222"
+              },
+              "invoicedetailrequest" : {
+                "invoicenumber" : "60ABCDE11"
+              }
+            }
+          }
+        }
+      },
+      "invoiceDetailResponse" : {
+        "title" : "invoiceDetailResponse",
+        "type" : "object",
+        "x-tags" : [ "invoices" ],
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responsestatus" : {
+                    "type" : "string"
+                  },
+                  "statuscode" : {
+                    "type" : "string"
+                  },
+                  "responsemessage" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "invoicedetailresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "customernumber" : {
+                    "type" : "string"
+                  },
+                  "invoicenumber" : {
+                    "type" : "string"
+                  },
+                  "invoicedate" : {
+                    "type" : "string",
+                    "format" : "date"
+                  },
+                  "invoicetype" : {
+                    "type" : "string"
+                  },
+                  "customerordernumber" : {
+                    "type" : "string"
+                  },
+                  "customerfreightamount" : {
+                    "type" : "number",
+                    "format" : "double"
+                  },
+                  "customerforeignfrightamt" : {
+                    "type" : "number",
+                    "format" : "float"
+                  },
+                  "totaltaxamount" : {
+                    "type" : "number",
+                    "format" : "double"
+                  },
+                  "totalamount" : {
+                    "type" : "number",
+                    "format" : "double"
+                  },
+                  "shiptosuffix" : {
+                    "type" : "string"
+                  },
+                  "billtosuffix" : {
+                    "type" : "string"
+                  },
+                  "freightamount" : {
+                    "type" : "number",
+                    "format" : "double"
+                  },
+                  "paymentterms" : {
+                    "type" : "string"
+                  },
+                  "orderdate" : {
+                    "type" : "string"
+                  },
+                  "carrier" : {
+                    "type" : "string"
+                  },
+                  "carrierdescription" : {
+                    "type" : "string"
+                  },
+                  "discountamount" : {
+                    "type" : "number",
+                    "format" : "double"
+                  },
+                  "taxtype" : {
+                    "type" : "string"
+                  },
+                  "enduserponumber" : {
+                    "type" : "string"
+                  },
+                  "freightforwardercode" : {
+                    "type" : "string"
+                  },
+                  "creditmemoreasoncode" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "orderModifyResponse" : {
+        "title" : "orderModifyResponse",
+        "type" : "object",
+        "description" : "Response schema for order modify endpoint",
+        "x-tags" : [ "orders" ],
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responsestatus" : {
+                    "type" : "string"
+                  },
+                  "responsemessage" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "ordermodifyresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "responseflag" : {
+                    "type" : "string"
+                  },
+                  "errortype" : {
+                    "type" : "string"
+                  },
+                  "acktriggered" : {
+                    "type" : "string"
+                  },
+                  "warncode" : {
+                    "type" : "string"
+                  },
+                  "headerresponse" : {
+                    "type" : "string"
+                  },
+                  "" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "orderModifyRequest" : {
+        "title" : "orderModifyRequest",
+        "type" : "object",
+        "description" : "Request schema for order modify endpoint",
+        "x-tags" : [ "orders" ],
+        "properties" : {
+          "servicerequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "isocountrycode" : {
+                    "type" : "string"
+                  },
+                  "customernumber" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "ordermodifyrequest" : {
+                "type" : "object",
+                "properties" : {
+                  "ingramorderbranch" : {
+                    "type" : "string"
+                  },
+                  "ingramordernumber" : {
+                    "type" : "string"
+                  },
+                  "ingramorderdist" : {
+                    "type" : "string"
+                  },
+                  "ingramordership" : {
+                    "type" : "string"
+                  },
+                  "customerponumber" : {
+                    "type" : "string"
+                  },
+                  "shipto" : {
+                    "type" : "object",
+                    "properties" : {
+                      "Id" : {
+                        "type" : "string"
+                      },
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "addressline" : {
+                        "type" : "string"
+                      },
+                      "city" : {
+                        "type" : "string"
+                      },
+                      "state" : {
+                        "type" : "string"
+                      },
+                      "postalcode" : {
+                        "type" : "string"
+                      },
+                      "countrycode" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "headerdata" : {
+                    "type" : "object",
+                    "properties" : {
+                      "actioncode" : {
+                        "type" : "string"
+                      },
+                      "shipviacode" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "linedata" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "addlineorupdateline" : {
+                          "type" : "string"
+                        },
+                        "linenumber" : {
+                          "type" : "string"
+                        },
+                        "customerlinenumber" : {
+                          "type" : "string"
+                        },
+                        "ingrampartnumber" : {
+                          "type" : "string"
+                        },
+                        "quantityordered" : {
+                          "type" : "integer"
+                        },
+                        "customerpartnumber" : {
+                          "type" : "string"
+                        },
+                        "linetype" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrderSearchResponse" : {
+        "title" : "orderSearchResponse",
+        "type" : "object",
+        "properties" : {
+          "serviceResponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "requeststatus" : {
+                    "type" : "string"
+                  },
+                  "returnmessage" : {
+                    "type" : "string"
+                  },
+                  "returncode" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "orderlookupresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "numberrfresults" : {
+                    "type" : "string"
+                  },
+                  "responsedata" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "ordernumber" : {
+                          "type" : "string"
+                        },
+                        "entrytimestamp" : {
+                          "type" : "string"
+                        },
+                        "customerordernumber" : {
+                          "type" : "string"
+                        },
+                        "endUserordernumber" : {
+                          "type" : "string"
+                        },
+                        "shipment" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "properties" : {
+                              "distributionnumber" : {
+                                "type" : "string"
+                              },
+                              "shipmentnumber" : {
+                                "type" : "string"
+                              },
+                              "branchnumber" : {
+                                "type" : "string"
+                              },
+                              "statuscode" : {
+                                "type" : "string"
+                              },
+                              "status" : {
+                                "type" : "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description" : "Response schema for order search endpoint"
+      },
+      "orderSearchRequest" : {
+        "title" : "orderSearchRequest",
+        "type" : "object",
+        "description" : "Request schema for order search endpoint",
+        "properties" : {
+          "servicerequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "required" : [ "isoCountryCode", "customerNumber" ],
+                "properties" : {
+                  "isoCountryCode" : {
+                    "type" : "string"
+                  },
+                  "customerNumber" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "orderLookupRequest" : {
+                "type" : "object",
+                "properties" : {
+                  "orderNumber" : {
+                    "type" : "object",
+                    "properties" : {
+                      "entryDate" : {
+                        "type" : "string"
+                      },
+                      "orderBranch" : {
+                        "type" : "string"
+                      },
+                      "orderNumber" : {
+                        "type" : "string"
+                      },
+                      "distributionNumber" : {
+                        "type" : "string"
+                      },
+                      "shipmentNumber" : {
+                        "type" : "string"
+                      }
+                    },
+                    "required" : [ "entryDate", "orderBranch" ]
+                  },
+                  "customerOrderNumber" : {
+                    "type" : "object",
+                    "properties" : {
+                      "customerOrderNumber" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "required" : [ "requestpreamble" ]
+          }
+        },
+        "x-examples" : {
+          "Example" : {
+            "servicerequest" : {
+              "requestpreamble" : {
+                "isocountrycode" : "US",
+                "customernumber" : "20-222222"
+              },
+              "orderlookuprequest" : {
+                "status" : {
+                  "fromdate" : "2020-01-07",
+                  "todate" : "2020-01-14"
+                }
+              }
+            }
+          }
+        },
+        "x-tags" : [ "orders" ]
+      },
+      "orderDeleteResponse" : {
+        "title" : "orderDeleteResponse",
+        "type" : "object",
+        "x-tags" : [ "orders" ],
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "requestStatus" : {
+                    "type" : "string"
+                  },
+                  "returnCode" : {
+                    "type" : "string"
+                  },
+                  "returnMessage" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description" : "Response schema for order delete endpoint",
+        "x-examples" : {
+          "Example" : {
+            "serviceresponse" : {
+              "responsepreamble" : {
+                "requestStatus" : "SUCCESS",
+                "returnCode" : "00",
+                "returnMessage" : "Order Deleted Successfully"
+              }
+            }
+          }
+        }
+      },
+      "orderDeleteRequest" : {
+        "title" : "orderDeleteRequest",
+        "type" : "object",
+        "x-tags" : [ "orders" ],
+        "description" : "Request schema for order delete endpoint",
+        "x-examples" : {
+          "Example" : {
+            "servicerequest" : {
+              "requestpreamble" : {
+                "isocountrycode" : "US",
+                "customerumber" : "20-222222"
+              },
+              "OrderDeleteRequestDetails" : {
+                "entryDate" : "2019-01-22",
+                "orderBranch" : "20",
+                "orderNumber" : "RC62Z"
+              }
+            }
+          }
+        },
+        "properties" : {
+          "servicerequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "required" : [ "isocountrycode", "customerNumber" ],
+                "properties" : {
+                  "isocountrycode" : {
+                    "type" : "string",
+                    "description" : "Country that Order is being place in."
+                  },
+                  "customerNumber" : {
+                    "type" : "string",
+                    "description" : "Account number order will be billed to.\nINGRAM MICRO ACCOUNT NUMBER REQUIRED"
+                  }
+                }
+              },
+              "OrderDeleteRequestDetails" : {
+                "type" : "object",
+                "properties" : {
+                  "entryDate" : {
+                    "type" : "string",
+                    "description" : "Date order entered",
+                    "example" : "8/25/2018"
+                  },
+                  "orderBranch" : {
+                    "type" : "string",
+                    "description" : "Ingram Micro's first 2 numbers of the order number"
+                  },
+                  "orderNumber" : {
+                    "type" : "string",
+                    "description" : "Ingram Micro's middle 6 numbers of the order#"
+                  },
+                  "rejectionCode" : {
+                    "type" : "string"
+                  },
+                  "distributionNumber" : {
+                    "type" : "string",
+                    "description" : "Ingram Micro's suffix number of the order#"
+                  },
+                  "shipmentNumber" : {
+                    "type" : "string",
+                    "description" : "Ingram Micro's last number of the order#"
+                  },
+                  "operatorID" : {
+                    "type" : "string",
+                    "description" : "Ingram ID(not required)"
+                  }
+                },
+                "required" : [ "entryDate", "orderBranch", "orderNumber" ]
+              }
+            },
+            "required" : [ "requestpreamble" ]
+          }
+        }
+      },
+      "orderDetailsResponse" : {
+        "title" : "orderDetailResponse",
+        "type" : "object",
+        "x-tags" : [ "orders" ],
+        "description" : "Response schema for order details endpoint",
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responsestatus" : {
+                    "type" : "string"
+                  },
+                  "statuscode" : {
+                    "type" : "string"
+                  },
+                  "responsemessage" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "orderdetailresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "ordernumber" : {
+                    "type" : "string"
+                  },
+                  "ordertype" : {
+                    "type" : "string",
+                    "description" : "Order Type\t\t\nB - BRANCH TRANSFER\nC - CASH ORDER\nD - DIRECT ORDER\nF - FUTURE ORDER\nP - SPECIAL ORDER\nQ - QUOTE ORDER\nS - STOCK ORDER\nM - MEMO ORDER"
+                  },
+                  "customerordernumber" : {
+                    "type" : "string",
+                    "description" : "Customer PO number"
+                  },
+                  "enduserponumber" : {
+                    "type" : "string",
+                    "description" : "End User PO number"
+                  },
+                  "orderstatus" : {
+                    "type" : "string",
+                    "description" : "Status of order within Ingram system\nS - SALES HOLD\nH - TAG HOLD\nI - INVOICED\nP - PENDING\nE - BILLING ERROR\nF - FORCE BILLING\nV - VOIDED\nT - TRANSFERRED\nD - HOLD SHIPMENT\nR - RELEASED\nO - IM ONLINE HOLD\nU - BILL FOR HISTORY ONLY\nW - ORDER NOT PRINTED\nA - DROP SHIP HOLD\nB - INTERNET CUST ORIG HOLD\n1 - PICKED\n2 - INSPECTED\n3 - PACKED\n4 - SHIPPED\nC - CREDIT HOLD\n9 - CISCO 3A6\nQ - RMA HOLD\nG - CREDIT HOLD\nN - CREDIT HOLD"
+                  },
+                  "entrytimestamp" : {
+                    "type" : "string",
+                    "description" : "Time stamp of the order placed"
+                  },
+                  "entrymethoddescription" : {
+                    "type" : "string",
+                    "description" : "Description of the entry method\t"
+                  },
+                  "ordertotalvalue" : {
+                    "type" : "number",
+                    "description" : "Total order value"
+                  },
+                  "ordersubtotal" : {
+                    "type" : "number",
+                    "description" : "Subtotal order value"
+                  },
+                  "freightamount" : {
+                    "type" : "string",
+                    "description" : "Freight charges"
+                  },
+                  "currencycode" : {
+                    "type" : "string",
+                    "description" : "Country specific currency code"
+                  },
+                  "totalweight" : {
+                    "type" : "string",
+                    "description" : "Total order weight. unit -- North america - Pounds , other countries will be KG"
+                  },
+                  "totaltax" : {
+                    "type" : "string",
+                    "description" : "total tax on the orders placed"
+                  },
+                  "billtoaddress" : {
+                    "type" : "object",
+                    "properties" : {
+                      "suffix" : {
+                        "type" : "string"
+                      },
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "attention" : {
+                        "type" : "string"
+                      },
+                      "addressline1" : {
+                        "type" : "string"
+                      },
+                      "addressline2" : {
+                        "type" : "string"
+                      },
+                      "addressline3" : {
+                        "type" : "string"
+                      },
+                      "city" : {
+                        "type" : "string"
+                      },
+                      "state" : {
+                        "type" : "string"
+                      },
+                      "postalcode" : {
+                        "type" : "string"
+                      },
+                      "countrycode" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "shiptoaddress" : {
+                    "type" : "object",
+                    "properties" : {
+                      "suffix" : {
+                        "type" : "string"
+                      },
+                      "attention" : {
+                        "type" : "string"
+                      },
+                      "name" : {
+                        "type" : "string"
+                      },
+                      "addressline1" : {
+                        "type" : "string"
+                      },
+                      "addressline2" : {
+                        "type" : "string"
+                      },
+                      "addressline3" : {
+                        "type" : "string"
+                      },
+                      "city" : {
+                        "type" : "string"
+                      },
+                      "state" : {
+                        "type" : "string"
+                      },
+                      "postalcode" : {
+                        "type" : "string"
+                      },
+                      "countrycode" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "enduserinfo" : {
+                    "type" : "object",
+                    "properties" : {
+                      "enduserid" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "lines" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "linenumber" : {
+                          "type" : "string",
+                          "description" : "Impulse line number"
+                        },
+                        "globallinenumber" : {
+                          "type" : "string",
+                          "description" : "Line of the Globel Sku / Customer Line Number"
+                        },
+                        "ordersuffix" : {
+                          "type" : "string",
+                          "description" : "Order Suffix"
+                        },
+                        "erpordernumber" : {
+                          "type" : "string",
+                          "description" : "Sales order number"
+                        },
+                        "linestatus" : {
+                          "type" : "string",
+                          "description" : "Status of the line"
+                        },
+                        "partnumber" : {
+                          "type" : "string",
+                          "description" : "Ingram part number"
+                        },
+                        "manufacturerpartnumber" : {
+                          "type" : "string",
+                          "description" : "manufacture number of the product"
+                        },
+                        "vendorname" : {
+                          "type" : "string",
+                          "description" : "name of the vendor"
+                        },
+                        "vendorcode" : {
+                          "type" : "string",
+                          "description" : "Ingram Micro assigned code for the vendor"
+                        },
+                        "partdescription1" : {
+                          "type" : "string"
+                        },
+                        "partdescription2" : {
+                          "type" : "string"
+                        },
+                        "unitweight" : {
+                          "type" : "string",
+                          "description" : "weight of the product unit"
+                        },
+                        "unitprice" : {
+                          "type" : "number",
+                          "description" : "Customer price of the unit"
+                        },
+                        "extendedprice" : {
+                          "type" : "number",
+                          "description" : "extended price of the order"
+                        },
+                        "taxamount" : {
+                          "type" : "number",
+                          "description" : "tax amount for the order"
+                        },
+                        "requestedquantity" : {
+                          "type" : "string",
+                          "description" : "no. of units requested"
+                        },
+                        "confirmedquantity" : {
+                          "type" : "string",
+                          "description" : "no. of units confirmed available"
+                        },
+                        "backorderquantity" : {
+                          "type" : "string",
+                          "description" : "quantity of back order"
+                        },
+                        "serialnumberdetails" : {
+                          "type" : "object",
+                          "properties" : {
+                            "serialnumber" : {
+                              "type" : "string",
+                              "description" : "serial number of the ordered SKU"
+                            }
+                          }
+                        },
+                        "trackingnumber" : {
+                          "type" : "string",
+                          "description" : "tracking number of the order"
+                        },
+                        "shipmentdetails" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "properties" : {
+                              "quantity" : {
+                                "type" : "number",
+                                "description" : "quantity shipped"
+                              },
+                              "shipmentdate" : {
+                                "type" : "string",
+                                "description" : "date of shipment"
+                              },
+                              "shipfromwarehouseid" : {
+                                "type" : "string",
+                                "description" : "Warehouse product was shipped from"
+                              },
+                              "warehousename" : {
+                                "type" : "string",
+                                "description" : "name of the warehouse"
+                              },
+                              "invoicenumber" : {
+                                "type" : "string",
+                                "description" : "Invoice Number"
+                              },
+                              "invoicedate" : {
+                                "type" : "string",
+                                "description" : "date on the invoice generated"
+                              },
+                              "status" : {
+                                "type" : "string",
+                                "description" : "code for current Status of the order"
+                              },
+                              "statusdescription" : {
+                                "type" : "string",
+                                "description" : "Description of status"
+                              },
+                              "shippeddate" : {
+                                "type" : "string",
+                                "description" : "date of shipment"
+                              },
+                              "holdreasoncodedescription" : {
+                                "type" : "string",
+                                "description" : "Description of the code if the order is on hold"
+                              },
+                              "ponumber" : {
+                                "type" : "string",
+                                "description" : "Ingram PO Number to vendors for direct ship orders"
+                              },
+                              "carriercode" : {
+                                "type" : "string",
+                                "description" : ""
+                              },
+                              "carriername" : {
+                                "type" : "string",
+                                "description" : "name of the carrier"
+                              },
+                              "pronumber" : {
+                                "type" : "string",
+                                "description" : "the condition is being handled in Insideline / Impulse. And data gets populated based upon the rules in backend systems"
+                              },
+                              "packagedetails" : {
+                                "type" : "object",
+                                "properties" : {
+                                  "trackingnumber" : {
+                                    "type" : "string"
+                                  },
+                                  "packageweight" : {
+                                    "type" : "string"
+                                  },
+                                  "cartonnumber" : {
+                                    "type" : "string"
+                                  },
+                                  "quantityinbox" : {
+                                    "type" : "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "productextendedspecs" : {
+                          "type" : "object",
+                          "properties" : {
+                            "attributename" : {
+                              "type" : "string"
+                            },
+                            "attributevalue" : {
+                              "type" : "string"
+                            }
+                          }
+                        },
+                        "backorderetadate" : {
+                          "type" : "string",
+                          "description" : "estimated date of back order"
+                        }
+                      }
+                    }
+                  },
+                  "commentlines" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "commenttext1" : {
+                          "type" : "string"
+                        },
+                        "commenttext2" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  },
+                  "miscfeeline" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "description" : {
+                          "type" : "string",
+                          "description" : "Handling charges/Miscellaneous Fee description"
+                        },
+                        "chargeamount" : {
+                          "type" : "string",
+                          "description" : "Handling charges/ Miscelaneous fee amount"
+                        }
+                      }
+                    }
+                  },
+                  "extendedspecs" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "attributename" : {
+                          "type" : "string",
+                          "description" : "termscode' | 'termsdescription' | 'commenttext' are the atrribute name"
+                        },
+                        "attributevalue" : {
+                          "type" : "string",
+                          "description" : "values of these fields are send . termscode' | 'termsdescription' | 'commenttext' are the atrribute name"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-examples" : {
+          "Example" : {
+            "serviceresponse" : {
+              "responsepreamble" : {
+                "responsestatus" : "SUCCESS"
+              },
+              "orderdetailresponse" : {
+                "ordernumber" : "10-12345",
+                "customerordernumber" : "test order",
+                "enduserponumber" : "ABC",
+                "orderstatus" : "INVOICED",
+                "entrytimestamp" : "2018-07-15T04:31:42-07:00",
+                "entrymethoddescription" : "XML/PCG",
+                "fulfilmentordercode" : "Y",
+                "ordertotalvalue" : 3907.38,
+                "ordersubtotal" : 3907.38,
+                "freightamount" : 141.34,
+                "currencycode" : "USD",
+                "totalweight" : "86",
+                "totaltax" : "0",
+                "billtoaddress" : {
+                  "suffix" : "000",
+                  "name" : "Ingram Micro",
+                  "addressline1" : "123 Ingram Way",
+                  "addressline2" : null,
+                  "addressline3" : null,
+                  "city" : "Irvine",
+                  "state" : "CA",
+                  "postalcode" : "12345000",
+                  "countrycode" : "US"
+                },
+                "shiptoaddress" : {
+                  "name" : "Mr Customer",
+                  "addressline1" : "123 Main St",
+                  "city" : "Anywhere",
+                  "state" : "CA",
+                  "postalcode" : "12345000",
+                  "countrycode" : "US"
+                },
+                "lines" : [ {
+                  "globallinenumber" : "001",
+                  "ordersuffix" : "11",
+                  "linestatus" : "INVOICED",
+                  "partnumber" : "3AM612",
+                  "manufacturerpartnumber" : "QN75Q8FNBFXZA",
+                  "vendorname" : "SAMSUNG - CONSUMER TV",
+                  "partdescription1" : "75IN Q8 FLAT 4K UHD HDR SMARTTV",
+                  "partdescription2" : "FULL ARRAY BACKLIGHTIN CLEAN CABLE",
+                  "freeitempromoflag" : "false",
+                  "unitweight" : "75",
+                  "unitprice" : 50000.48,
+                  "foreignunitprice" : 0,
+                  "extendedprice" : 5000.48,
+                  "foreignextendedprice" : 0,
+                  "taxamount" : 0,
+                  "requestedquantity" : "1",
+                  "confirmedquantity" : "1",
+                  "backorderquantity" : "0",
+                  "promisedate" : "2018-07-15",
+                  "shipmentdetails" : [ {
+                    "quantity" : 1,
+                    "shipmentdate" : "2018-07-16",
+                    "shipfromwarehouseid" : "40",
+                    "warehousename" : "Carol Stream, IL",
+                    "invoicenumber" : "1234511",
+                    "invoicedate" : "2018-07-16",
+                    "status" : "I",
+                    "statusdescription" : "INVOICED",
+                    "shippeddate" : "2018-07-16",
+                    "carriercode" : "AY",
+                    "carriername" : "ORD4708752",
+                    "packagedetails" : {
+                      "trackingnumber" : 6838019,
+                      "packageweight" : 80,
+                      "cartonnumber" : "001",
+                      "quantityinbox" : "0000001"
+                    }
+                  } ],
+                  "erpordernumber" : "10-12345-11",
+                  "vendorcode" : "Q012",
+                  "isacopapplied" : "N",
+                  "adjustedcost" : "5000.09",
+                  "serialnumberdetails" : {
+                    "serialnumber" : "07AS3CAK500682"
+                  },
+                  "productextendedspecs" : {
+                    "attributename" : "commenttext",
+                    "attributevalue" : "FULL ARRAY BACKLIGHTIN CLEAN CABLE"
+                  }
+                }, {
+                  "globallinenumber" : "002",
+                  "ordersuffix" : "21",
+                  "linestatus" : "INVOICED",
+                  "partnumber" : "2GH590",
+                  "manufacturerpartnumber" : "F-ADT-STR-KT-1",
+                  "vendorname" : "SAMSUNG - SMART THINGS",
+                  "partdescription1" : "ADT HOME SECURITY STARTER KIT",
+                  "partdescription2" : "SECURITY STARTER KIT",
+                  "freeitempromoflag" : "false",
+                  "unitweight" : "5.15",
+                  "unitprice" : 500.9,
+                  "foreignunitprice" : 0,
+                  "extendedprice" : 500.9,
+                  "foreignextendedprice" : 0,
+                  "taxamount" : 0,
+                  "requestedquantity" : "1",
+                  "confirmedquantity" : "1",
+                  "backorderquantity" : "0",
+                  "promisedate" : "2018-07-15",
+                  "shipmentdetails" : [ {
+                    "quantity" : 1,
+                    "shipmentdate" : "2018-07-17",
+                    "shipfromwarehouseid" : "80",
+                    "warehousename" : "Jonestown, PA",
+                    "invoicenumber" : "1234521",
+                    "invoicedate" : "2018-07-16",
+                    "status" : "I",
+                    "statusdescription" : "INVOICED",
+                    "shippeddate" : "2018-07-17",
+                    "carriercode" : "RG",
+                    "carriername" : "FEDEX GROUND",
+                    "packagedetails" : {
+                      "trackingnumber" : "017136225260674",
+                      "packageweight" : "000000006",
+                      "cartonnumber" : "001",
+                      "quantityinbox" : "0000001"
+                    }
+                  } ],
+                  "erpordernumber" : "10-12345-21",
+                  "vendorcode" : "QG64",
+                  "isacopapplied" : "N",
+                  "adjustedcost" : "400.99",
+                  "productextendedspecs" : {
+                    "attributename" : "commenttext",
+                    "attributevalue" : "SECURITY STARTER KIT"
+                  }
+                } ],
+                "extendedspecs" : [ {
+                  "attributename" : "termscode",
+                  "attributevalue" : "300"
+                }, {
+                  "attributename" : "termsdescription",
+                  "attributevalue" : "NET 30 DAYS"
+                }, {
+                  "attributename" : "commenttext",
+                  "attributevalue" : "PHONE:7148675309"
+                }, {
+                  "attributename" : "commenttext",
+                  "attributevalue" : "PHONE:7148675309"
+                } ],
+                "ordertype" : "S",
+                "erpid" : null
+              }
+            }
+          }
+        }
+      },
+      "orderDetailRequest" : {
+        "title" : "orderDetailRequest",
+        "type" : "object",
+        "x-tags" : [ "orders" ],
+        "description" : "Request schema for order details endpoint",
+        "properties" : {
+          "servicerequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "required" : [ "isocountrycode", "customernumber" ],
+                "properties" : {
+                  "isocountrycode" : {
+                    "type" : "string"
+                  },
+                  "customernumber" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "orderdetailrequest" : {
+                "type" : "object",
+                "properties" : {
+                  "ordernumber" : {
+                    "type" : "string",
+                    "description" : "Ingram Micro Order Number"
+                  },
+                  "customerponumber" : {
+                    "type" : "string"
+                  },
+                  "orderdate" : {
+                    "type" : "string"
+                  },
+                  "systemid" : {
+                    "type" : "string"
+                  }
+                },
+                "required" : [ "ordernumber" ]
+              }
+            },
+            "required" : [ "requestpreamble" ]
+          }
+        },
+        "x-examples" : {
+          "Example" : {
+            "servicerequest" : {
+              "requestpreamble" : {
+                "isocountrycode" : "US",
+                "customernumber" : "20-222222"
+              },
+              "orderdetailrequest" : {
+                "ordernumber" : "10-H07XB",
+                "orderdate" : "2018-07-15",
+                "systemid" : "A300"
+              }
+            }
+          }
+        }
+      },
+      "OrderCreateresponse" : {
+        "title" : "orderCreateResponse",
+        "type" : "object",
+        "x-tags" : [ "Orders" ],
+        "description" : "Response schema for order create endpoint",
+        "x-examples" : {
+          "Example" : {
+            "serviceresponse" : {
+              "responsepreamble" : {
+                "responsestatus" : "SUCCESS"
+              },
+              "ordercreateresponse" : {
+                "numberoflineswithsuccess" : "1",
+                "numberoflineswitherror" : "0",
+                "numberoflineswithwarning" : "0",
+                "globalorderid" : "20-RBRN9",
+                "customerponumber" : "H3E",
+                "ordertype" : "S",
+                "ordertimestamp" : "2018-07-18",
+                "invoicingsystemorderid" : "20-RBRN9",
+                "taxamount" : 0,
+                "freightamount" : 0,
+                "totalorderamount" : 0,
+                "shiptoaddress" : {
+                  "attention" : null,
+                  "name" : null,
+                  "addressline1" : null,
+                  "addressline2" : null,
+                  "addressline3" : null,
+                  "addressline4" : null,
+                  "city" : null,
+                  "state" : null,
+                  "postalcode" : null,
+                  "countrycode" : null
+                },
+                "lines" : [ {
+                  "linetype" : "P",
+                  "globallinenumber" : "002",
+                  "partnumber" : "4K9938",
+                  "globalskuid" : "A300-4K9938",
+                  "freeitempromoflag" : "false",
+                  "linenumber" : "4",
+                  "carriercode" : "WC",
+                  "carrierdescription" : "WILL CALL",
+                  "requestedunitprice" : 647.6,
+                  "requestedquantity" : 1,
+                  "confirmedquantity" : 0,
+                  "backorderedquantity" : 1,
+                  "backorderetadate" : "2018-05-15",
+                  "unitproductprice" : 647.6,
+                  "netamount" : 0,
+                  "warehouseid" : "40",
+                  "ordersuffix" : "11",
+                  "isacopapplied" : "Y"
+                } ]
+              }
+            }
+          }
+        },
+        "properties" : {
+          "serviceresponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsepreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "Responsepreamble" : {
+                    "type" : "string"
+                  },
+                  "Responsestatus" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "Ordercreateresponse" : {
+                "type" : "object",
+                "properties" : {
+                  "Numberoflineswithsuccess" : {
+                    "type" : "string",
+                    "description" : "Number of line items that were successful"
+                  },
+                  "Numberoflineswitherror" : {
+                    "type" : "string",
+                    "description" : "Number of line items with error"
+                  },
+                  "Numberoflineswithwarning" : {
+                    "type" : "string",
+                    "description" : "Number of line items with warnings"
+                  },
+                  "Globalorderid" : {
+                    "type" : "string",
+                    "description" : "Ingram sales order number"
+                  },
+                  "Customerponumber" : {
+                    "type" : "string",
+                    "description" : "Customer assigned purchase order number"
+                  },
+                  "Ordertype" : {
+                    "type" : "string",
+                    "description" : "S=Stocked PO D=Direct Ship PO",
+                    "enum" : [ "S", "D" ]
+                  },
+                  "Ordertimestamp" : {
+                    "type" : "string",
+                    "description" : "Time order received"
+                  },
+                  "Invoicingsystemorderid" : {
+                    "type" : "string",
+                    "description" : "Ingram Micro generated order number"
+                  },
+                  "Taxamount" : {
+                    "type" : "number"
+                  },
+                  "Freightamount" : {
+                    "type" : "number",
+                    "description" : "Freight amount customer pays for freight"
+                  },
+                  "Totalorderamount" : {
+                    "type" : "number",
+                    "description" : "Total amount of order with freight and taxes"
+                  },
+                  "Shiptoaddress" : {
+                    "type" : "object",
+                    "properties" : {
+                      "Attention" : {
+                        "type" : "string",
+                        "description" : "Contact person at delivery site"
+                      },
+                      "Name" : {
+                        "type" : "string",
+                        "description" : "Company Name or name of person item being delivered to"
+                      },
+                      "addressline1" : {
+                        "type" : "string",
+                        "description" : "Physical address of delivery"
+                      },
+                      "addressline2" : {
+                        "type" : "string",
+                        "description" : "Continuation of address line 1,\t"
+                      },
+                      "addressline3" : {
+                        "type" : "string"
+                      },
+                      "City" : {
+                        "type" : "string"
+                      },
+                      "State" : {
+                        "type" : "string"
+                      },
+                      "Postalcode" : {
+                        "type" : "string"
+                      },
+                      "Countrycode" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "Lines" : {
+                    "type" : "object",
+                    "properties" : {
+                      "Linetype" : {
+                        "type" : "string",
+                        "description" : "“P”-Line or SKU Number “C”-Comment Line"
+                      },
+                      "globallinenumber" : {
+                        "type" : "string",
+                        "description" : "Ingram generated line number"
+                      },
+                      "Partnumber" : {
+                        "type" : "string",
+                        "description" : "Ingram Micro Sku Number"
+                      },
+                      "globalskuid" : {
+                        "type" : "string"
+                      },
+                      "linenumber" : {
+                        "type" : "string"
+                      },
+                      "carriercode" : {
+                        "type" : "string",
+                        "description" : "Transportation 2 digit codes"
+                      },
+                      "carrierdescription" : {
+                        "type" : "string",
+                        "description" : "Transportation Carrier Name"
+                      },
+                      "requestedunitprice" : {
+                        "type" : "number",
+                        "description" : "Price requested by reseller. Price Variance can be set up by Ingram Micro Sales Rep"
+                      },
+                      "requestedquantity" : {
+                        "type" : "integer",
+                        "description" : "Quanity Requested"
+                      },
+                      "confirmedquantity" : {
+                        "type" : "integer",
+                        "description" : "Quanity Shipped"
+                      },
+                      "backorderedquantity" : {
+                        "type" : "integer",
+                        "description" : "Quanity of units that didn’t ship"
+                      },
+                      "unitproductprice" : {
+                        "type" : "number",
+                        "description" : "Price Per Unit"
+                      },
+                      "netamount" : {
+                        "type" : "number",
+                        "description" : "Total amount. Quantity X Unit Price"
+                      },
+                      "warehouseid" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "OrderCreaterequest" : {
+        "title" : "orderCreateRequest",
+        "type" : "object",
+        "x-examples" : {
+          "Example" : {
+            "ordercreaterequest" : {
+              "requestpreamble" : {
+                "isocountrycode" : "US",
+                "customernumber" : "20-222222"
+              },
+              "ordercreatedetails" : {
+                "systemid" : "",
+                "customerponumber" : "TESTAPIORBT1",
+                "billtosuffix" : "000",
+                "shiptoaddress" : {
+                  "attention" : "HARRY WELLS",
+                  "addressline1" : "THE COMPUTER STORE",
+                  "addressline2" : "754 LAS PALMAS DR",
+                  "city" : "IRVINE",
+                  "state" : "CA",
+                  "postalcode" : "926022004",
+                  "countrycode" : "US"
+                },
+                "lines" : [ {
+                  "linetype" : "P",
+                  "linenumber" : "001",
+                  "globalskuid" : "",
+                  "quantity" : "1",
+                  "ingrampartnumber" : "3N7314"
+                } ],
+                "extendedspecs" : [ {
+                  "attributename" : "isbackorderflagallowed",
+                  "attributevalue" : "Y"
+                } ]
+              }
+            }
+          }
+        },
+        "x-tags" : [ "orders" ],
+        "description" : "Request schema for order create endpoint",
+        "properties" : {
+          "ordercreaterequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "required" : [ "isocountrycode", "customernumber" ],
+                "properties" : {
+                  "isocountrycode" : {
+                    "type" : "string",
+                    "description" : "This ISO country codes are internationally recognized codes that designates the country that the order is meant to post to.  United States= US, Canada = CA"
+                  },
+                  "customernumber" : {
+                    "type" : "string",
+                    "description" : "This is the Ingram Micro account number that is assigned to you. This is the account number that the pricing is based on and where the orders will be billed to.  (sample: 20-222222)",
+                    "example" : "20-222222"
+                  }
+                }
+              },
+              "ordercreatedetails" : {
+                "type" : "object",
+                "properties" : {
+                  "customerponumber" : {
+                    "type" : "string",
+                    "minLength" : 1,
+                    "maxLength" : 18,
+                    "description" : "The customers unique Purchase Order number "
+                  },
+                  "ordertype" : {
+                    "type" : "string",
+                    "enum" : [ "Standard", "Direct Ship" ],
+                    "description" : "Order Type tells our system if this is standard order or a direct ship order\n•\tCurrently Ingram Micro’s system has 2 types of sales orders.  \no\tStandard orders:  Orders that contain skus that ship from Ingram Micro’s warehouse locations.\no\tDirect ship orders:  Orders for skus, such as licenses, warranties and custom-built hardware skus that ship directly from our vendors.\n\tWe identify SKUs that must be processed separately with a class code of “X”.  The class code is found in the daily FTP price file, If Class Code is not included in your FTP Price file, you can request that it be added by contacting 1-800-616-4665. \n"
+                  },
+                  "enduserordernumber" : {
+                    "type" : "string",
+                    "description" : "Customers End-user PO number",
+                    "minLength" : 0,
+                    "maxLength" : 18
+                  },
+                  "billtosuffix" : {
+                    "type" : "string",
+                    "description" : "Designates flooring acct to be used",
+                    "maxLength" : 3
+                  },
+                  "shiptosuffix" : {
+                    "type" : "string",
+                    "description" : "Applies to customers with multiple ship to locations (store locations)",
+                    "maxLength" : 3
+                  },
+                  "shiptoaddress" : {
+                    "type" : "object",
+                    "required" : [ "addressline1", "addressline2", "city", "state", "postalcode" ],
+                    "properties" : {
+                      "attention" : {
+                        "type" : "string",
+                        "description" : "Customer contact name",
+                        "example" : "“Mr. Customer”",
+                        "maxLength" : 35
+                      },
+                      "addressline1" : {
+                        "type" : "string",
+                        "description" : "Company Name or person to deliver.\n\n*If there isn’t an attention line please add the company name on address line 1.   UPS and FedEx will create surcharges if address line 1 contains a physical address.",
+                        "example" : "“Ingram Micro”",
+                        "maxLength" : 35
+                      },
+                      "addressline2" : {
+                        "type" : "string",
+                        "description" : "Street address for delivery",
+                        "example" : "3351 Michelson Dr",
+                        "maxLength" : 35
+                      },
+                      "addressline3" : {
+                        "type" : "string",
+                        "description" : "Continuation of address line 2",
+                        "example" : "Ste 100 or ship to phone number",
+                        "maxLength" : 35
+                      },
+                      "city" : {
+                        "type" : "string",
+                        "example" : "Irvine",
+                        "maxLength" : 21,
+                        "description" : "Ship to city"
+                      },
+                      "state" : {
+                        "type" : "string",
+                        "example" : "CA",
+                        "maxLength" : 2,
+                        "description" : "Ship to State or Region"
+                      },
+                      "postalcode" : {
+                        "type" : "string",
+                        "description" : "Ship to Zip code or Postal code",
+                        "example" : "92712",
+                        "maxLength" : 9
+                      },
+                      "countrycode" : {
+                        "type" : "string",
+                        "description" : "Ship to country",
+                        "example" : "US",
+                        "maxLength" : 2
+                      }
+                    }
+                  },
+                  "carriercode" : {
+                    "type" : "string",
+                    "description" : "A customer can dictate what carrier to use for their shipment (Ingram 2-digit carrier code is required). Our recommendation is leave this field blank which will allow Ingram Micro to choose the best carrier to gain the best freight rates.",
+                    "maxLength" : 2
+                  },
+                  "thirdpartyfrieghtaccountnumber" : {
+                    "type" : "string",
+                    "description" : "Refers to a third-party freight account number for charging freight against. The account number should be passed within this field and the appropriate carrier code should be supplied within the carrier code tags. Prior to sending your request containing the third-party account number, it must be first entered into our system. Your Ingram Micro Sales Representative can action this for you. If submitted within an order without this preapproval the third-party account number will be ignored.\n\nNote: USA partners- For FedEx Air only (carrier codes F1, FO, F2, FG.), please send three leading zeros before your third-party freight account number (i.e.: 000999999999.) "
+                  },
+                  "specialbidnumber" : {
+                    "type" : "string",
+                    "description" : "This is the special quote number given to a customer either by a vendor for special pricing or by Ingram Micro. To receive the special pricing assigned to this number it must be included on the order."
+                  },
+                  "lines" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "properties" : {
+                        "linetype" : {
+                          "type" : "string",
+                          "description" : "Values are “P” for product or “C” for comments. This can be left blank when ordering product and a “P” will be assumed.  If you are adding a COMMENT, then this value must be “C”.\n\nExtended spec for comments:  \nAttribute Name: “commenttext”\nAttribute Value: “thank you for the order” \nTo make the comment invisible to the packing slip place “///” in front of the comment in the Attribute Value field.  This will allow the Ingram sales rep to see the comment on the order but will not forward on to shipping documents.",
+                          "enum" : [ "P", "C" ]
+                        },
+                        "linenumber" : {
+                          "type" : "string",
+                          "description" : "This is used when a partner wants to use their own line number. Can be left blank."
+                        },
+                        "ingrampartnumber" : {
+                          "type" : "string",
+                          "description" : "This is the Ingram sku number to be used for placing an order."
+                        },
+                        "quantity" : {
+                          "type" : "string",
+                          "description" : "The quantity that is to be ordered."
+                        },
+                        "vendorpartnumber" : {
+                          "type" : "string",
+                          "description" : "The Manufacturer part number. Can be used to place an order instead of the Ingram sku.  If there are multiple Ingram part numbers to one vendor part number.  The order will be rejected."
+                        },
+                        "customerpartnumber" : {
+                          "type" : "string",
+                          "description" : "This is the Customers unique part numbers that must be crossed referenced to the Ingram Micro Sku before it can be used.  Please contact your sales rep for additional information on how to set this up."
+                        },
+                        "UPCCode" : {
+                          "type" : "string"
+                        },
+                        "warehouseid" : {
+                          "type" : "string"
+                        },
+                        "unitprice" : {
+                          "type" : "string",
+                          "description" : "This is a requested price from the customer. Pre-approval is necessary before using this feature.  A methodology called price variance to manage requested pricing needs to be setup in advance by your sales rep.\n\nIf unit price is provided without this advanced setup the unit price will be ignored and standard Ingram Micro pricing will apply."
+                        },
+                        "enduser" : {
+                          "type" : "object",
+                          "properties" : {
+                            "id" : {
+                              "type" : "string"
+                            },
+                            "addressline1" : {
+                              "type" : "string"
+                            },
+                            "addressline2" : {
+                              "type" : "string"
+                            },
+                            "addressline3" : {
+                              "type" : "string"
+                            },
+                            "city" : {
+                              "type" : "string"
+                            },
+                            "state" : {
+                              "type" : "string"
+                            },
+                            "postalcode" : {
+                              "type" : "string"
+                            },
+                            "countrycode" : {
+                              "type" : "string"
+                            },
+                            "phonenumber" : {
+                              "type" : "string"
+                            },
+                            "extensionnumber" : {
+                              "type" : "string"
+                            },
+                            "faxnumber" : {
+                              "type" : "string"
+                            },
+                            "email" : {
+                              "type" : "string",
+                              "format" : "email"
+                            }
+                          }
+                        },
+                        "productextendedspecs" : {
+                          "type" : "object",
+                          "properties" : {
+                            "attributename" : {
+                              "type" : "string",
+                              "enum" : [ "shipfrom", "specialprice", "authbidnumber", "commenttext", "serialnumber", "contactnumber", "shipnotestxt" ]
+                            },
+                            "attributevalue" : {
+                              "type" : "string"
+                            }
+                          }
+                        }
+                      },
+                      "required" : [ "ingrampartnumber", "quantity" ]
+                    }
+                  },
+                  "extendedspecs" : {
+                    "type" : "object",
+                    "description" : "Attribute Name and Value: This field identifies if your order is a DIRECT SHIP order (license / warranty) or how you want your Backorders managed as well as other process options like placing your order on hold or adding a comment. ",
+                    "properties" : {
+                      "attributename" : {
+                        "type" : "string",
+                        "enum" : [ "Isdirectshiporder", "emailaddress", "Isbackorderflagallowed", "placeoncustomerhold", "signaturerequired", "commenttext", "resellerctacemail", "duplicatecustomerordernumbervalidate", "quotenumber", "shipctacphone", "vendauthnumber", "continueonerror" ]
+                      },
+                      "attributevalue" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                },
+                "required" : [ "customerponumber", "ordertype", "shiptoaddress", "lines" ]
+              }
+            },
+            "required" : [ "requestpreamble" ]
+          }
+        }
+      },
+      "QuoteProductList" : {
+        "title" : "quoteProductList",
+        "type" : "object",
+        "x-tags" : [ "quotes" ],
+        "properties" : {
+          "quoteProductGuid" : {
+            "type" : "string"
+          },
+          "quantity" : {
+            "type" : "string"
+          },
+          "comments" : {
+            "type" : "string"
+          },
+          "bidStartDate" : {
+            "type" : "string"
+          },
+          "bidExpiryDate" : {
+            "type" : "string"
+          },
+          "sku" : {
+            "type" : "string"
+          },
+          "lineNumber" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "vendorPartNumber" : {
+            "type" : "string"
+          },
+          "weight" : {
+            "type" : "string"
+          },
+          "isSuggestionProduct" : {
+            "type" : "string"
+          },
+          "vpnCategory" : {
+            "type" : "string"
+          },
+          "quoteProductsSupplierPartAuxiliaryId" : {
+            "type" : "string"
+          },
+          "quoteProductsVendor" : {
+            "type" : "string"
+          },
+          "price" : {
+            "type" : "object",
+            "properties" : {
+              "quotePrice" : {
+                "type" : "number"
+              },
+              "msrp" : {
+                "type" : "number"
+              },
+              "extendedMsrp" : {
+                "type" : "number"
+              },
+              "extendedQuotePrice" : {
+                "type" : "number"
+              }
+            }
+          }
+        }
+      },
+      "quoteDetailsResponse" : {
+        "title" : "quoteDetailsResponse",
+        "type" : "object",
+        "x-tags" : [ "quotes" ],
+        "properties" : {
+          "quoteDetailResponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsePreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responseStatus" : {
+                    "type" : "string"
+                  },
+                  "statusCode" : {
+                    "type" : "string"
+                  },
+                  "responseMessage" : {
+                    "type" : "string"
+                  }
+                }
+              },
+              "retrieveQuoteResponse" : {
+                "type" : "object",
+                "properties" : {
+                  "quoteGuid" : {
+                    "type" : "string"
+                  },
+                  "quoteName" : {
+                    "type" : "string"
+                  },
+                  "quoteNumber" : {
+                    "type" : "string"
+                  },
+                  "quoteExpiryDate" : {
+                    "type" : "string"
+                  },
+                  "revisionNumber" : {
+                    "type" : "string"
+                  },
+                  "introPreamble" : {
+                    "type" : "string"
+                  },
+                  "purchaseInstructions" : {
+                    "type" : "string"
+                  },
+                  "legalTerms" : {
+                    "type" : "string"
+                  },
+                  "currencyCode" : {
+                    "type" : "string"
+                  },
+                  "priceDeviationId" : {
+                    "type" : "string"
+                  },
+                  "priceDeviationStartDate" : {
+                    "type" : "string"
+                  },
+                  "priceDeviationExpiryDate" : {
+                    "type" : "string"
+                  },
+                  "customerNeed" : {
+                    "type" : "string"
+                  },
+                  "solutionProposed" : {
+                    "type" : "string"
+                  },
+                  "status" : {
+                    "type" : "string"
+                  },
+                  "created" : {
+                    "type" : "string"
+                  },
+                  "modified" : {
+                    "type" : "string"
+                  },
+                  "leasingCalculations" : {
+                    "type" : "string"
+                  },
+                  "leasingInstructions" : {
+                    "type" : "string"
+                  },
+                  "accountInfo" : {
+                    "type" : "object",
+                    "properties" : {
+                      "accountName" : {
+                        "type" : "string"
+                      },
+                      "bcn" : {
+                        "type" : "string"
+                      },
+                      "phone" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "contactInfo" : {
+                    "type" : "object",
+                    "properties" : {
+                      "contactEmail" : {
+                        "type" : "string"
+                      },
+                      "contactName" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "vendorAttributes" : {
+                    "type" : "object",
+                    "properties" : {
+                      "estimateId" : {
+                        "type" : "string"
+                      },
+                      "dealId" : {
+                        "type" : "string"
+                      },
+                      "vendorName" : {
+                        "type" : "string"
+                      },
+                      "vendorSettingMessage" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "endUser" : {
+                    "type" : "object",
+                    "properties" : {
+                      "endUserName" : {
+                        "type" : "string"
+                      },
+                      "endUserAddress" : {
+                        "type" : "string"
+                      },
+                      "endUserAddress2" : {
+                        "type" : "string"
+                      },
+                      "endUserAddress3" : {
+                        "type" : "string"
+                      },
+                      "endUserCity" : {
+                        "type" : "string"
+                      },
+                      "endUserState" : {
+                        "type" : "string"
+                      },
+                      "endUserEmail" : {
+                        "type" : "string"
+                      },
+                      "endUserPhone" : {
+                        "type" : "string"
+                      },
+                      "endUserZipCode" : {
+                        "type" : "string"
+                      },
+                      "endUserContactName" : {
+                        "type" : "string"
+                      },
+                      "endUserMarketSegment" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "quoteProductList" : {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/components/schemas/quoteProductList"
+                    }
+                  },
+                  "totalQuoteProductCount" : {
+                    "type" : "string"
+                  },
+                  "totalExtendedMsrp" : {
+                    "type" : "string"
+                  },
+                  "totalQuantity" : {
+                    "type" : "string"
+                  },
+                  "totalExtendedQuotePrice" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "QuoteDetailsRequest" : {
+        "title" : "quoteDetailsRequest",
+        "type" : "object",
+        "properties" : {
+          "quoteProductsRequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestpreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "customerNumber" : {
+                    "type" : "string",
+                    "description" : "Reseller Number (referred to as the account BCN) is the unique identifier for an Ingram Micro customer account."
+                  },
+                  "isoCountryCode" : {
+                    "type" : "string",
+                    "description" : "The ISO country codes are internationally recognized codes designated for each country represented by a two-letter combination (alpha-2)."
+                  }
+                },
+                "required" : [ "customerNumber", "isoCountryCode" ]
+              },
+              "retrieveQuoteProductsRequest" : {
+                "type" : "object",
+                "properties" : {
+                  "quoteNumber" : {
+                    "type" : "string",
+                    "description" : "Unique identifier generated by Ingram Micro's CRM specific to each quote. When applying a filter to the quoteNumber and including a partial quote number in the filter, all quotes containing any information included in the filter can be retrieved as a subset of all available customer quotes."
+                  },
+                  "thirdPartySource" : {
+                    "type" : "string",
+                    "description" : "Unique identifier used to identify the third party source accessing the services."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-examples" : {
+          "Example" : {
+            "quoteProductsRequest" : {
+              "requestPreamble" : {
+                "customerNumber" : "20-222222",
+                "isoCountryCode" : "US"
+              },
+              "retrieveQuoteProductsRequest" : {
+                "quoteNumber" : "QUO-04959-C3V6L4",
+                "thirdPartySource" : "3RDPIDCONWISE"
+              }
+            }
+          }
+        },
+        "description" : "Request schema for get quote details endpoint",
+        "x-tags" : [ "quotes" ]
+      },
+      "QuoteListResponse" : {
+        "title" : "quoteListResponse",
+        "type" : "object",
+        "x-examples" : {
+          "Example" : {
+            "quoteSearchResponse" : {
+              "responsePreamble" : {
+                "responseStatus" : "Passed",
+                "responseStatusCode" : "200",
+                "responseMessage" : "Records Found"
+              },
+              "quotelist" : [ {
+                "quoteGuid" : "dbabb2a5-02ea-e911-a97b-000d3a30e34c",
+                "quoteName" : "TEST-9771006-1920_CW EndUser11",
+                "quoteNumber" : "QUO-11048-S9P1R3",
+                "revisionNumber" : 0,
+                "endUserName" : "CW EndUser11",
+                "bidNumber" : "TEST-9771006-1920",
+                "totalAmount" : "60766.2",
+                "quoteStatus" : "Active",
+                "createdDate" : "2019-10-08",
+                "lastModifiedDate" : "2019-10-08",
+                "quoteExpiryDate" : "0001-01-01"
+              }, {
+                "quoteGuid" : "ec14fd96-02ea-e911-a98d-000d3a30e941",
+                "quoteName" : "TEST-9771006-1920_CW EndUser12",
+                "quoteNumber" : "QUO-11047-M1K1Z6",
+                "revisionNumber" : 0,
+                "endUserName" : "CW EndUser12",
+                "bidNumber" : "TEST-9771006-1920",
+                "totalAmount" : "60766.2",
+                "quoteStatus" : "Active",
+                "createdDate" : "2019-10-08",
+                "lastModifiedDate" : "2019-10-08",
+                "quoteExpiryDate" : "0001-01-01"
+              }, {
+                "quoteGuid" : "f3d7d186-02ea-e911-a98d-000d3a30e941",
+                "quoteName" : "TEST-9771006-1920_CW EndUser10",
+                "quoteNumber" : "QUO-11045-G1X9S8",
+                "revisionNumber" : 0,
+                "endUserName" : "CW EndUser10",
+                "bidNumber" : "TEST-9771006-1920",
+                "totalAmount" : "60766.2",
+                "quoteStatus" : "Active",
+                "createdDate" : "2019-10-08",
+                "lastModifiedDate" : "2019-10-08",
+                "quoteExpiryDate" : "0001-01-01"
+              }, {
+                "quoteGuid" : "43ae3e7f-02ea-e911-a97a-000d3a30eb04",
+                "quoteName" : "TEST-9771006-1920_CW EndUser9",
+                "quoteNumber" : "QUO-11044-V2F8F9",
+                "revisionNumber" : 0,
+                "endUserName" : "CW EndUser9",
+                "bidNumber" : "TEST-9771006-1920",
+                "totalAmount" : "60766.2",
+                "quoteStatus" : "Active",
+                "createdDate" : "2019-10-08",
+                "lastModifiedDate" : "2019-10-08",
+                "quoteExpiryDate" : "0001-01-01"
+              }, {
+                "quoteGuid" : "88062b6f-02ea-e911-a97a-000d3a30eb04",
+                "quoteName" : "TEST-9771006-1920_CW EndUser8",
+                "quoteNumber" : "QUO-11043-W2X1T5",
+                "revisionNumber" : 0,
+                "endUserName" : "CW EndUser8",
+                "bidNumber" : "TEST-9771006-1920",
+                "totalAmount" : "60766.2",
+                "quoteStatus" : "Active",
+                "createdDate" : "2019-10-08",
+                "lastModifiedDate" : "2019-10-08",
+                "quoteExpiryDate" : "0001-01-01"
+              } ],
+              "totalCount" : 5
+            }
+          }
+        },
+        "properties" : {
+          "quoteSearchResponse" : {
+            "type" : "object",
+            "properties" : {
+              "responsePreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "responseStatus" : {
+                    "type" : "string",
+                    "description" : "Status of the Request - \"Passed\", \"Failed\""
+                  },
+                  "responseStatusCode" : {
+                    "type" : "string",
+                    "description" : "responseStatusCode is the code returned in response to a request. The following Codes are returned: 200 400 500"
+                  },
+                  "responseMessage" : {
+                    "type" : "string",
+                    "description" : "200 = Action was successfully received, understood and accepted. 400 = The request contains bad syntax or can not be fullfilled. This means there is a problem with the request. 500 = The server failed to fulfill an apparently valid request. This is a temporary problem, the request should be resubmitted."
+                  }
+                }
+              },
+              "quoteList" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "quoteGuid" : {
+                      "type" : "string",
+                      "description" : "Quote GUID is the primary quote key in Ingram Micro's CRM - needed to retrieve quote details."
+                    },
+                    "quoteName" : {
+                      "type" : "string",
+                      "description" : "Quote Name given to quote by sales team or system generated. Generally used as a reference to identify the quote."
+                    },
+                    "quoteNumber" : {
+                      "type" : "string",
+                      "description" : "Unique identifier generated by Ingram Micro's CRM specific to each quote. When applying a filter to the quoteNumber and including a partial quote number in the filter, all quotes containing any information included in the filter can be retrieved as a subset of all available customer quotes."
+                    },
+                    "revisionNumber" : {
+                      "type" : "string",
+                      "description" : "When a quote has been revised and updated, the quote number remains the same throughout the lifecycle of the quote, however, a Revision number is updated for each revision of the quote. The revision numbers is associated with the Unique Quote Number."
+                    },
+                    "endUserName" : {
+                      "type" : "string",
+                      "description" : "End User Name is the end customer name that is associated with a quote in Ingram Micro's CRM"
+                    },
+                    "bidNumber" : {
+                      "type" : "string",
+                      "description" : "Special Pricing Bid Number, also refers to as Dart Number relates to a unique pricing deal associated with a vendor for the quote."
+                    },
+                    "totalAmount" : {
+                      "type" : "string",
+                      "description" : "Total amount of quoted price for all products in the quote."
+                    },
+                    "quoteStatus" : {
+                      "type" : "string",
+                      "description" : "This refers to the primary status of the quote. API responses will return: Active"
+                    },
+                    "createdDate" : {
+                      "type" : "string",
+                      "description" : "Date the Quote was initially Created",
+                      "format" : "date"
+                    },
+                    "lastModifiedDate" : {
+                      "type" : "string",
+                      "description" : "Date the Quote was last updated or modified.",
+                      "format" : "date"
+                    },
+                    "quoteExpiryDate" : {
+                      "type" : "string",
+                      "description" : "Date the Quote Expires",
+                      "format" : "date"
+                    }
+                  }
+                }
+              },
+              "totalCount" : {
+                "type" : "integer",
+                "description" : "Total count of quotes retrieved in the request response."
+              }
+            }
+          }
+        },
+        "description" : "Response schema for get quote list endpoint",
+        "x-tags" : [ "quotes" ]
+      },
+      "QuoteListRequest" : {
+        "title" : "quoteListRequest",
+        "type" : "object",
+        "x-examples" : {
+          "Example" : {
+            "quoteSearchRequest" : {
+              "requestPreamble" : {
+                "customerNumber" : "20-222222",
+                "customerContact" : "user.name@ingrampartner.com",
+                "isoCountryCode" : "US"
+              },
+              "retrieveQuoteRequest" : {
+                "quoteNumber" : "QUO-02973-V6H8R6",
+                "bidNumber" : "MDMF-1199371-1811",
+                "endUserName" : "CARESOURCE MANAGEMENT GROUP CO.",
+                "quoteStatus" : "3",
+                "fromDate" : "2019-09-01",
+                "toDate" : "2019-09-11",
+                "pageIndex" : 1,
+                "recordsPerPage" : 25,
+                "sorting" : "desc",
+                "sortingColumnName" : "createdon",
+                "thirdPartySource" : "3RDPIDCONWISE"
+              }
+            }
+          }
+        },
+        "properties" : {
+          "quoteSearchRequest" : {
+            "type" : "object",
+            "properties" : {
+              "requestPreamble" : {
+                "type" : "object",
+                "properties" : {
+                  "customerNumber" : {
+                    "type" : "string",
+                    "description" : "Reseller Number (referred to as the account BCN) is the unique identifier for an Ingram Micro customer account.",
+                    "maxLength" : 10
+                  },
+                  "customerContact" : {
+                    "type" : "string",
+                    "description" : "Logged in User's email address.",
+                    "format" : "email"
+                  },
+                  "isoCountryCode" : {
+                    "type" : "string",
+                    "description" : "The ISO country codes are internationally recognized codes designated for each country represented by a two-letter combination (alpha-2).",
+                    "maxLength" : 3
+                  }
+                },
+                "required" : [ "customerNumber", "customerContact", "isoCountryCode" ]
+              },
+              "retrieveQuoteRequest" : {
+                "type" : "object",
+                "properties" : {
+                  "quoteNumber" : {
+                    "type" : "string",
+                    "description" : "Unique identifier generated by Ingram Micro's CRM specific to each quote. When applying a filter to the quoteNumber and including a partial quote number in the filter, all quotes containing any information included in the filter can be retrieved as a subset of all available customer quotes.",
+                    "maxLength" : 100
+                  },
+                  "bidNumber" : {
+                    "type" : "string",
+                    "description" : "Special Pricing Bid Number, also referred to as a Dart Number by some vendors, is a unique identifier associated with vendor specific products and discounts.",
+                    "maxLength" : 100
+                  },
+                  "endUserName" : {
+                    "type" : "string",
+                    "description" : "End User Name is the end customer name that is associated with a quote in Ingram Micro's CRM",
+                    "maxLength" : 300
+                  },
+                  "fromDate" : {
+                    "type" : "string",
+                    "description" : "Filter to select the beginning date of a desired date range. The default filter is set to the date the user is logged-in to request quotes. Date format: YYYY-MM-DD - An incorrect date input will result in a message \"Date must be entered as YYYY-MM-DD\"",
+                    "format" : "date",
+                    "example" : "2019-06-21"
+                  },
+                  "toDate" : {
+                    "type" : "string",
+                    "description" : "Filter to select the end date of a desired date range. The default number of days to request is the previous 30 days from the date user has logged in. Date format: YYYY-MM-DD - An incorrect date input will result in a message \"Date must be entered as YYYY-MM-DD\"",
+                    "format" : "date",
+                    "example" : "2019-06-21"
+                  },
+                  "pageIndex" : {
+                    "type" : "string",
+                    "description" : "Page index or page number for the list of quotes being returned. When less than 25 quotes are returned, the page number will be \"1\". In cases where more than 25 quotes are returned, and the default quotes per page are 25 (see recordPerPage), then the list will continue on subsequent pages."
+                  },
+                  "recordsPerPage" : {
+                    "type" : "string",
+                    "description" : "Number of records (quotes) to display per page in the quote list. The default is 25, but may be increased using the filter by up to 100 records per page. If more than 100 records are requested a message will be returned \"The number of records requested exceeds the 100 record limit.\"\t"
+                  },
+                  "sorting" : {
+                    "type" : "string",
+                    "description" : "Sort applies to the selected column (sortingColumnName) and may be specified in Ascending (asc) or Descending (desc) order. The default sort is Descending (desc) - most recent first.",
+                    "enum" : [ "asc", "desc" ]
+                  },
+                  "sortingColumnName" : {
+                    "type" : "string",
+                    "description" : "Refers to the column selected to apply the sorting criteria. The default column is dateCreated and will sort by the most recently created quote first with the following in descending order. The default filter retrieves quotes created within the last 30 days. Filtering allows user to select a specific column to sort: quoteNumber, createdDate, lastModifiedDate, expiryDate, and endUserName.",
+                    "example" : "toDate",
+                    "maxLength" : 100
+                  },
+                  "thirdPartySource" : {
+                    "type" : "string",
+                    "description" : "Unique identifier used to identify the third party source accessing the services.",
+                    "maxLength" : 100
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description" : "Request schema for get quote list endpoint",
+        "x-tags" : [ "quotes" ]
+      },
+      "AdditionalAttribute" : {
+        "type" : "object",
+        "properties" : {
+          "attributeName" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "attributeValue" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "CarrierDetailB2B" : {
+        "type" : "object",
+        "properties" : {
+          "carrierCode" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "carrierName" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "quantity" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true
+          },
+          "shippedDate" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "estimatedDeliveryDate" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "deliveredDate" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "carrierPickupDate" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "trackingDetails" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TrackingDetailB2B"
+            },
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "Contractinfo" : {
+        "type" : "object",
+        "properties" : {
+          "contractDescription" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "contractNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "contractStatus" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "contractStartDate" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "contractEndDate" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "contractDuration" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "Error" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "type" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "message" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "fields" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Fields"
+            },
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "ErrorResponseDTO" : {
+        "type" : "object",
+        "properties" : {
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Error"
+            },
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "Fields" : {
+        "type" : "object",
+        "properties" : {
+          "field" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "message" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "value" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "LicenseInfo" : {
+        "type" : "object",
+        "properties" : {
+          "licenseNumber" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            },
+            "nullable" : true
+          },
+          "licenseStartDate" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "licenseEndDate" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "quantity" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "LineB2B" : {
+        "type" : "object",
+        "properties" : {
+          "subOrderNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "ingramOrderLineNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "vendorSalesOrderLineNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "customerLineNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "lineStatus" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "ingramPartNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "vendorPartNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "vendorName" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "partDescription" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "unitWeight" : {
+            "type" : "number",
+            "format" : "double"
+          },
+          "weightUom" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "unitPrice" : {
+            "type" : "number",
+            "format" : "double"
+          },
+          "upcCode" : {
+            "type" : "string",
+            "default" : "",
+            "nullable" : true
+          },
+          "extendedPrice" : {
+            "type" : "number",
+            "format" : "double"
+          },
+          "taxAmount" : {
+            "type" : "number",
+            "format" : "double"
+          },
+          "currencyCode" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "quantityOrdered" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "quantityConfirmed" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "quantityBackOrdered" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "specialBidNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "requestedDeliverydate" : {
+            "type" : "string",
+            "default" : "",
+            "nullable" : true
+          },
+          "promisedDeliveryDate" : {
+            "type" : "string",
+            "default" : "",
+            "nullable" : true
+          },
+          "lineNotes" : {
+            "type" : "string",
+            "default" : "",
+            "nullable" : true
+          },
+          "shipmentDetails" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ShipmentDetailB2B"
+            },
+            "nullable" : true
+          },
+          "serviceContractInfo" : {
+            "$ref" : "#/components/schemas/Servicecontractinfo"
+          },
+          "additionalAttributes" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AdditionalAttribute"
+            },
+            "nullable" : true
+          },
+          "links" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Link"
+            },
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "Link" : {
+        "type" : "object",
+        "properties" : {
+          "topic" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "href" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "type" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "MiscellaneousChargeB2BDto" : {
+        "type" : "object",
+        "properties" : {
+          "subOrderNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "chargeLineReference" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "chargeDescription" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "chargeAmount" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "OrderDetailB2B" : {
+        "type" : "object",
+        "properties" : {
+          "ingramOrderNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "ingramOrderDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "orderType" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "customerOrderNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "endCustomerOrderNumber" : {
+            "type" : "string",
+            "default" : "",
+            "nullable" : true
+          },
+          "webOrderId" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "vendorSalesOrderNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "ingramPurchaseOrderNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "orderStatus" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "orderTotal" : {
+            "type" : "number",
+            "format" : "double"
+          },
+          "orderSubTotal" : {
+            "type" : "number",
+            "format" : "double"
+          },
+          "freightCharges" : {
+            "type" : "number",
+            "format" : "double"
+          },
+          "currencyCode" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "totalWeight" : {
+            "type" : "number",
+            "format" : "double"
+          },
+          "totalTax" : {
+            "type" : "number",
+            "format" : "double"
+          },
+          "paymentTerms" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "notes" : {
+            "type" : "string",
+            "default" : "",
+            "nullable" : true
+          },
+          "billToInfo" : {
+            "$ref" : "#/components/schemas/OrderDetailB2BAddressDto"
+          },
+          "shipToInfo" : {
+            "$ref" : "#/components/schemas/OrderDetailB2BAddressDto"
+          },
+          "endUserInfo" : {
+            "$ref" : "#/components/schemas/OrderDetailB2BAddressDto"
+          },
+          "lines" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LineB2B"
+            },
+            "nullable" : true
+          },
+          "miscellaneousCharges" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MiscellaneousChargeB2BDto"
+            },
+            "nullable" : true
+          },
+          "additionalAttributes" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AdditionalAttribute"
+            },
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "OrderDetailB2BAddressDto" : {
+        "type" : "object",
+        "properties" : {
+          "contact" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "companyName" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "addressLine1" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "addressLine2" : {
+            "type" : "string",
+            "default" : "",
+            "nullable" : true
+          },
+          "addressLine3" : {
+            "type" : "string",
+            "default" : "",
+            "nullable" : true
+          },
+          "city" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "state" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "postalCode" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "countryCode" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "phoneNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "email" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "SerialNumberB2B" : {
+        "type" : "object",
+        "properties" : {
+          "serialNumber" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "Servicecontractinfo" : {
+        "type" : "object",
+        "properties" : {
+          "contractInfo" : {
+            "$ref" : "#/components/schemas/Contractinfo"
+          },
+          "subscriptions" : {
+            "$ref" : "#/components/schemas/Subscriptions"
+          },
+          "licenseInfo" : {
+            "$ref" : "#/components/schemas/LicenseInfo"
+          }
+        },
+        "additionalProperties" : false
+      },
+      "ShipmentDetailB2B" : {
+        "type" : "object",
+        "properties" : {
+          "quantity" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "deliveryNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "estimatedShipDate" : {
+            "type" : "string",
+            "default" : "",
+            "nullable" : true
+          },
+          "shipFromWarehouseId" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "shipFromLocation" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "invoiceNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "invoiceDate" : {
+            "type" : "string",
+            "default" : "",
+            "nullable" : true
+          },
+          "carrierDetails" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CarrierDetailB2B"
+            },
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "Subscriptions" : {
+        "type" : "object",
+        "properties" : {
+          "subscriptionId" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "subscriptionTerm" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "renewalTerm" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "billingModel" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "subcriptionStartDate" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "subcriptionEndDate" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      },
+      "TrackingDetailB2B" : {
+        "type" : "object",
+        "properties" : {
+          "trackingNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "trackingUrl" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "packageWeight" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "cartonNumber" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "quantityInBox" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "serialNumbers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SerialNumberB2B"
+            },
+            "nullable" : true
+          }
+        },
+        "additionalProperties" : false
+      }
+    },
+    "securitySchemes" : {
+      "application" : {
+        "type" : "oauth2",
+        "flows" : {
+          "clientCredentials" : {
+            "tokenUrl" : "https://api.ingrammicro.com:443/oauth/oauth30/token",
+            "scopes" : {
+              "write" : "allows modifying resources",
+              "read" : "allows reading resources"
+            }
+          }
+        },
+        "description" : ""
+      }
+    }
+  }
+}

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -33,7 +33,8 @@ function RunTests {
         # "petstore-minimal",
         # "petstore-simple",
         # "petstore-with-external-docs",
-        "petstore"
+        "petstore",
+        "IngramMicro"
     )
     "v2.0", "v3.0" | ForEach-Object {
         $version = $_
@@ -96,9 +97,6 @@ function RunTests {
     }    
 }
 
-Remove-Item ./v2.0-*.cs -Force
-Remove-Item ./v3.0-*.cs -Force
-Remove-Item ./v3.1-*.cs -Force
-Remove-Item ./**/*Output.cs -Force
+Remove-Item * -Include *.cs -Recurse -Force -Exclude *Program.cs
 Measure-Command { RunTests -Method "dotnet-run" -Parallel $Parallel }
 Write-Host "`r`n"


### PR DESCRIPTION
Hi there,

I was having some issues with refitter so I've created a fix for them, I hope they're of some use.

Things I've changed are:
* Multiline descriptions show on new lines without being commented out
* Query string parameter names aren't being encoded safely, things like dashes and reserved keywords causing problems
* Client methods aren't being encoded safely, this pull request just deals with full stops, I couldn't see any way to leverage NSwag's encoding
* Properties with no names aren't generated correctly. This one is weird and might be a bit specific to the doc I'm generating from.
* Fixed the smoke-test.ps1 cleanup of generated files
* Added vscode files
* Added IngramMicro.json sample for smoke tests