### PR TITLE
Show help text if no arguments are passed

### DIFF
--- a/src/Refitter/Program.cs
+++ b/src/Refitter/Program.cs
@@ -12,6 +12,14 @@ static class Program
     {
         Analytics.Configure();
 
+        if (args.Length == 0)
+        {
+            args = new[]
+            {
+                "--help"
+            };
+        }
+
         var app = new CommandApp<GenerateCommand>();
         app.Configure(
             configuration =>


### PR DESCRIPTION
A conditional statement was added in Program.cs to automatically insert `--help` as the default argument for the command app if no argument is provided by the user. This change simplifies the usability for those unfamiliar with the required command line arguments.