### PR TITLE
Charge Target Framework to .NET 6.0 (LTS)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
-      "program": "${workspaceFolder}/src/Refitter/bin/Debug/net7.0/refitter.dll",
+      "program": "${workspaceFolder}/src/Refitter/bin/Debug/net6.0/refitter.dll",
       "args": [
         "${workspaceFolder}/test/OpenAPI/v3.0/IngramMicro.json",
         "--namespace",

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Returns a response that looks something like this:
 ```
 
 ## System requirements
-.NET 7.0
+.NET 6.0 (LTS)
 
 #
 

--- a/src/Refitter.Tests/Refitter.Tests.csproj
+++ b/src/Refitter.Tests/Refitter.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Refitter/Refitter.csproj
+++ b/src/Refitter/Refitter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>


### PR DESCRIPTION
There is really no reason behind why this project targetted .NET 7.0 so I'm lowering it to .NET 6.0 to ensure that developers that work with constraints that require them to only use LTS versions of .NET can also use Refitter

This change was requested by @kirides and resolves #17 