### PR TITLE
Update docs with deails about --no-deprecated-operations

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -36,7 +36,8 @@ jobs:
           "--use-iso-date-format",
           "--multiple-interfaces ByEndpoint",
           "--match-path ^/pet/.*",
-          "--tag pet"
+          "--tag pet",
+          "--no-deprecated-operations"
         ]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ EXAMPLES:
     refitter ./openapi.json --multiple-interfaces ByEndpoint
     refitter ./openapi.json --tag Pet --tag Store --tag User
     refitter ./openapi.json --match-path '^/pet/.*'
+    refitter ./openapi.json --no-deprecated-operations
 
 ARGUMENTS:
     [URL or input file]    URL or file path to OpenAPI Specification file
@@ -75,6 +76,7 @@ OPTIONS:
         --match-path                                   Only include Paths that match the provided regular expression. May be set multiple times                     
         --tag                                          Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation       
         --skip-validation                              Skip validation of the OpenAPI specification                                                                 
+        --no-deprecated-operations                     Don't generate deprecated operations                                                                         
 ```
 
 To generate code from an OpenAPI specifications file, run the following:

--- a/src/Refitter.Tests/Examples/DeprecatedEndpointTests.cs
+++ b/src/Refitter.Tests/Examples/DeprecatedEndpointTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+
+using Refitter.Core;
+using Refitter.Tests.Build;
+
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class DeprecatedEndpointTests
+{
+    private const string OpenApiSpec = @"
+openapi: '3.0.0'
+paths:
+  /foo/{id}:
+    get:
+      tags:
+      - 'Foo'
+      operationId: 'Get foo details'
+      description: 'Get the details of the specified foo'
+      parameters:
+        - in: 'path'
+          name: 'id'
+          description: 'Foo ID'
+          required: true
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'successful operation'
+  /foo:
+    get:
+      tags:
+      - 'Foo'
+      operationId: 'Get all foos'
+      description: 'Get all foos'      
+      responses:
+        '200':
+          description: 'successful operation'
+  /bar:
+    get:
+      tags:
+      - 'Bar'
+      operationId: 'Get all bars'
+      description: 'Get all bars'
+      deprecated: true
+      responses:
+        '200':
+          description: 'successful operation'
+  /bar/{id}:
+    get:
+      tags:
+      - 'Bar'
+      operationId: 'Get bar details'
+      description: 'Get the details of the specified bar'  
+      deprecated: true
+      responses:
+        '200':
+          description: 'successful operation'
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Should_Contain_Obsolete_Attribute()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().Contain("[System.Obsolete]");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/src/Refitter.Tests/Examples/DeprecatedEndpointsSkippedTests.cs
+++ b/src/Refitter.Tests/Examples/DeprecatedEndpointsSkippedTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+
+using Refitter.Core;
+using Refitter.Tests.Build;
+
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class DeprecatedEndpointsSkippedTests
+{
+    private const string OpenApiSpec = @"
+openapi: '3.0.0'
+paths:
+  /foo/{id}:
+    get:
+      tags:
+      - 'Foo'
+      operationId: 'Get foo details'
+      description: 'Get the details of the specified foo'
+      parameters:
+        - in: 'path'
+          name: 'id'
+          description: 'Foo ID'
+          required: true
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'successful operation'
+  /foo:
+    get:
+      tags:
+      - 'Foo'
+      operationId: 'Get all foos'
+      description: 'Get all foos'      
+      responses:
+        '200':
+          description: 'successful operation'
+  /bar:
+    get:
+      tags:
+      - 'Bar'
+      operationId: 'Get all bars'
+      description: 'Get all bars'
+      deprecated: true
+      responses:
+        '200':
+          description: 'successful operation'
+  /bar/{id}:
+    get:
+      tags:
+      - 'Bar'
+      operationId: 'Get bar details'
+      description: 'Get the details of the specified bar'  
+      deprecated: true
+      responses:
+        '200':
+          description: 'successful operation'
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Should_NotContain_Obsolete_Attribute()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotContain("[System.Obsolete]");
+    }
+
+    [Fact]
+    public async Task Should_NotContain_GetAllBars()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotContain("GetAllBars");
+    }
+
+    [Fact]
+    public async Task Should_NotContain_GetBarDetails()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotContain("GetBarDetails");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = swaggerFile,
+            GenerateDeprecatedOperations = false
+        };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -60,7 +60,7 @@ OPTIONS:
         --match-path                                   Only include Paths that match the provided regular expression. May be set multiple times                     
         --tag                                          Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation       
         --skip-validation                              Skip validation of the OpenAPI specification                                                                 
-        --no-deprecated-operations                     Don't generate deprecated operations
+        --no-deprecated-operations                     Don't generate deprecated operations                                                                         
 ```
 
 To generate code from an OpenAPI specifications file, run the following:


### PR DESCRIPTION
The changes here also add missing tests regarding handling deprecated operations and skipping code generation of deprecated operations