### PR TITLE
Introduce Error logging using Exceptionless

### DIFF
--- a/src/Refitter/Program.cs
+++ b/src/Refitter/Program.cs
@@ -1,9 +1,12 @@
 ﻿using System.ComponentModel;
+using Exceptionless;
+using Exceptionless.Plugins;
 using Refitter.Core;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using ValidationResult = Spectre.Console.ValidationResult;
 
+ExceptionlessClient.Default.Startup("pRql7vmgecZ0Iph6MU5TJE5XsZeesdTe0yx7TN4f");
 
 var app = new CommandApp<GenerateCommand>();
 app.Configure(

--- a/src/Refitter/Refitter.csproj
+++ b/src/Refitter/Refitter.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Exceptionless" Version="6.0.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The changes here introduce logging errors to a 3rd party service called [Exceptionless](https://exceptionless.io/). Users can opt out of error logging by setting the CLI tool's `-no-logging` argument. By default, all exceptions are logged