### PR TITLE
Speed up local smoke tests

### DIFF
--- a/test/ConsoleApp/ConsoleApp.sln
+++ b/test/ConsoleApp/ConsoleApp.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStandard20", "NetStandar
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStandard21", "NetStandard21\NetStandard21.csproj", "{0A8BAE94-81E2-43FE-8DD2-EE9E576DDB47}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Net8", "Net8\Net8.csproj", "{25A04BD8-942D-412D-AEEA-1E54FC24BE02}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,5 +62,9 @@ Global
 		{0A8BAE94-81E2-43FE-8DD2-EE9E576DDB47}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A8BAE94-81E2-43FE-8DD2-EE9E576DDB47}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0A8BAE94-81E2-43FE-8DD2-EE9E576DDB47}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25A04BD8-942D-412D-AEEA-1E54FC24BE02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25A04BD8-942D-412D-AEEA-1E54FC24BE02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25A04BD8-942D-412D-AEEA-1E54FC24BE02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25A04BD8-942D-412D-AEEA-1E54FC24BE02}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/test/ConsoleApp/Net8/Net8.csproj
+++ b/test/ConsoleApp/Net8/Net8.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -117,9 +117,9 @@ function RunTests {
         
         Get-ChildItem '*.generated.cs' -Recurse | foreach { Remove-Item -Path $_.FullName }
 
-        Write-Host "dotnet run --no-build --project ../src/Refitter/Refitter.csproj ""$_"" --namespace $namespace --output ./GeneratedCode/$outputPath"
-        $process = Start-Process "dotnet" `
-            -Args "run --no-build --project ../src/Refitter/Refitter.csproj ""$_"" --namespace $namespace --output ./GeneratedCode/$outputPath" `
+        Write-Host "refitter ./openapi.$format --namespace $namespace --output ./GeneratedCode/$outputPath --no-logging $args"
+        $process = Start-Process "./bin/refitter" `
+            -Args """$_"" --namespace $namespace --output ./GeneratedCode/$outputPath" `
             -NoNewWindow `
             -PassThru
         $process | Wait-Process

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -32,9 +32,9 @@ function GenerateAndBuild {
     
     Get-ChildItem '*.generated.cs' -Recurse | foreach { Remove-Item -Path $_.FullName }
 
-    Write-Host "dotnet run --no-build --project ../src/Refitter/Refitter.csproj ./openapi.$format --namespace $namespace --output ./GeneratedCode/$outputPath --no-logging $args"
-    $process = Start-Process "dotnet" `
-        -Args "run --no-build --project ../src/Refitter/Refitter.csproj ./openapi.$format --namespace $namespace --output ./GeneratedCode/$outputPath --no-logging $args" `
+    Write-Host "refitter ./openapi.$format --namespace $namespace --output ./GeneratedCode/$outputPath --no-logging $args"
+    $process = Start-Process "./bin/refitter" `
+        -Args "./openapi.$format --namespace $namespace --output ./GeneratedCode/$outputPath --no-logging $args" `
         -NoNewWindow `
         -PassThru
     $process | Wait-Process
@@ -81,8 +81,8 @@ function RunTests {
         "hubspot-webhooks"
     )
     
-    Write-Host "dotnet build --project ../src/Refitter/Refitter.csproj"
-    Start-Process "dotnet" -Args "build -p:TreatWarningsAsErrors=true ../src/Refitter/Refitter.csproj" -NoNewWindow -PassThru | Wait-Process
+    Write-Host "dotnet publish ../src/Refitter/Refitter.csproj -p:TreatWarningsAsErrors=true -p:PublishReadyToRun=true -o bin"
+    Start-Process "dotnet" -Args "publish ../src/Refitter/Refitter.csproj -p:TreatWarningsAsErrors=true -p:PublishReadyToRun=true -o bin" -NoNewWindow -PassThru | Wait-Process
 
     "v3.0", "v2.0" | ForEach-Object {
         $version = $_
@@ -104,7 +104,7 @@ function RunTests {
                     GenerateAndBuild -format $format -namespace "$namespace.UsingApiResponse" -outputPath "IApi$outputPath" -args "--use-api-response"
                     GenerateAndBuild -format $format -namespace "$namespace.UsingIsoDateFormat" -outputPath "UsingIsoDateFormat$outputPath" -args "--use-iso-date-format"
                     GenerateAndBuild -format $format -namespace "$namespace.MultipleInterfaces" -outputPath "MultipleInterfaces$outputPath" -args "--multiple-interfaces ByEndpoint"
-                    GenerateAndBuild -format $format -namespace "$namespace.TagFiltered" -outputPath "TagFiltered$outputPath" -args "--tag pet"
+                    GenerateAndBuild -format $format -namespace "$namespace.TagFiltered" -outputPath "TagFiltered$outputPath" -args "--tag pet --tag user --tag store"
                     GenerateAndBuild -format $format -namespace "$namespace.MatchPathFiltered" -outputPath "MatchPathFiltered$outputPath" -args "--match-path ^/pet/.*"
                 }
             }


### PR DESCRIPTION
The changes update the local smoke tests script to only build once with the `PublishReadyToRun` option enabled. This gives a 200% speed increase in running the local smoke test scripts

Tested on a 32-core AMD Threadripper with 128 GB of RAM workstation running Windows 10 on an NVMe drive