### PR TITLE
Disable support keys if --no-logging is specified

### DIFF
--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -54,9 +54,10 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         {
             var stopwatch = Stopwatch.StartNew();
             AnsiConsole.MarkupLine($"[green]Refitter v{GetType().Assembly.GetName().Version!}[/]");
-            
-            if (!settings.NoLogging)
-                AnsiConsole.MarkupLine($"[green]Support key: {SupportInformation.GetSupportKey()}[/]");
+            AnsiConsole.MarkupLine(
+                settings.NoLogging
+                    ? "[green]Support key: Unavailable when logging is disabled[/]"
+                    : $"[green]Support key: {SupportInformation.GetSupportKey()}[/]");
 
             if (!settings.SkipValidation) 
                 await ValidateOpenApiSpec(settings);
@@ -107,7 +108,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         if (!validationResult.IsValid)
         {
             AnsiConsole.MarkupLine($"[red]{Crlf}OpenAPI validation failed:{Crlf}[/]");
-            
+
             foreach (var error in validationResult.Diagnostics.Errors)
             {
                 TryWriteLine(error, "red", "Error");
@@ -117,10 +118,10 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             {
                 TryWriteLine(warning, "yellow", "Warning");
             }
-            
+
             validationResult.ThrowIfInvalid();
         }
-        
+
         AnsiConsole.MarkupLine($"[green]{Crlf}OpenAPI statistics:{Crlf}{validationResult.Statistics}{Crlf}[/]");
     }
 

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -14,6 +14,9 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
 
     public override ValidationResult Validate(CommandContext context, Settings settings)
     {
+        if (!settings.NoLogging) 
+            Analytics.Configure();
+
         if (string.IsNullOrWhiteSpace(settings.OpenApiPath))
             return ValidationResult.Error("Input file is required");
 

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -54,12 +54,12 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         {
             var stopwatch = Stopwatch.StartNew();
             AnsiConsole.MarkupLine($"[green]Refitter v{GetType().Assembly.GetName().Version!}[/]");
-            AnsiConsole.MarkupLine($"[green]Support key: {SupportInformation.GetSupportKey()}[/]");
+            
+            if (!settings.NoLogging)
+                AnsiConsole.MarkupLine($"[green]Support key: {SupportInformation.GetSupportKey()}[/]");
 
-            if (!settings.SkipValidation)
-            {
+            if (!settings.SkipValidation) 
                 await ValidateOpenApiSpec(settings);
-            }
 
             if (!string.IsNullOrWhiteSpace(settings.SettingsFilePath))
             {

--- a/src/Refitter/Program.cs
+++ b/src/Refitter/Program.cs
@@ -10,8 +10,6 @@ static class Program
 {
     static int Main(string[] args)
     {
-        Analytics.Configure();
-
         if (args.Length == 0)
         {
             args = new[]


### PR DESCRIPTION
### Skip analytics configuration entirely if --no-logging is specified
Moved the line that configures Analytics from the Main method of the Program class to the Validate method of the GenerateCommand class. This ensures that analytics will only be configured if the 'NoLogging' setting is not active, optimizing performance and improving the user's control over logging.

### Show a message regarding support keys when logging is disabled
Adjusted the way the support key is handled when the logging is disabled. Previously, the support key wasn't printed at all if the logging was off. A message specifying that the support key is unavailable when logging is disabled is printed instead. This serves to ensure that users are informed about the unavailability of the support key when logging is off rather than silently omitting it.