### PR TITLE
Rename source generator output to use .refitter file and replace extension with .g.cs

### DIFF
--- a/src/Refitter.Core/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/RefitGeneratorSettings.cs
@@ -123,13 +123,6 @@ public class NamingSettings
     [JsonPropertyName("interfaceName")]
     [JsonProperty("interfaceName")]
     public string InterfaceName { get; set; } = "ApiClient";
-
-    /// <summary>
-    /// Gets or sets the name of the output file. Default is "ApiClient".
-    /// </summary>
-    [JsonPropertyName("filename")]
-    [JsonProperty("filename")]
-    public string Filename { get; set; } = "ApiClient";
 }
 
 /// <summary>


### PR DESCRIPTION
Removed filename settings from the RefitGeneratorSettings and made it use the original filename from the AdditionalText file (replacing '.refitter' with '.g.cs'). This makes the filename handling more straightforward since the output filename doesn't need to be fetched from settings and can be directly derived from the AdditionalText file.