### PR TITLE
Fix issue when downloading an OpenAPI spec from a URL that returns a GZIP stream

### DIFF
--- a/src/Refitter.Core/OpenApiDocumentFactory.cs
+++ b/src/Refitter.Core/OpenApiDocumentFactory.cs
@@ -1,0 +1,81 @@
+﻿using System.Net;
+
+using NSwag;
+
+namespace Refitter.Core;
+
+/// <summary>
+/// Creates an <see cref="OpenApiDocument"/> from a specified path or URL.
+/// </summary>
+public static class OpenApiDocumentFactory
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="OpenApiDocument"/> class asynchronously.
+    /// </summary>
+    /// <param name="settings">The settings used to configure the generator.</param>
+    /// <returns>A new instance of the <see cref="OpenApiDocument"/> class.</returns>
+    public static async Task<OpenApiDocument> CreateAsync(RefitGeneratorSettings settings)
+    {
+        OpenApiDocument document;
+        if (IsHttp(settings.OpenApiPath))
+        {
+            var content = await GetHttpContent(settings);
+
+            if (IsYaml(settings.OpenApiPath))
+            {
+                document = await OpenApiYamlDocument.FromYamlAsync(content);
+            }
+            else
+            {
+                document = await OpenApiDocument.FromJsonAsync(content);
+            }
+        }
+        else 
+        {
+            if (IsYaml(settings.OpenApiPath))
+            {
+                document = await OpenApiYamlDocument.FromFileAsync(settings.OpenApiPath);
+            }
+            else
+            {
+                document = await OpenApiDocument.FromFileAsync(settings.OpenApiPath);
+            }
+        }
+
+        return document;
+    }
+
+    /// <summary>
+    /// Gets the content of the URI as a string and decompresses it if necessary. 
+    /// </summary>
+    /// <param name="settings">The settings used to configure the generator.</param>
+    /// <returns>The content of the HTTP request.</returns>
+    private static async Task<string> GetHttpContent(RefitGeneratorSettings settings)
+    {
+        var httpMessageHandler = new HttpClientHandler();
+        httpMessageHandler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+        using var http = new HttpClient(httpMessageHandler);
+        var content = await http.GetStringAsync(settings.OpenApiPath);
+        return content;
+    }
+
+    /// <summary>
+    /// Determines whether the specified path is an HTTP URL.
+    /// </summary>
+    /// <param name="path">The path to check.</param>
+    /// <returns>True if the path is an HTTP URL, otherwise false.</returns>
+    private static bool IsHttp(string path)
+    {
+        return path.StartsWith("http://") || path.StartsWith("https://");
+    }
+
+    /// <summary>
+    /// Determines whether the specified path is a YAML file.
+    /// </summary>
+    /// <param name="path">The path to check.</param>
+    /// <returns>True if the path is a YAML file, otherwise false.</returns>
+    private static bool IsYaml(string path)
+    {
+        return path.EndsWith("yaml") || path.EndsWith("yml");
+    }
+}

--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -8,19 +8,8 @@ namespace Refitter.Core;
 /// <summary>
 /// Generates Refit clients and interfaces based on an OpenAPI specification.
 /// </summary>
-public class RefitGenerator
+public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument document)
 {
-    private readonly RefitGeneratorSettings settings;
-    private readonly OpenApiDocument document;
-    private readonly CSharpClientGeneratorFactory factory;
-
-    private RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument document)
-    {
-        this.settings = settings;
-        this.document = document;
-        factory = new CSharpClientGeneratorFactory(settings, document);
-    }
-
     /// <summary>
     /// Creates a new instance of the <see cref="RefitGenerator"/> class asynchronously.
     /// </summary>
@@ -108,6 +97,7 @@ public class RefitGenerator
     /// <returns>The generated code as a string.</returns>
     public string Generate()
     {
+        var factory = new CSharpClientGeneratorFactory(settings, document);
         var generator = factory.Create();
         var contracts = RefitInterfaceImports
             .GetImportedNamespaces(settings)

--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -28,28 +28,12 @@ public class RefitGenerator
     /// <returns>A new instance of the <see cref="RefitGenerator"/> class.</returns>
     public static async Task<RefitGenerator> CreateAsync(RefitGeneratorSettings settings)
     {
-        OpenApiDocument document;
-        if (IsHttp(settings.OpenApiPath) && IsYaml(settings.OpenApiPath))
-        {
-            document = await OpenApiYamlDocument.FromUrlAsync(settings.OpenApiPath);
-        }
-        else if (IsHttp(settings.OpenApiPath))
-        {
-            document = await OpenApiDocument.FromUrlAsync(settings.OpenApiPath);
-        }
-        else if (IsYaml(settings.OpenApiPath))
-        {
-            document = await OpenApiYamlDocument.FromFileAsync(settings.OpenApiPath);
-        }
-        else
-        {
-            document = await OpenApiDocument.FromFileAsync(settings.OpenApiPath);
-        }
+        var openApiDocument = await OpenApiDocumentFactory.CreateAsync(settings);
 
-        ProcessTagFilters(document, settings.IncludeTags);
-        ProcessPathFilters(document, settings.IncludePathMatches);
+        ProcessTagFilters(openApiDocument, settings.IncludeTags);
+        ProcessPathFilters(openApiDocument, settings.IncludePathMatches);
 
-        return new RefitGenerator(settings, document);
+        return new RefitGenerator(settings, openApiDocument);
     }
 
     private static void ProcessTagFilters(OpenApiDocument document,
@@ -193,25 +177,5 @@ public class RefitGenerator
             // </auto-generated>
 
             """);
-    }
-
-    /// <summary>
-    /// Determines whether the specified path is an HTTP URL.
-    /// </summary>
-    /// <param name="path">The path to check.</param>
-    /// <returns>True if the path is an HTTP URL, otherwise false.</returns>
-    private static bool IsHttp(string path)
-    {
-        return path.StartsWith("http://") || path.StartsWith("https://");
-    }
-
-    /// <summary>
-    /// Determines whether the specified path is a YAML file.
-    /// </summary>
-    /// <param name="path">The path to check.</param>
-    /// <returns>True if the path is a YAML file, otherwise false.</returns>
-    private static bool IsYaml(string path)
-    {
-        return path.EndsWith("yaml") || path.EndsWith("yml");
     }
 }

--- a/src/Refitter.Tests/OpenApiDocumentFactoryTests.cs
+++ b/src/Refitter.Tests/OpenApiDocumentFactoryTests.cs
@@ -1,0 +1,36 @@
+﻿using FluentAssertions;
+
+using Refitter.Core;
+using Refitter.Tests.Resources;
+
+using Xunit;
+
+namespace Refitter.Tests;
+
+public class OpenApiDocumentFactoryTests
+{
+    [Theory]
+    [InlineData("https://developers.intellihr.io/docs/v1/swagger.json")] // GZIP encoded
+    [InlineData("http://raw.githubusercontent.com/christianhelle/refitter/main/test/OpenAPI/v3.0/petstore.json")]
+    public async Task Can_Build_Generated_Code_From_Url(string url)
+    {
+        var settings = new RefitGeneratorSettings { OpenApiPath = url };
+        (await OpenApiDocumentFactory.CreateAsync(settings))
+            .Should()
+            .NotBeNull();
+    }
+    
+    [Theory]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV2, "SwaggerPetstore.yaml")]
+    public async Task Can_Generate_Code_With_Multiple_Interfaces(SampleOpenSpecifications version, string filename)
+    {
+        var swaggerFile = await TestFile.CreateSwaggerFile(EmbeddedResources.GetSwaggerPetstore(version), filename);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+        (await OpenApiDocumentFactory.CreateAsync(settings))
+            .Should()
+            .NotBeNull();
+    }
+}

--- a/src/Refitter.Tests/OpenApiDocumentFactoryTests.cs
+++ b/src/Refitter.Tests/OpenApiDocumentFactoryTests.cs
@@ -12,7 +12,7 @@ public class OpenApiDocumentFactoryTests
     [Theory]
     [InlineData("https://developers.intellihr.io/docs/v1/swagger.json")] // GZIP encoded
     [InlineData("http://raw.githubusercontent.com/christianhelle/refitter/main/test/OpenAPI/v3.0/petstore.json")]
-    public async Task Can_Build_Generated_Code_From_Url(string url)
+    public async Task Create_From_Uri_Returns_NotNull(string url)
     {
         var settings = new RefitGeneratorSettings { OpenApiPath = url };
         (await OpenApiDocumentFactory.CreateAsync(settings))
@@ -25,7 +25,7 @@ public class OpenApiDocumentFactoryTests
     [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
     [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]
     [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV2, "SwaggerPetstore.yaml")]
-    public async Task Can_Generate_Code_With_Multiple_Interfaces(SampleOpenSpecifications version, string filename)
+    public async Task Create_From_File_Returns_NotNull(SampleOpenSpecifications version, string filename)
     {
         var swaggerFile = await TestFile.CreateSwaggerFile(EmbeddedResources.GetSwaggerPetstore(version), filename);
         var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -357,7 +357,7 @@ public class SwaggerPetstoreTests
         string filename,
         RefitGeneratorSettings? settings = null)
     {
-        var swaggerFile = await CreateSwaggerFile(EmbeddedResources.GetSwaggerPetstore(version), filename);
+        var swaggerFile = await TestFile.CreateSwaggerFile(EmbeddedResources.GetSwaggerPetstore(version), filename);
         if (settings is null)
         {
             settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
@@ -369,14 +369,5 @@ public class SwaggerPetstoreTests
 
         var sut = await RefitGenerator.CreateAsync(settings);
         return sut.Generate();
-    }
-
-    private static async Task<string> CreateSwaggerFile(string contents, string filename)
-    {
-        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(folder);
-        var swaggerFile = Path.Combine(folder, filename);
-        await File.WriteAllTextAsync(swaggerFile, contents);
-        return swaggerFile;
     }
 }

--- a/src/Refitter.Tests/TestFile.cs
+++ b/src/Refitter.Tests/TestFile.cs
@@ -1,0 +1,13 @@
+﻿namespace Refitter.Tests;
+
+public static class TestFile
+{
+    public static async Task<string> CreateSwaggerFile(string contents, string filename)
+    {
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}


### PR DESCRIPTION
The changes here introduces the `OpenApiDocumentFactory` as to handle URLs to OpenAPI specifications that return GZIP encoded streams.