### PR TITLE
Fix inconsistent line endings in generated file

### DIFF
--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -40,7 +40,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         {
             AnsiConsole.MarkupLine($"[green]Support key: {SupportInformation.GetSupportKey()}{crlf}[/]");
             var generator = await RefitGenerator.CreateAsync(refitGeneratorSettings);
-            var code = generator.Generate();
+            var code = generator.Generate().ReplaceLineEndings();
             await File.WriteAllTextAsync(settings.OutputPath ?? "Output.cs", code);
             AnsiConsole.MarkupLine($"[green]Output: {code.Length} bytes[/]");
             await Analytics.LogFeatureUsage(settings);


### PR DESCRIPTION
Replaces all newline sequences in the generated code with [`Environment.NewLine`](https://learn.microsoft.com/en-us/dotnet/api/system.environment.newline?view=net-6.0#system-environment-newline) using [`String.ReplaceLineEndings()`](https://learn.microsoft.com/en-us/dotnet/api/system.string.replacelineendings?view=net-6.0#system-string-replacelineendings) on the generated code

This resolves #57 