### PR TITLE
Generate Multiple interfaces based on first Tag

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -57,7 +57,7 @@ jobs:
         ${{ inputs.command }} ./openapi.${{ inputs.format }} --namespace "$namespace.Interface" --output "I$outputPath" --interface-only --no-logging
         ${{ inputs.command }} ./openapi.${{ inputs.format }} --namespace "$namespace.UsingApiResponse" --output "IApi$outputPath" --interface-only --return-api-response --no-logging
         ${{ inputs.command }} ./openapi.${{ inputs.format }} --namespace "$namespace.UsingIsoDateFormat" --output "UsingIsoDateFormat$outputPath" --use-iso-date-format --no-logging
-        ${{ inputs.command }} ./openapi.${{ inputs.format }} --namespace "$namespace.MultipleInterfaces" --output "MultipleInterfaces$outputPath" --multiple-interfaces --no-logging
+        ${{ inputs.command }} ./openapi.${{ inputs.format }} --namespace "$namespace.MultipleInterfaces" --output "MultipleInterfaces$outputPath" --multiple-interfaces byEndpoint --no-logging
         Copy-Item $outputPath ./OpenAPI/${{ inputs.version }}/${{ inputs.openapi }}.${{ inputs.format }}.cs
         Copy-Item $outputPath ./ConsoleApp/Net6/
         Copy-Item $outputPath ./ConsoleApp/Net7/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ EXAMPLES:
     refitter ./openapi.json --no-operation-headers
     refitter ./openapi.json --use-iso-date-format
     refitter ./openapi.json --additional-namespace "Your.Additional.Namespace" --additional-namespace "Your.Other.Additional.Namespace"
-    refitter ./openapi.json --multiple-interfaces
+    refitter ./openapi.json --multiple-interfaces ByEndpoint
 
 ARGUMENTS:
     [URL or input file]    URL or file path to OpenAPI Specification file
@@ -62,7 +62,7 @@ OPTIONS:
         --no-logging                                   Don't log errors or collect telemetry                                                                        
         --additional-namespace                         Add additional namespace to generated types                                                                  
         --use-iso-date-format                          Explicitly format date query string parameters in ISO 8601 standard date format using delimiters (2023-06-15)
-        --multiple-interfaces                          Generate a Refit interface for each endpoint                                                                                                                       
+        --multiple-interfaces                          Generate a Refit interface for each endpoint. May be one of ByEndpoint, ByTag
 ```
 
 To generate code from an OpenAPI specifications file, run the following:
@@ -111,7 +111,7 @@ The following is an example `.refitter` file
   "typeAccessibility": "Public", // Optional. Values=Public|Internal. Default=Public
   "useCancellationTokens": false, // Optional. Default=false
   "useIsoDateFormat": false, // Optional. Default=false
-  "multipleInterfaces": false, // Optional. Default=false
+  "multipleInterfaces": "ByEndpoint", // Optional. May be one of "ByEndpoint" or "ByTag"
   "additionalNamespaces": [ // Optional
     "Namespace1",
     "Namespace2"
@@ -131,7 +131,7 @@ The following is an example `.refitter` file
 - `typeAccessibility` - the generated type accessibility. Possible values are `Public` and `Internal`. Default is `Public`
 - `useCancellationTokens` - Use cancellation tokens in the generated methods. Default is `false`
 - `useIsoDateFormat` - Set to `true` to explicitly format date query string parameters in ISO 8601 standard date format using delimiters (for example: 2023-06-15). Default is `false`
-- `multipleInterfaces` - Set to `true` to generate an interface for each endpoint. Default is `false`
+- `multipleInterfaces` - Set to `ByEndpoint` to generate an interface for each endpoint, or `ByTag` to group Endpoints by their Tag (like SwaggerUI groups them).
 - `additionalNamespaces` - A collection of additional namespaces to include in the generated file. A use case for this is when you want to reuse contracts from a different namespace than the generated code. Default is empty
 
 
@@ -397,7 +397,7 @@ Here's an example generated output from the [Swagger Petstore example](https://p
 **CLI Tool**
 
 ```bash
-$ refitter ./openapi.json --namespace "Your.Namespace.Of.Choice.GeneratedCode" --multiple-interfaces
+$ refitter ./openapi.json --namespace "Your.Namespace.Of.Choice.GeneratedCode" --multiple-interfaces ByEndpoint
 ```
 
 **Source Generator ***.refitter*** file**
@@ -406,7 +406,7 @@ $ refitter ./openapi.json --namespace "Your.Namespace.Of.Choice.GeneratedCode" -
 {
   "openApiPath": "./openapi.json",
   "namespace": "Your.Namespace.Of.Choice.GeneratedCode",
-  "multipleInterfaces": true
+  "multipleInterfaces": "ByEndpoint"
 }
 ```
 

--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -49,9 +49,12 @@ public class RefitGenerator
                 generator.GenerateFile(),
                 (current, import) => current.Replace($"{import}.", string.Empty));
 
-        IRefitInterfaceGenerator interfaceGenerator = settings.MultipleInterfaces
-            ? new RefitMultipleInterfaceGenerator(settings, document, generator)
-            : new RefitInterfaceGenerator(settings, document, generator);
+        IRefitInterfaceGenerator interfaceGenerator = settings.MultipleInterfaces switch
+        {
+            MultipleInterfaces.ByEndpoint => new RefitMultipleInterfaceGenerator(settings, document, generator),
+            MultipleInterfaces.ByTag => new RefitMultipleInterfaceByTagGenerator(settings, document, generator),
+            _ => new RefitInterfaceGenerator(settings, document, generator),
+        };
 
         var client = GenerateClient(interfaceGenerator);
         return new StringBuilder()

--- a/src/Refitter.Core/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/RefitGeneratorSettings.cs
@@ -1,7 +1,9 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Refitter.Core;
 
@@ -101,7 +103,21 @@ public class RefitGeneratorSettings
     /// </summary>
     [JsonPropertyName("multipleInterfaces")]
     [JsonProperty("multipleInterfaces")]
-    public bool MultipleInterfaces { get; set; }
+    [Newtonsoft.Json.JsonConverter(typeof(StringEnumConverter))]
+    public MultipleInterfaces MultipleInterfaces { get; set; }
+}
+
+public enum MultipleInterfaces
+{
+    [JsonPropertyName("unset")]
+    [JsonProperty("unset")]
+    Unset,
+    [JsonPropertyName("byEndpoint")]
+    [JsonProperty("byEndpoint")]
+    ByEndpoint,
+    [JsonPropertyName("byTag")]
+    [JsonProperty("byTag")]
+    ByTag
 }
 
 /// <summary>

--- a/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
@@ -1,0 +1,182 @@
+﻿using System.Text;
+
+using NSwag;
+
+namespace Refitter.Core;
+
+internal class RefitMultipleInterfaceByTagGenerator : IRefitInterfaceGenerator
+{
+    private const string Separator = "    ";
+
+    private readonly RefitGeneratorSettings settings;
+    private readonly OpenApiDocument document;
+    private readonly CustomCSharpClientGenerator generator;
+
+    internal RefitMultipleInterfaceByTagGenerator(
+        RefitGeneratorSettings settings,
+        OpenApiDocument document,
+        CustomCSharpClientGenerator generator)
+    {
+        this.settings = settings;
+        this.document = document;
+        this.generator = generator;
+        generator.BaseSettings.OperationNameGenerator = new OperationNameGenerator(document);
+    }
+
+    public string GenerateCode()
+    {
+        var ungroupedTitle = settings.Naming.UseOpenApiTitle
+            ? document.Info?.Title?
+                  .Replace(" ", string.Empty)
+                  .Replace("-", string.Empty)
+                  .Replace(".", string.Empty) ??
+              "ApiClient"
+            : settings.Naming.InterfaceName;
+        ungroupedTitle = ungroupedTitle.CapitalizeFirstCharacter();
+
+        var byGroup = document.Paths
+            .SelectMany(x => x.Value, (k, v) => (PathItem: k, Operation: v))
+            .GroupBy(x => GetGroupName(x.Operation.Value, ungroupedTitle), (k, v) => new {Key = k, Combined = v});
+
+        Dictionary<string, StringBuilder> interfacesByGroup = new();
+        foreach (var kv in byGroup)
+        {
+            foreach (var op in kv.Combined)
+            {
+                var operations = op.Operation;
+                var pathItem = op.PathItem;
+                var operation = operations.Value;
+
+                var returnTypeParameter = new[] {"200", "201", "203", "206"}
+                    .Where(code => operation.Responses.ContainsKey(code))
+                    .Select(code => generator.GetTypeName(operation.Responses[code].ActualResponse.Schema, true, null))
+                    .FirstOrDefault();
+
+                var returnType = GetReturnType(returnTypeParameter);
+
+                var verb = operations.Key.CapitalizeFirstCharacter();
+
+                if (!interfacesByGroup.TryGetValue(kv.Key, out var sb))
+                {
+                    interfacesByGroup[kv.Key] = sb = new StringBuilder();
+                    GenerateInterfaceXmlDocComments(operation, sb);
+                    sb.AppendLine($$"""
+                                    {{GenerateInterfaceDeclaration(GetInterfaceName(kv.Key, sb))}}
+                                    {{Separator}}{
+                                    """);
+                }
+
+                var operationModel = generator.CreateOperationModel(operation);
+                var parameters = ParameterExtractor.GetParameters(operationModel, operation, settings);
+                var parametersString = string.Join(", ", parameters);
+
+                GenerateMethodXmlDocComments(operation, sb);
+
+                if (operationModel.Consumes.Contains("multipart/form-data"))
+                {
+                    sb.AppendLine($"{Separator}{Separator}[Multipart]");
+                }
+
+                var opName = GetOperationName(op.PathItem.Key, operations.Key, operation, returnType, sb);
+                sb.AppendLine($"{Separator}{Separator}[{verb}(\"{op.PathItem.Key}\")]")
+                    .AppendLine($"{Separator}{Separator}{returnType} {opName}({parametersString});")
+                    .AppendLine();
+            }
+        }
+
+        var code = new StringBuilder();
+        foreach (var kv in interfacesByGroup)
+        {
+            while (char.IsWhiteSpace(kv.Value[kv.Value.Length - 1]))
+            {
+                kv.Value.Length--;
+            }
+
+            code.AppendLine(kv.Value.ToString());
+            code.AppendLine($"{Separator}}}");
+            code.AppendLine();
+        }
+
+        return code.ToString();
+    }
+
+    private string GetGroupName(OpenApiOperation operation, string ungroupedTitle)
+    {
+        if (operation.Tags.FirstOrDefault() is string group && !string.IsNullOrWhiteSpace(group))
+        {
+            return group.Replace(" ", string.Empty)
+                .Replace("-", string.Empty)
+                .Replace(".", string.Empty)
+                .CapitalizeFirstCharacter();
+        }
+
+        return ungroupedTitle;
+    }
+
+    private string GetInterfaceName(string name,
+        StringBuilder stringBuilder) =>
+        StringSuffixUtils.InterfaceNameWithCounter(
+            stringBuilder,
+            name.CapitalizeFirstCharacter());
+
+    private string GetOperationName(
+        string name,
+        string verb,
+        OpenApiOperation operation,
+        string returnType,
+        StringBuilder stringBuilder)
+        => generator
+            .BaseSettings
+            .OperationNameGenerator
+            .GetOperationName(document, name, verb, operation);
+
+    private string GetReturnType(string? returnTypeParameter)
+    {
+        return returnTypeParameter is null or "void"
+            ? "Task"
+            : GetConfiguredReturnType(returnTypeParameter);
+    }
+
+    private string GetConfiguredReturnType(string returnTypeParameter)
+    {
+        return settings.ReturnIApiResponse
+            ? $"Task<IApiResponse<{WellKnownNamesspaces.TrimImportedNamespaces(returnTypeParameter)}>>"
+            : $"Task<{WellKnownNamesspaces.TrimImportedNamespaces(returnTypeParameter)}>";
+    }
+
+    private void GenerateInterfaceXmlDocComments(OpenApiOperation operation, StringBuilder code)
+    {
+        if (!settings.GenerateXmlDocCodeComments ||
+            string.IsNullOrWhiteSpace(operation.Summary))
+            return;
+
+        code.AppendLine(
+            $$"""
+              {{Separator}}/// <summary>
+              {{Separator}}/// {{operation.Summary}}
+              {{Separator}}/// </summary>
+              """);
+    }
+
+    private void GenerateMethodXmlDocComments(OpenApiOperation operation, StringBuilder code)
+    {
+        if (!settings.GenerateXmlDocCodeComments)
+            return;
+
+        if (!string.IsNullOrWhiteSpace(operation.Description))
+        {
+            code.AppendLine($"{Separator}{Separator}/// <summary>");
+
+            foreach (var line in operation.Description.Split(new[] {"\r\n", "\r", "\n"}, StringSplitOptions.None))
+                code.AppendLine($"{Separator}{Separator}/// {line.Trim()}");
+
+            code.AppendLine($"{Separator}{Separator}/// </summary>");
+        }
+    }
+
+    private string GenerateInterfaceDeclaration(string name)
+    {
+        var modifier = settings.TypeAccessibility.ToString().ToLowerInvariant();
+        return $"{Separator}{modifier} interface I{name.CapitalizeFirstCharacter()}Api";
+    }
+}

--- a/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using System.Text;
 
 using NSwag;
@@ -74,26 +75,14 @@ internal class RefitMultipleInterfaceGenerator : IRefitInterfaceGenerator
         string verb,
         OpenApiOperation operation,
         StringBuilder stringBuilder) =>
-        SuffixDuplicateNameWithCounter(
+        StringSuffixUtils.InterfaceNameWithCounter(
             stringBuilder,
             generator
                 .BaseSettings
                 .OperationNameGenerator
                 .GetOperationName(document, kv.Key, verb, operation));
 
-    private static string SuffixDuplicateNameWithCounter(StringBuilder stringBuilder, string name)
-    {
-        if (!stringBuilder.ToString().Contains($"interface I{name}"))
-        {
-            return name;
-        }
-
-        var counter = 2;
-        while (stringBuilder.ToString().Contains($"interface I{name}{counter}"))
-            counter++;
-
-        return $"{name}{counter}";
-    }
+    
 
     private string GetReturnType(string? returnTypeParameter)
     {

--- a/src/Refitter.Core/StringSuffixUtils.cs
+++ b/src/Refitter.Core/StringSuffixUtils.cs
@@ -1,0 +1,37 @@
+﻿using System.Text;
+
+namespace Refitter.Core;
+
+internal static class StringSuffixUtils
+{
+    public static string InterfaceNameWithCounter(StringBuilder stringBuilder, string name)
+    {
+        var body = stringBuilder.ToString().AsSpan();
+        if (!ContainsBounded(body, $"interface I{name}".AsSpan()))
+        {
+            return name;
+        }
+
+        var counter = 2;
+        while (ContainsBounded(body,$"interface I{name}{counter}".AsSpan()))
+            counter++;
+
+        return $"{name}{counter}";
+    }
+    
+    private static bool ContainsBounded(ReadOnlySpan<char> haystack, ReadOnlySpan<char> needle)
+    {
+        var idx = haystack.IndexOf(needle, StringComparison.Ordinal);
+        if (idx == -1)
+        {
+            return false;
+        }
+
+        return haystack.IsEmpty || !IsIdentifierChar(haystack[0]);
+    }
+
+    private static bool IsIdentifierChar(char c)
+    {
+        return char.IsLetterOrDigit(c) || c == '_';
+    }
+}

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/MultipleInterfaceByTagGeneratorTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/MultipleInterfaceByTagGeneratorTests.cs
@@ -1,0 +1,18 @@
+﻿using FluentAssertions;
+
+using Xunit;
+
+namespace Refitter.Tests.AdditionalFiles;
+
+public class MultipleInterfaceByTagGeneratorTests
+{
+    [Theory]
+    [InlineData(typeof(ByTag.IPetApi))]
+    [InlineData(typeof(ByTag.IUserApi))]
+    [InlineData(typeof(ByTag.IStoreApi))]
+    public void Should_Generate_Interface(Type type) =>
+        type
+            .Namespace
+            .Should()
+            .Be("Refitter.Tests.AdditionalFiles.ByTag");
+}

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/MultipleInterfaceGeneratorTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/MultipleInterfaceGeneratorTests.cs
@@ -7,28 +7,28 @@ namespace Refitter.Tests.AdditionalFiles;
 public class MultipleInterfaceGeneratorTests
 {
     [Theory]
-    [InlineData(typeof(IAddPetEndpoint))]
-    [InlineData(typeof(IUpdatePetEndpoint))]
-    [InlineData(typeof(IDeletePetEndpoint))]
-    [InlineData(typeof(ICreateUserEndpoint))]
-    [InlineData(typeof(IUpdateUserEndpoint))]
-    [InlineData(typeof(IDeleteUserEndpoint))]
-    [InlineData(typeof(ILoginUserEndpoint))]
-    [InlineData(typeof(ILogoutUserEndpoint))]
-    [InlineData(typeof(IPlaceOrderEndpoint))]
-    [InlineData(typeof(IGetOrderByIdEndpoint))]
-    [InlineData(typeof(IDeleteOrderEndpoint))]
-    [InlineData(typeof(IGetInventoryEndpoint))]
-    [InlineData(typeof(IGetPetByIdEndpoint))]
-    [InlineData(typeof(IUploadFileEndpoint))]
-    [InlineData(typeof(IFindPetsByStatusEndpoint))]
-    [InlineData(typeof(IFindPetsByTagsEndpoint))]
-    [InlineData(typeof(IGetUserByNameEndpoint))]
-    [InlineData(typeof(IUpdatePetWithFormEndpoint))]
-    [InlineData(typeof(ICreateUsersWithListInputEndpoint))]
+    [InlineData(typeof(ByEndpoint.IAddPetEndpoint))]
+    [InlineData(typeof(ByEndpoint.IUpdatePetEndpoint))]
+    [InlineData(typeof(ByEndpoint.IDeletePetEndpoint))]
+    [InlineData(typeof(ByEndpoint.ICreateUserEndpoint))]
+    [InlineData(typeof(ByEndpoint.IUpdateUserEndpoint))]
+    [InlineData(typeof(ByEndpoint.IDeleteUserEndpoint))]
+    [InlineData(typeof(ByEndpoint.ILoginUserEndpoint))]
+    [InlineData(typeof(ByEndpoint.ILogoutUserEndpoint))]
+    [InlineData(typeof(ByEndpoint.IPlaceOrderEndpoint))]
+    [InlineData(typeof(ByEndpoint.IGetOrderByIdEndpoint))]
+    [InlineData(typeof(ByEndpoint.IDeleteOrderEndpoint))]
+    [InlineData(typeof(ByEndpoint.IGetInventoryEndpoint))]
+    [InlineData(typeof(ByEndpoint.IGetPetByIdEndpoint))]
+    [InlineData(typeof(ByEndpoint.IUploadFileEndpoint))]
+    [InlineData(typeof(ByEndpoint.IFindPetsByStatusEndpoint))]
+    [InlineData(typeof(ByEndpoint.IFindPetsByTagsEndpoint))]
+    [InlineData(typeof(ByEndpoint.IGetUserByNameEndpoint))]
+    [InlineData(typeof(ByEndpoint.IUpdatePetWithFormEndpoint))]
+    [InlineData(typeof(ByEndpoint.ICreateUsersWithListInputEndpoint))]
     public void Should_Generate_Interface(Type type) =>
         type
             .Namespace
             .Should()
-            .Be("Refitter.Tests.AdditionalFiles");
+            .Be("Refitter.Tests.AdditionalFiles.ByEndpoint");
 }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/SingleInterfaceGeneratorTest.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/SingleInterfaceGeneratorTest.cs
@@ -8,8 +8,8 @@ public class SingleInterfaceGeneratorTest
 {
     [Fact]
     public void Should_Type_Exist() =>
-        typeof(ISwaggerPetstore)
+        typeof(SingeInterface.ISwaggerPetstore)
             .Namespace
             .Should()
-            .Be("Refitter.Tests.AdditionalFiles");
+            .Be("Refitter.Tests.AdditionalFiles.SingeInterface");
 }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/SwaggerPetstoreMultipleInterfacesByTag.refitter
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/SwaggerPetstoreMultipleInterfacesByTag.refitter
@@ -1,8 +1,8 @@
 {
   "openApiPath": "../Resources/V3/SwaggerPetstore.json",
-  "namespace": "Refitter.Tests.AdditionalFiles.ByEndpoint",
+  "namespace": "Refitter.Tests.AdditionalFiles.ByTag",
   "generateContracts": false,
-  "multipleInterfaces": "ByEndpoint",
+  "multipleInterfaces": "ByTag",
   "additionalNamespaces": ["Refitter.Tests.AdditionalFiles.SingeInterface"],
   "naming": {
     "filename": "SwaggerPetstoreInterfaces"

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/SwaggerPetstoreSingleInterface.refitter
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/SwaggerPetstoreSingleInterface.refitter
@@ -1,6 +1,6 @@
 {
   "openApiPath": "../Resources/V3/SwaggerPetstore.json",
-  "namespace": "Refitter.Tests.AdditionalFiles",
+  "namespace": "Refitter.Tests.AdditionalFiles.SingeInterface",
   "naming": {
     "useOpenApiTitle": false,
     "interfaceName": "SwaggerPetstore",

--- a/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
+++ b/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
@@ -34,6 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <AdditionalFiles Include="AdditionalFiles\SwaggerPetstoreMultipleInterfacesByTag.refitter" />
       <AdditionalFiles Include="AdditionalFiles\SwaggerPetstoreSingleInterface.refitter" />
       <AdditionalFiles Include="AdditionalFiles\SwaggerPetstoreMultipleInterfaces.refitter" />
     </ItemGroup>

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -208,7 +208,7 @@ public class SwaggerPetstoreTests
     public async Task Can_Generate_Code_With_Multiple_Interfaces(SampleOpenSpecifications version, string filename)
     {
         var settings = new RefitGeneratorSettings();
-        settings.MultipleInterfaces = true;
+        settings.MultipleInterfaces = MultipleInterfaces.ByEndpoint;
         var generateCode = await GenerateCode(version, filename, settings);
     }
 
@@ -256,7 +256,7 @@ public class SwaggerPetstoreTests
     public async Task Can_Build_Generated_Code_With_Multiple_Interfaces(SampleOpenSpecifications version, string filename)
     {
         var settings = new RefitGeneratorSettings();
-        settings.MultipleInterfaces = true;
+        settings.MultipleInterfaces = MultipleInterfaces.ByEndpoint;
         var generateCode = await GenerateCode(version, filename, settings);
         BuildHelper
             .BuildCSharp(generateCode)

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -64,8 +64,9 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool UseIsoDateFormat { get; set; }
 
-    [Description("Generate a Refit interface for each endpoint")]
+    private const string MultipleInterfacesValues = $"{nameof(Core.MultipleInterfaces.ByEndpoint)}, {nameof(Core.MultipleInterfaces.ByTag)}";
+
+    [Description($"Generate a Refit interface for each endpoint. May be one of {MultipleInterfacesValues}")]
     [CommandOption("--multiple-interfaces")]
-    [DefaultValue(false)]
-    public bool MultipleInterfaces { get; set; }
+    public Core.MultipleInterfaces MultipleInterfaces { get; set; } = Core.MultipleInterfaces.Unset;
 }

--- a/src/Refitter/SupportInformation.cs
+++ b/src/Refitter/SupportInformation.cs
@@ -27,9 +27,8 @@ public static class SupportInformation
 
     private static string ToSha256(this string value)
     {
-        using var sha256 = SHA256.Create();
         var bytes = Encoding.UTF8.GetBytes(value);
-        var hash = sha256.ComputeHash(bytes);
+        var hash = SHA256.HashData(bytes);
         return Convert.ToBase64String(hash).ToLowerInvariant();
     }
 }

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -114,7 +114,7 @@ function RunTests {
 
                     Write-Host "dotnet run --project ../src/Refitter/Refitter.csproj ./openapi.$format --namespace $namespace.MultipleInterfaces --output ./GeneratedCode/MultipleInterfaces$outputPath --multiple-interfaces --no-logging"
                     $process = Start-Process "dotnet" `
-                        -Args "run --project ../src/Refitter/Refitter.csproj ./openapi.$format --namespace $namespace.MultipleInterfaces --output ./GeneratedCode/MultipleInterfaces$outputPath --multiple-interfaces --no-logging" `
+                        -Args "run --project ../src/Refitter/Refitter.csproj ./openapi.$format --namespace $namespace.MultipleInterfaces --output ./GeneratedCode/MultipleInterfaces$outputPath --multiple-interfaces byEndpoint --no-logging" `
                         -NoNewWindow `
                         -PassThru
                     $process | Wait-Process


### PR DESCRIPTION
This PR adds an additional mode for `--multiple-interfaces` called `ByTag` which uses the first Tag of the operation to generate the interface name.

This PR also adds a `BREAKING` change as `--multiple-interfaces` now takes in an enumeration of `Unset`, `ByEndpoint` and `ByTag`.
The source generator `.refitter` file has the same breaking change, as it now takes its value as string like this:
```json
{
  "multipleInterfaces": "ByTag" // or ByEndpoint
}
```

Generated sample:
```cs
namespace GeneratedCode
{
    // No/Empty first Tag 
    public interface IDocumentV1Api
    {
        [Get("/api/greet-unsafe")]
        Task GreetUnsafe([Query] string name);
    }

    // tag "Greeting"
    public interface IGreetingApi
    {
        [Get("/api/greet")]
        Task Greet([Query] string name);
    }

    // tag "OpenApi"
    public interface IOpenApiApi
    {
        [Get("/api/custom-docs")]
        Task<ICollection<Item>> CustomDocs([Query] string name);

        [Get("/api/some-other-thing")]
        Task<ICollection<Item>> SomeOtherThing([Query] string name);
    }


}
```

spec:
```yaml
openapi: 3.0.1
# ...
info:
  title: Document V1
paths:
  /api/greet-unsafe:
    get:
      tags:
        - ''
      parameters:...
      responses:
        '200':...
  /api/greet:
    get:
      tags:
        - Greeting
      parameters:...
      responses:...
  /api/custom-docs:
    get:
      tags:
        - OpenApi
      parameters:...
      responses:
        '200':...
  /api/some-other-thing:
    get:
      tags:
        - OpenApi
      parameters:...
      responses:
        '200':...

```