### PR TITLE
Fix parameters' casing in openAPI document are not honoured in Refit interface methods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: 👌 Verify build
-    runs-on: linux-latest    
+    runs-on: ubuntu-latest
     steps:    
     - name: 🛒 Checkout repository
       uses: actions/checkout@v3        

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -67,7 +67,7 @@ internal static class ParameterExtractor
     }
 
     private static string GetAliasAsAttribute(CSharpParameterModel parameterModel) =>
-        string.Equals(parameterModel.Name, parameterModel.VariableName, StringComparison.OrdinalIgnoreCase)
+        string.Equals(parameterModel.Name, parameterModel.VariableName)
             ? string.Empty
             : $"AliasAs(\"{parameterModel.Name}\")";
 

--- a/src/Refitter.Tests/Examples/CaseSensitiveParametersTests.cs
+++ b/src/Refitter.Tests/Examples/CaseSensitiveParametersTests.cs
@@ -1,0 +1,91 @@
+using FluentAssertions;
+
+using Refitter.Core;
+using Refitter.Tests.Build;
+
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class CaseSensitiveParametersTests
+{
+    private const string OpenApiSpec = @"
+openapi: '3.0.0'
+paths:
+  /job/{Id}:
+    post:
+      tags:
+      - 'Jobs'
+      operationId: 'Update job details'
+      description: 'Update the details of the specified job.'
+      parameters:
+        - in: 'path'
+          name: 'Id'
+          description: 'Foo Id'
+          required: true
+          schema:
+            type: 'string'
+        - in: 'query'
+          name: 'Title'
+          description: 'Job title'
+          required: true
+          schema:
+            type: 'string'
+        - in: 'query'
+          name: 'Description'
+          description: 'Job description'
+          required: true
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'successful operation'
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData("Id")]
+    [InlineData("Title")]
+    [InlineData("Description")]
+    public async Task Generates_AliasAs_For_Parameters(string parameterName)
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().Contain($"AliasAs(\"{parameterName}\")");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}


### PR DESCRIPTION
The changes here fixes a case sensitivity issue regarding handling query string parameters.

This resolves #124 

The follow OpenAPI spec:

```yaml
openapi: '3.0.0'
paths:
  /job/{Id}:
    post:
      tags:
      - 'Jobs'
      operationId: 'Update job details'
      description: 'Update the details of the specified job.'
      parameters:
        - in: 'path'
          name: 'Id'
          description: 'Foo Id'
          required: true
          schema:
            type: 'string'
        - in: 'query'
          name: 'Title'
          description: 'Job title'
          required: true
          schema:
            type: 'string'
        - in: 'query'
          name: 'Description'
          description: 'Job description'
          required: true
          schema:
            type: 'string'
      responses:
        '200':
          description: 'successful operation'
```

Generates the following:

```cs
[Post("/job/{Id}")]
Task UpdateJobDetails(
    [AliasAs("Id")] string id, 
    [Query, AliasAs("Title")] string title, 
    [Query, AliasAs("Description")] string description);
```

And

```yaml
openapi: '3.0.0'
paths:
  /job/{id}:
    post:
      tags:
      - 'Jobs'
      operationId: 'Update job details'
      description: 'Update the details of the specified job.'
      parameters:
        - in: 'path'
          name: 'id'
          description: 'Foo Id'
          required: true
          schema:
            type: 'string'
        - in: 'query'
          name: 'title'
          description: 'Job title'
          required: true
          schema:
            type: 'string'
        - in: 'query'
          name: 'description'
          description: 'Job description'
          required: true
          schema:
            type: 'string'
      responses:
        '200':
          description: 'successful operation'
```

Generates the following:

```cs
[Post("/job/{id}")]
Task UpdateJobDetails(string id, [Query] string title, [Query] string description);
```