### PR TITLE
Add matchPath option in example .refitter file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ The following is an example `.refitter` file
     "Pet",
     "Store",
     "User"
+  ],
+  "matchPath": [ // Optional. Only include Paths that match the provided regular expression
+    "^/pet/.*",
+    "^/store/.*",
   ]
 }
 ```

--- a/src/Refitter.SourceGenerator/README.md
+++ b/src/Refitter.SourceGenerator/README.md
@@ -50,6 +50,10 @@ The following is an example `.refitter` file
     "Pet",
     "Store",
     "User"
+  ],
+  "matchPath": [ // Optional. Only include Paths that match the provided regular expression
+    "^/pet/.*",
+    "^/store/.*",
   ]
 }
 ```


### PR DESCRIPTION
New "matchPath" fields have been added to the configuration examples in both Refitter.SourceGenerator's README file and the main project README. This enables the use of regular expressions to include only specific paths, providing additional flexibility for users.