### PR TITLE
Enhanced HTTP status code 200 handling for API responses

### DIFF
--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -42,9 +42,10 @@ public class RefitInterfaceGenerator
             {
                 var operation = operations.Value;
 
-                var returnTypeParameter = operation.Responses.ContainsKey("200")
-                    ? generator.GetTypeName(operation.Responses["200"].ActualResponse.Schema, true, null)
-                    : null;
+                var returnTypeParameter = new[] { "200", "201", "203", "206" }
+                    .Where(code => operation.Responses.ContainsKey(code))
+                    .Select(code => generator.GetTypeName(operation.Responses[code].ActualResponse.Schema, true, null))
+                    .FirstOrDefault();
 
                 var returnType = GetReturnType(returnTypeParameter);
 

--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -1,6 +1,8 @@
 using NSwag;
 using System;
 using System.Text;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Refitter.Core;
 


### PR DESCRIPTION
Enhanced HTTP status code handling for API responses

Previously, our API handling logic only checked for a '200' HTTP status code to retrieve the response schema. However, there are several other success status codes, like '201', '203', and '206', which also indicate that the request was successful and can include a response schema.

https://restfulapi.net/http-status-codes/#2xx
