### PR TITLE
Add support for multipart/form-data file uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,4 +269,5 @@ test/**/*Petstore*.cs
 test/**/*Uber.cs
 test/**/*Uspto.cs
 test/**/*Ingram-micro.cs
+test/**/*Hubspot*.cs
 *.lutconfig

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "Refitter.sln"
+}

--- a/src/Refitter.Core/OperationNameGenerator.cs
+++ b/src/Refitter.Core/OperationNameGenerator.cs
@@ -12,7 +12,7 @@ public class OperationNameGenerator : IOperationNameGenerator
 
     public OperationNameGenerator(OpenApiDocument document)
     {
-        if (this.CheckForDuplicateOperationIds(document))
+        if (CheckForDuplicateOperationIds(document))
             defaultGenerator = new MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator();
     }
 
@@ -33,12 +33,8 @@ public class OperationNameGenerator : IOperationNameGenerator
             .CapitalizeFirstCharacter()
             .ConvertKebabCaseToPascalCase()
             .ConvertRouteToCamelCase();
-}
 
-public static class IOperationNameGeneratorExtensions
-{
-    public static bool CheckForDuplicateOperationIds(
-        this IOperationNameGenerator generator,
+    public bool CheckForDuplicateOperationIds(
         OpenApiDocument document)
     {
         List<string> operationNames = new();
@@ -48,7 +44,7 @@ public static class IOperationNameGeneratorExtensions
             {
                 var operation = operations.Value;
                 operationNames.Add(
-                    generator.GetOperationName(
+                    GetOperationName(
                         document,
                         kv.Key,
                         operations.Key,

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -9,12 +9,10 @@ namespace Refitter.Core;
 public static class ParameterExtractor
 {
     public static IEnumerable<string> GetParameters(
-        CustomCSharpClientGenerator generator,
+        CSharpOperationModel operationModel,
         OpenApiOperation operation,
         RefitGeneratorSettings settings)
     {
-        var operationModel = generator.CreateOperationModel(operation);
-
         var routeParameters = operationModel.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Path)
             .Select(p => $"{JoinAttributes(GetAliasAsAttribute(p))}{p.Type} {p.VariableName}")

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -32,7 +32,7 @@ public static class ParameterExtractor
 
         var headerParameters = new List<string>();
 
-        if(settings.GenerateOperationHeaders)
+        if (settings.GenerateOperationHeaders)
         {
             headerParameters = operationModel.Parameters
                 .Where(p => p.Kind == OpenApiParameterKind.Header && p.IsHeader)
@@ -40,9 +40,9 @@ public static class ParameterExtractor
                 .ToList();
         }
 
-        var multipartFormParameters = operationModel.Parameters
+        var binaryBodyParameters = operationModel.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Body && p.IsBinaryBodyParameter)
-            .Select(p => $"{JoinAttributes("Body(BodySerializationMethod.UrlEncoded)", GetAliasAsAttribute(p))}Dictionary<string, object> {p.VariableName}")
+            .Select(p => $"{GetAliasAsAttribute(p)}StreamPart {p.VariableName}")
             .ToList();
 
         var parameters = new List<string>();
@@ -50,7 +50,7 @@ public static class ParameterExtractor
         parameters.AddRange(queryParameters);
         parameters.AddRange(bodyParameters);
         parameters.AddRange(headerParameters);
-        parameters.AddRange(multipartFormParameters);
+        parameters.AddRange(binaryBodyParameters);
 
         if (settings.UseCancellationTokens)
             parameters.Add("CancellationToken cancellationToken = default");

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -39,7 +39,7 @@ public static class ParameterExtractor
         }
 
         var binaryBodyParameters = operationModel.Parameters
-            .Where(p => p.Kind == OpenApiParameterKind.Body && p.IsBinaryBodyParameter)
+            .Where(p => p.Kind == OpenApiParameterKind.Body && p.IsBinaryBodyParameter || p.IsFile)
             .Select(p => $"{GetAliasAsAttribute(p)}StreamPart {p.VariableName}")
             .ToList();
 

--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -51,7 +51,8 @@ public class RefitInterfaceGenerator
                 var name = generator.BaseSettings.OperationNameGenerator
                     .GetOperationName(document, kv.Key, verb, operation);
 
-                var parameters = ParameterExtractor.GetParameters(generator, operation, settings);
+                var operationModel = generator.CreateOperationModel(operation);
+                var parameters = ParameterExtractor.GetParameters(operationModel, operation, settings);
                 var parametersString = string.Join(", ", parameters);
 
                 GenerateMethodXmlDocComments(operation, code);

--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -57,6 +57,11 @@ public class RefitInterfaceGenerator
 
                 GenerateMethodXmlDocComments(operation, code);
 
+                if (operationModel.Consumes.Contains("multipart/form-data"))
+                {
+                    code.AppendLine($"{Separator}{Separator}[Multipart]");
+                }
+
                 code.AppendLine($"{Separator}{Separator}[{verb}(\"{kv.Key}\")]")
                     .AppendLine($"{Separator}{Separator}{returnType} {name}({parametersString});")
                     .AppendLine();

--- a/src/Refitter.Tests/MultiPartFormDataTests.cs
+++ b/src/Refitter.Tests/MultiPartFormDataTests.cs
@@ -11,10 +11,22 @@ public class MultiPartFormDataTests
 {
    ""openapi"":""3.0.2"",
    ""paths"":{
-      ""/uploadFile"":{
+      ""/foo/{id}/files"":{
          ""post"":{
             ""summary"":""uploads a file"",
             ""operationId"":""uploadFile"",
+            ""parameters"":[
+               {
+                  ""name"":""id"",
+                  ""in"":""path"",
+                  ""description"":""Id of the foo resource"",
+                  ""required"":true,
+                  ""schema"":{
+                     ""type"":""integer"",
+                     ""format"":""int64""
+                  }
+               }
+            ],
             ""requestBody"":{
                ""content"":{
                   ""multipart/form-data"":{
@@ -37,33 +49,7 @@ public class MultiPartFormDataTests
             },
             ""responses"":{
                ""200"":{
-                  ""description"":""successful operation"",
-                  ""content"":{
-                     ""application/json"":{
-                        ""schema"":{
-                           ""$ref"":""#/components/schemas/ApiResponse""
-                        }
-                     }
-                  }
-               }
-            }
-         }
-      }
-   },
-   ""components"":{
-      ""schemas"":{
-         ""ApiResponse"":{
-            ""type"":""object"",
-            ""properties"":{
-               ""code"":{
-                  ""type"":""integer"",
-                  ""format"":""int32""
-               },
-               ""type"":{
-                  ""type"":""string""
-               },
-               ""message"":{
-                  ""type"":""string""
+                  ""description"":""successful operation""
                }
             }
          }

--- a/src/Refitter.Tests/MultiPartFormDataTests.cs
+++ b/src/Refitter.Tests/MultiPartFormDataTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests;
+
+public class MultiPartFormDataTests
+{
+    private const string OpenApiSpec = @"
+{
+   ""openapi"":""3.0.2"",
+   ""paths"":{
+      ""/uploadFile"":{
+         ""post"":{
+            ""summary"":""uploads a file"",
+            ""operationId"":""uploadFile"",
+            ""requestBody"":{
+               ""content"":{
+                  ""multipart/form-data"":{
+                     ""schema"":{
+                        ""type"":""object"",
+                        ""properties"":{
+                           ""formFile"":{
+                              ""type"":""string"",
+                              ""format"":""binary""
+                           }
+                        }
+                     },
+                     ""encoding"":{
+                        ""formFile"":{
+                           ""style"":""form""
+                        }
+                     }
+                  }
+               }
+            },
+            ""responses"":{
+               ""200"":{
+                  ""description"":""successful operation"",
+                  ""content"":{
+                     ""application/json"":{
+                        ""schema"":{
+                           ""$ref"":""#/components/schemas/ApiResponse""
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   },
+   ""components"":{
+      ""schemas"":{
+         ""ApiResponse"":{
+            ""type"":""object"",
+            ""properties"":{
+               ""code"":{
+                  ""type"":""integer"",
+                  ""format"":""int32""
+               },
+               ""type"":{
+                  ""type"":""string""
+               },
+               ""message"":{
+                  ""type"":""string""
+               }
+            }
+         }
+      }
+   }
+}
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public async Task Generated_Code_Contains_MultiPart_Attribute()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().Contain("[Multipart]");
+    }
+
+    [Fact]
+    public async Task Generated_Code_Contains_StreamPart_Parameter()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().Contain("StreamPart");
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.json";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}


### PR DESCRIPTION
The changes here adds support for `multipart/form-data` requests with a binary body. This is done by adding the `[Multipart]` attribute to the generated method and using `StreamPart` for the request body

The following OpenAPI v3 specifications

```json
{
   "openapi":"3.0.2",
   "paths":{
      "/foo/{id}/files":{
         "post":{
            "summary":"uploads a file",
            "operationId":"uploadFile",
            "parameters":[
               {
                  "name":"id",
                  "in":"path",
                  "description":"Id of the foo resource",
                  "required":true,
                  "schema":{
                     "type":"integer",
                     "format":"int64"
                  }
               }
            ],
            "requestBody":{
               "content":{
                  "multipart/form-data":{
                     "schema":{
                        "type":"object",
                        "properties":{
                           "formFile":{
                              "type":"string",
                              "format":"binary"
                           }
                        }
                     },
                     "encoding":{
                        "formFile":{
                           "style":"form"
                        }
                     }
                  }
               }
            },
            "responses":{
               "200":{
                  "description":"successful operation"
               }
            }
         }
      }
   }
}
```

Generates the following Refit interface

```cs
public interface IApiClient
{
    [Multipart]
    [Post("/foo/{id}/files")]
    Task UploadFile(long id, StreamPart formFile);
}
```

This resolves #62 