### PR TITLE
Fix #142 by changing includeTags filtering and restoring collection snapshots

### DIFF
--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -31,17 +31,18 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
         {
             return;
         }
-        var clonedPaths = document.Paths.Where(pair => pair.Value != null);
+        var clonedPaths = document.Paths.Where(pair => pair.Value != null)
+            // as we modify the document.Paths
+            // we have to enumerate on a snapshot of the items
+            .ToArray();
         foreach (var path in clonedPaths)
         {
-            var methods = path.Value.Where(pair => pair.Value != null);
+            var methods = path.Value.Where(pair => pair.Value != null)
+                // same reason as with document.Paths
+                .ToArray();
             foreach (var method in methods)
             {
-                var exclude = true;
-                foreach (var tag in includeTags)
-                {
-                    exclude = method.Value.Tags?.Exists(x => x == tag) != true;
-                }
+                var exclude = method.Value.Tags?.Exists(includeTags.Contains) != true;
                 if (exclude)
                 {
                     path.Value.Remove(method.Key);

--- a/src/Refitter.Tests/Examples/FilterByTagsTests.cs
+++ b/src/Refitter.Tests/Examples/FilterByTagsTests.cs
@@ -55,6 +55,15 @@ paths:
       responses:
         '200':
           description: 'successful operation'
+  /baz:
+    get:
+      tags:
+      - 'Baz'
+      operationId: 'Get all bazs'
+      description: 'Get all bazs'      
+      responses:
+        '200':
+          description: 'successful operation'
 ";
 
     [Fact]
@@ -65,11 +74,12 @@ paths:
     }
 
     [Fact]
-    public async Task Generates_Bar_Methods()
+    public async Task Generates_BarAndBaz_Methods()
     {
         string generateCode = await GenerateCode();
         generateCode.Should().Contain("\"/bar\"");
         generateCode.Should().Contain("\"/bar/{id}\"");
+        generateCode.Should().Contain("\"/baz\"");
         generateCode.Should().NotContain("/foo");
     }
 
@@ -89,7 +99,7 @@ paths:
         var settings = new RefitGeneratorSettings
         {
             OpenApiPath = swaggerFile,
-            IncludeTags = new[] { "Bar" }
+            IncludeTags = new[] { "Bar", "Baz" }
         };
 
         var sut = await RefitGenerator.CreateAsync(settings);


### PR DESCRIPTION
fixes #142 by changing includeTags filtering and restoring collection snapshots.

exclusion is now defined in a single statement, instead of a loop, to reduce likelyhood of failures.

Fixes improper use of collection enumeration and mutation while doing so.
We may not use code like the following, as that may either crash or produce UB.
```
foreach (var x in collection.Where(x....))
{
    // NOT OK
    collection.Remove(y);
}
```
instead, every mutating operation on a collection should enumerate on a snapshot
```
foreach (var x in collection.Where(x....).ToArray())
{
    // OK
    collection.Remove(y);
}
```