### PR TITLE
Feature: Filtering of endpoints and tags

### DIFF
--- a/src/Refitter.Core/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/RefitGeneratorSettings.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -112,6 +114,20 @@ public class RefitGeneratorSettings
     [JsonProperty("multipleInterfaces")]
     [Newtonsoft.Json.JsonConverter(typeof(StringEnumConverter))]
     public MultipleInterfaces MultipleInterfaces { get; set; }
+
+    /// <summary>
+    /// Set to <c>true</c> to Generate a Refit interface for each endpoint
+    /// </summary>
+    [JsonPropertyName("includePathMatches")]
+    [JsonProperty("includePathMatches")]
+    public string[] IncludePathMatches{ get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Set to <c>true</c> to Generate a Refit interface for each endpoint
+    /// </summary>
+    [JsonPropertyName("includeTags")]
+    [JsonProperty("includeTags")]
+    public string[] IncludeTags { get; set; } = Array.Empty<string>();
 }
 
 public enum MultipleInterfaces

--- a/src/Refitter.Tests/Examples/FilterByPathTests.cs
+++ b/src/Refitter.Tests/Examples/FilterByPathTests.cs
@@ -1,0 +1,110 @@
+﻿using FluentAssertions;
+
+using Refitter.Core;
+using Refitter.Tests.Build;
+
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class FilterByPathTests
+{
+    private const string OpenApiSpec = @"
+openapi: '3.0.0'
+paths:
+  /foo/{id}:
+    get:
+      tags:
+      - 'Foo'
+      operationId: 'Get foo details'
+      description: 'Get the details of the specified foo'
+      parameters:
+        - in: 'path'
+          name: 'id'
+          description: 'Foo ID'
+          required: true
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'successful operation'
+  /foo:
+    get:
+      tags:
+      - 'Foo'
+      operationId: 'Get all foos'
+      description: 'Get all foos'      
+      responses:
+        '200':
+          description: 'successful operation'
+  /bar:
+    get:
+      tags:
+      - 'Bar'
+      operationId: 'Get all bars'
+      description: 'Get all bars'      
+      responses:
+        '200':
+          description: 'successful operation'
+  /bar/{id}:
+    get:
+      tags:
+      - 'Bar'
+      operationId: 'Get bar details'
+      description: 'Get the details of the specified bar'   
+      responses:
+        '200':
+          description: 'successful operation'
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Generates_Methods()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().Contain("\"/bar\"");
+        generateCode.Should().NotContain("\"/bar/{id}\"");
+        generateCode.Should().Contain("\"/foo\"");
+        generateCode.Should().Contain("\"/foo/{id}\"");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = swaggerFile,
+            IncludePathMatches = new[] { @"^/bar$", @"^/foo" }
+        };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/src/Refitter.Tests/Examples/FilterByTagsTests.cs
+++ b/src/Refitter.Tests/Examples/FilterByTagsTests.cs
@@ -1,0 +1,109 @@
+﻿using FluentAssertions;
+
+using Refitter.Core;
+using Refitter.Tests.Build;
+
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class FilterByTagsTests
+{
+    private const string OpenApiSpec = @"
+openapi: '3.0.0'
+paths:
+  /foo/{id}:
+    get:
+      tags:
+      - 'Foo'
+      operationId: 'Get foo details'
+      description: 'Get the details of the specified foo'
+      parameters:
+        - in: 'path'
+          name: 'id'
+          description: 'Foo ID'
+          required: true
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'successful operation'
+  /foo:
+    get:
+      tags:
+      - 'Foo'
+      operationId: 'Get all foos'
+      description: 'Get all foos'      
+      responses:
+        '200':
+          description: 'successful operation'
+  /bar:
+    get:
+      tags:
+      - 'Bar'
+      operationId: 'Get all bars'
+      description: 'Get all bars'      
+      responses:
+        '200':
+          description: 'successful operation'
+  /bar/{id}:
+    get:
+      tags:
+      - 'Bar'
+      operationId: 'Get bar details'
+      description: 'Get the details of the specified bar'   
+      responses:
+        '200':
+          description: 'successful operation'
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Generates_Bar_Methods()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().Contain("\"/bar\"");
+        generateCode.Should().Contain("\"/bar/{id}\"");
+        generateCode.Should().NotContain("/foo");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = swaggerFile,
+            IncludeTags = new[] { "Bar" }
+        };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -39,6 +39,8 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                 : TypeAccessibility.Public,
             AdditionalNamespaces = settings.AdditionalNamespaces!,
             MultipleInterfaces = settings.MultipleInterfaces,
+            IncludePathMatches = settings.MatchPaths ?? Array.Empty<string>(),
+            IncludeTags = settings.Tags ?? Array.Empty<string>(),
         };
 
         var crlf = Environment.NewLine;

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -78,4 +78,14 @@ public sealed class Settings : CommandSettings
     [Description($"Generate a Refit interface for each endpoint. May be one of {MultipleInterfacesValues}")]
     [CommandOption("--multiple-interfaces")]
     public Core.MultipleInterfaces MultipleInterfaces { get; set; } = Core.MultipleInterfaces.Unset;
+
+    [Description("Only include Paths that match the provided regular expression. May be set multiple times.")]
+    [CommandOption("--match-path")]
+    [DefaultValue(new string[0])]
+    public string[]? MatchPaths { get; set; }
+
+    [Description("Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation.")]
+    [CommandOption("--tag")]
+    [DefaultValue(new string[0])]
+    public string[]? Tags { get; set; }
 }


### PR DESCRIPTION
This PR demonstrates how #131 could be implemented

It add `--match-path` and `--tag` CLI options, which allow the user to filter endpoints based on existing Tags and/or if the Path matches an regular expression.

It's not as fine grained as for supporting HTTP methods. I.e. you can't filter for `^/greet` and only allow `GET` and `PUT` or something like that.

A call might look like this:

```sh
refitter.exe swagger.json --tag Greeting --tag OpenApi --match-path '^/api/'
```

It works by modifying the OpenApiDocument and removing the Paths/Methods that don't match any of the Tags or patterns, thus further steps in code generation only see the filtered document.