### PR TITLE
Introduce OpenAPI validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ OPTIONS:
         --multiple-interfaces                          Generate a Refit interface for each endpoint. May be one of ByEndpoint, ByTag                                
         --match-path                                   Only include Paths that match the provided regular expression. May be set multiple times                     
         --tag                                          Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation       
+        --skip-validation                              Skip validation of the OpenAPI specification                                                                 
 ```
 
 To generate code from an OpenAPI specifications file, run the following:

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -53,7 +53,10 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             AnsiConsole.MarkupLine($"[green]Refitter v{GetType().Assembly.GetName().Version!}[/]");
             AnsiConsole.MarkupLine($"[green]Support key: {SupportInformation.GetSupportKey()}[/]");
 
-            await ValidateOpenApiSpec(settings);
+            if (!settings.SkipValidation)
+            {
+                await ValidateOpenApiSpec(settings);
+            }
 
             if (!string.IsNullOrWhiteSpace(settings.SettingsFilePath))
             {

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -58,6 +58,7 @@ OPTIONS:
         --multiple-interfaces                          Generate a Refit interface for each endpoint. May be one of ByEndpoint, ByTag                                
         --match-path                                   Only include Paths that match the provided regular expression. May be set multiple times                     
         --tag                                          Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation       
+        --skip-validation                              Skip validation of the OpenAPI specification                                                                 
 ```
 
 To generate code from an OpenAPI specifications file, run the following:

--- a/src/Refitter/Refitter.csproj
+++ b/src/Refitter/Refitter.csproj
@@ -18,6 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Exceptionless" Version="6.0.2" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.4.0" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.7" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -88,4 +88,8 @@ public sealed class Settings : CommandSettings
     [CommandOption("--tag")]
     [DefaultValue(new string[0])]
     public string[]? Tags { get; set; }
+    
+    [Description("Skip validation of the OpenAPI specification")]
+    [CommandOption("--skip-validation")]
+    public bool SkipValidation { get; set; }
 }

--- a/src/Refitter/Validation/OpenApiStats.cs
+++ b/src/Refitter/Validation/OpenApiStats.cs
@@ -69,14 +69,14 @@ public class OpenApiStats : OpenApiVisitorBase
     public override string ToString()
     {
         return $"""
-                Path Items: {PathItemCount}
-                Operations: {OperationCount}
-                Parameters: {ParameterCount}
-                Request Bodies: {RequestBodyCount}
-                Responses: {ResponseCount}
-                Links: {LinkCount}
-                Callbacks: {CallbackCount}
-                Schemas: {SchemaCount}
+                 - Path Items: {PathItemCount}
+                 - Operations: {OperationCount}
+                 - Parameters: {ParameterCount}
+                 - Request Bodies: {RequestBodyCount}
+                 - Responses: {ResponseCount}
+                 - Links: {LinkCount}
+                 - Callbacks: {CallbackCount}
+                 - Schemas: {SchemaCount}
                 """;
     }
 }

--- a/src/Refitter/Validation/OpenApiStats.cs
+++ b/src/Refitter/Validation/OpenApiStats.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Services;
+
+namespace Refitter.Validation;
+
+public class OpenApiStats : OpenApiVisitorBase
+{
+    public int ParameterCount { get; set; } = 0;
+    public int SchemaCount { get; set; } = 0;
+    public int HeaderCount { get; set; } = 0;
+    public int PathItemCount { get; set; } = 0;
+    public int RequestBodyCount { get; set; } = 0;
+    public int ResponseCount { get; set; } = 0;
+    public int OperationCount { get; set; } = 0;
+    public int LinkCount { get; set; } = 0;
+    public int CallbackCount { get; set; } = 0;
+
+    public override void Visit(OpenApiParameter parameter)
+    {
+        ParameterCount++;
+    }
+
+    public override void Visit(OpenApiSchema schema)
+    {
+        SchemaCount++;
+    }
+
+
+    public override void Visit(IDictionary<string, OpenApiHeader> headers)
+    {
+        HeaderCount++;
+    }
+
+
+    public override void Visit(OpenApiPathItem pathItem)
+    {
+        PathItemCount++;
+    }
+
+
+    public override void Visit(OpenApiRequestBody requestBody)
+    {
+        RequestBodyCount++;
+    }
+
+
+    public override void Visit(OpenApiResponses response)
+    {
+        ResponseCount++;
+    }
+
+
+    public override void Visit(OpenApiOperation operation)
+    {
+        OperationCount++;
+    }
+
+
+    public override void Visit(OpenApiLink link)
+    {
+        LinkCount++;
+    }
+
+    public override void Visit(OpenApiCallback callback)
+    {
+        CallbackCount++;
+    }
+
+    public override string ToString()
+    {
+        return $"""
+                Path Items: {PathItemCount}
+                Operations: {OperationCount}
+                Parameters: {ParameterCount}
+                Request Bodies: {RequestBodyCount}
+                Responses: {ResponseCount}
+                Links: {LinkCount}
+                Callbacks: {CallbackCount}
+                Schemas: {SchemaCount}
+                """;
+    }
+}

--- a/src/Refitter/Validation/OpenApiValidationException.cs
+++ b/src/Refitter/Validation/OpenApiValidationException.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.Serialization;
+
+namespace Refitter.Validation;
+
+[Serializable]
+public class OpenApiValidationException : Exception
+{
+    public OpenApiValidationResult ValidationResult { get; } = null!;
+
+    public OpenApiValidationException(
+        OpenApiValidationResult validationResult) 
+        : base("OpenAPI validation failed")
+    {
+        ValidationResult = validationResult;
+    }
+    
+    protected OpenApiValidationException(
+        SerializationInfo info,
+        StreamingContext context) : base(info, context)
+    {
+    }
+}

--- a/src/Refitter/Validation/OpenApiValidationResult.cs
+++ b/src/Refitter/Validation/OpenApiValidationResult.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.OpenApi.Readers;
+
+namespace Refitter.Validation;
+
+public record OpenApiValidationResult(
+    OpenApiDiagnostic Diagnostics,
+    OpenApiStats Statistics)
+{
+    public bool IsValid => Diagnostics.Errors.Count == 0;
+    
+    public void ThrowIfInvalid()
+    {
+        if (!IsValid)
+            throw new OpenApiValidationException(this);
+    }
+}

--- a/src/Refitter/Validation/OpenApiValidator.cs
+++ b/src/Refitter/Validation/OpenApiValidator.cs
@@ -1,0 +1,78 @@
+﻿using System.Net;
+using System.Security;
+
+using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi.Services;
+
+namespace Refitter.Validation;
+
+public static class OpenApiValidator
+{
+    public static async Task<OpenApiValidationResult> Validate(string openApiPath)
+    {
+        var result = await ParseOpenApi(openApiPath);
+
+        var statsVisitor = new OpenApiStats();
+        var walker = new OpenApiWalker(statsVisitor);
+        walker.Walk(result.OpenApiDocument);
+
+        return new(
+            result.OpenApiDiagnostic,
+            statsVisitor);
+    }
+
+    private static async Task<Stream> GetStream(
+        string input,
+        CancellationToken cancellationToken)
+    {
+        if (input.StartsWith("http"))
+        {
+            try
+            {
+                var httpClientHandler = new HttpClientHandler()
+                {
+                    SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+                };
+                using var httpClient = new HttpClient(httpClientHandler);
+                httpClient.DefaultRequestVersion = HttpVersion.Version20;
+                return await httpClient.GetStreamAsync(input, cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new InvalidOperationException($"Could not download the file at {input}", ex);
+            }
+        }
+
+        try
+        {
+            var fileInput = new FileInfo(input);
+            return fileInput.OpenRead();
+        }
+        catch (Exception ex) when (ex is FileNotFoundException ||
+                                   ex is PathTooLongException ||
+                                   ex is DirectoryNotFoundException ||
+                                   ex is IOException ||
+                                   ex is UnauthorizedAccessException ||
+                                   ex is SecurityException ||
+                                   ex is NotSupportedException)
+        {
+            throw new InvalidOperationException($"Could not open the file at {input}", ex);
+        }
+    }
+
+    private static async Task<ReadResult> ParseOpenApi(string openApiFile)
+    {
+        var directoryName = new FileInfo(openApiFile).DirectoryName;
+        var openApiReaderSettings = new OpenApiReaderSettings
+        {
+            BaseUrl = openApiFile.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? new Uri(openApiFile)
+                : new Uri($"file://{directoryName}{Path.DirectorySeparatorChar}")
+        };
+
+        await using var stream = await GetStream(openApiFile, CancellationToken.None);
+        var reader = new OpenApiStreamReader(openApiReaderSettings);
+        return await reader.ReadAsync(stream, CancellationToken.None);
+    }
+}


### PR DESCRIPTION
The changes here implement OpenAPI validation using Microsoft OpenAPI libraries. With the changes here, Refitter will print out validation errors (in red) and warnings (in yellow).

A user can also choose to opt out of OpenAPI validation by using the `--skip-validation` CLI tool argument

This pull request also includes a new feature that prints out OpenAPI specification statistics for the number of operations, links, parameters, requests, responses, etc...

It looks something like this:

```
OpenAPI document statistics:
- Path Items: 13
- Operations: 19
- Parameters: 17
- Request Bodies: 9
- Responses: 19
- Links: 0
- Callbacks: 0
- Schemas: 73
```