### PR TITLE
Optional OpenAPI Path in CLI arguments

### DIFF
--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -24,6 +24,13 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             string.IsNullOrWhiteSpace(settings.SettingsFilePath))
             return ValidationResult.Error("Input or settings file is required");
 
+        if (!string.IsNullOrWhiteSpace(settings.OpenApiPath) &&
+            !string.IsNullOrWhiteSpace(settings.SettingsFilePath))
+            return ValidationResult.Error(
+                "You should either specify an input URL/file directly " +
+                "or use specify it in 'openApiPath' from the settings file, " +
+                "not both");
+
         if (!string.IsNullOrWhiteSpace(settings.SettingsFilePath))
         {
             var json = File.ReadAllText(settings.SettingsFilePath);

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -20,15 +20,29 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         if (!settings.NoLogging)
             Analytics.Configure();
 
-        if (string.IsNullOrWhiteSpace(settings.OpenApiPath))
-            return ValidationResult.Error("Input file is required");
+        if (string.IsNullOrWhiteSpace(settings.OpenApiPath) &&
+            string.IsNullOrWhiteSpace(settings.SettingsFilePath))
+            return ValidationResult.Error("Input or settings file is required");
 
-        if (IsUrl(settings.OpenApiPath))
+        if (!string.IsNullOrWhiteSpace(settings.SettingsFilePath))
+        {
+            var json = File.ReadAllText(settings.SettingsFilePath);
+            var refitGeneratorSettings = JsonSerializer.Deserialize<RefitGeneratorSettings>(json)!;
+            settings.OpenApiPath = refitGeneratorSettings.OpenApiPath;
+            
+            if (string.IsNullOrWhiteSpace(refitGeneratorSettings.OpenApiPath))
+                return ValidationResult.Error(
+                    "The 'openApiPath' in settings file is required when " +
+                    "URL or file path to OpenAPI Specification file " +
+                    "is not specified in command line argument");
+        }
+
+        if (IsUrl(settings.OpenApiPath!))
             return base.Validate(context, settings);
 
         return File.Exists(settings.OpenApiPath)
             ? base.Validate(context, settings)
-            : ValidationResult.Error($"File not found - {Path.GetFullPath(settings.OpenApiPath)}");
+            : ValidationResult.Error($"File not found - {Path.GetFullPath(settings.OpenApiPath!)}");
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -8,6 +8,7 @@ public sealed class Settings : CommandSettings
 {
     [Description("URL or file path to OpenAPI Specification file")]
     [CommandArgument(0, "[URL or input file]")]
+    [DefaultValue(null)]
     public string? OpenApiPath { get; set; }
 
     [Description("Path to .refitter settings file. Specifying this will ignore all other settings (except for --output)")]

--- a/test/petstore.refitter
+++ b/test/petstore.refitter
@@ -1,0 +1,8 @@
+{
+  "openApiPath": "./OpenAPI/v3.0/petstore.json",
+  "namespace": "Petstore",
+  "naming": {    
+    "useOpenApiTitle": false,
+    "interfaceName": "SwaggerPetstoreDirect"
+  }
+}

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -30,7 +30,7 @@ function GenerateAndBuild {
         $args
     )
     
-    Get-ChildItem '*.generated.cs' -Recurse | foreach { Remove-Item -Path $_.FullName }
+    Get-ChildItem '*.generated.cs' -Recurse | ForEach-Object { Remove-Item -Path $_.FullName }
 
     Write-Host "refitter ./openapi.$format --namespace $namespace --output ./GeneratedCode/$outputPath --no-logging $args"
     $process = Start-Process "./bin/refitter" `


### PR DESCRIPTION
The changes here gives users the choice to specify the path or URL to the OpenAPI specifications document from either the command line argument or via the settings file specified via `--settings-file`

This implements #149 