### PR TITLE
Generate Refit interfaces as partial

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -52,7 +52,7 @@ parameters:
 
 #### Example generated Refit interface
 ```cs
-public interface IReferenceparameters
+public partial interface IReferenceparameters
 {
 	/// <summary>
 	/// This method allows to remove an order item from an order, by specifying their ids.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ using System.Collections.Generic;
 
 namespace Your.Namespace.Of.Choice.GeneratedCode
 {
-    public interface ISwaggerPetstore
+    public partial interface ISwaggerPetstore
     {
         /// <summary>
         /// Update an existing pet by Id
@@ -322,7 +322,7 @@ using System.Collections.Generic;
 
 namespace Your.Namespace.Of.Choice.GeneratedCode.WithApiResponse
 {
-    public interface ISwaggerPetstore
+    public partial interface ISwaggerPetstore
     {
         /// <summary>
         /// Update an existing pet by Id
@@ -447,7 +447,7 @@ $ refitter ./openapi.json --namespace "Your.Namespace.Of.Choice.GeneratedCode" -
 /// <summary>
 /// Update an existing pet
 /// </summary>
-public interface IUpdatePetEndpoint
+public partial interface IUpdatePetEndpoint
 {
     /// <summary>
     /// Update an existing pet by Id
@@ -459,7 +459,7 @@ public interface IUpdatePetEndpoint
 /// <summary>
 /// Add a new pet to the store
 /// </summary>
-public interface IAddPetEndpoint
+public partial interface IAddPetEndpoint
 {
     /// <summary>
     /// Add a new pet to the store
@@ -471,7 +471,7 @@ public interface IAddPetEndpoint
 /// <summary>
 /// Finds Pets by status
 /// </summary>
-public interface IFindPetsByStatusEndpoint
+public partial interface IFindPetsByStatusEndpoint
 {
     /// <summary>
     /// Multiple status values can be provided with comma separated strings
@@ -483,7 +483,7 @@ public interface IFindPetsByStatusEndpoint
 /// <summary>
 /// Finds Pets by tags
 /// </summary>
-public interface IFindPetsByTagsEndpoint
+public partial interface IFindPetsByTagsEndpoint
 {
     /// <summary>
     /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -495,7 +495,7 @@ public interface IFindPetsByTagsEndpoint
 /// <summary>
 /// Find pet by ID
 /// </summary>
-public interface IGetPetByIdEndpoint
+public partial interface IGetPetByIdEndpoint
 {
     /// <summary>
     /// Returns a single pet
@@ -507,7 +507,7 @@ public interface IGetPetByIdEndpoint
 /// <summary>
 /// Updates a pet in the store with form data
 /// </summary>
-public interface IUpdatePetWithFormEndpoint
+public partial interface IUpdatePetWithFormEndpoint
 {
     [Post("/pet/{petId}")]
     Task Execute(long petId, [Query] string name, [Query] string status);
@@ -516,7 +516,7 @@ public interface IUpdatePetWithFormEndpoint
 /// <summary>
 /// Deletes a pet
 /// </summary>
-public interface IDeletePetEndpoint
+public partial interface IDeletePetEndpoint
 {
     [Delete("/pet/{petId}")]
     Task Execute(long petId, [Header("api_key")] string api_key);
@@ -525,7 +525,7 @@ public interface IDeletePetEndpoint
 /// <summary>
 /// uploads an image
 /// </summary>
-public interface IUploadFileEndpoint
+public partial interface IUploadFileEndpoint
 {
     [Post("/pet/{petId}/uploadImage")]
     Task<ApiResponse> Execute(long petId, [Query] string additionalMetadata, StreamPart body);
@@ -534,7 +534,7 @@ public interface IUploadFileEndpoint
 /// <summary>
 /// Returns pet inventories by status
 /// </summary>
-public interface IGetInventoryEndpoint
+public partial interface IGetInventoryEndpoint
 {
     /// <summary>
     /// Returns a map of status codes to quantities
@@ -546,7 +546,7 @@ public interface IGetInventoryEndpoint
 /// <summary>
 /// Place an order for a pet
 /// </summary>
-public interface IPlaceOrderEndpoint
+public partial interface IPlaceOrderEndpoint
 {
     /// <summary>
     /// Place a new order in the store
@@ -558,7 +558,7 @@ public interface IPlaceOrderEndpoint
 /// <summary>
 /// Find purchase order by ID
 /// </summary>
-public interface IGetOrderByIdEndpoint
+public partial interface IGetOrderByIdEndpoint
 {
     /// <summary>
     /// For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -570,7 +570,7 @@ public interface IGetOrderByIdEndpoint
 /// <summary>
 /// Delete purchase order by ID
 /// </summary>
-public interface IDeleteOrderEndpoint
+public partial interface IDeleteOrderEndpoint
 {
     /// <summary>
     /// For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -582,7 +582,7 @@ public interface IDeleteOrderEndpoint
 /// <summary>
 /// Create user
 /// </summary>
-public interface ICreateUserEndpoint
+public partial interface ICreateUserEndpoint
 {
     /// <summary>
     /// This can only be done by the logged in user.
@@ -594,7 +594,7 @@ public interface ICreateUserEndpoint
 /// <summary>
 /// Creates list of users with given input array
 /// </summary>
-public interface ICreateUsersWithListInputEndpoint
+public partial interface ICreateUsersWithListInputEndpoint
 {
     /// <summary>
     /// Creates list of users with given input array
@@ -606,7 +606,7 @@ public interface ICreateUsersWithListInputEndpoint
 /// <summary>
 /// Logs user into the system
 /// </summary>
-public interface ILoginUserEndpoint
+public partial interface ILoginUserEndpoint
 {
     [Get("/user/login")]
     Task<string> Execute([Query] string username, [Query] string password);
@@ -615,7 +615,7 @@ public interface ILoginUserEndpoint
 /// <summary>
 /// Logs out current logged in user session
 /// </summary>
-public interface ILogoutUserEndpoint
+public partial interface ILogoutUserEndpoint
 {
     [Get("/user/logout")]
     Task Execute();
@@ -624,7 +624,7 @@ public interface ILogoutUserEndpoint
 /// <summary>
 /// Get user by user name
 /// </summary>
-public interface IGetUserByNameEndpoint
+public partial interface IGetUserByNameEndpoint
 {
     [Get("/user/{username}")]
     Task<User> Execute(string username);
@@ -633,7 +633,7 @@ public interface IGetUserByNameEndpoint
 /// <summary>
 /// Update user
 /// </summary>
-public interface IUpdateUserEndpoint
+public partial interface IUpdateUserEndpoint
 {
     /// <summary>
     /// This can only be done by the logged in user.
@@ -645,7 +645,7 @@ public interface IUpdateUserEndpoint
 /// <summary>
 /// Delete user
 /// </summary>
-public interface IDeleteUserEndpoint
+public partial interface IDeleteUserEndpoint
 {
     /// <summary>
     /// This can only be done by the logged in user.

--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -157,7 +157,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
         var modifier = settings.TypeAccessibility.ToString().ToLowerInvariant();
         return $"""
                 {Separator}{GetGeneratedCodeAttribute()}
-                {Separator}{modifier} interface I{title.CapitalizeFirstCharacter()}
+                {Separator}{modifier} partial interface I{title.CapitalizeFirstCharacter()}
                 """;
     }
 

--- a/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
@@ -142,7 +142,7 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
         var modifier = settings.TypeAccessibility.ToString().ToLowerInvariant();
         return $"""
                 {Separator}{GetGeneratedCodeAttribute()}
-                {Separator}{modifier} interface {name}
+                {Separator}{modifier} partial interface {name}
                 """;
     }
 }

--- a/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
@@ -94,7 +94,7 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
         var modifier = settings.TypeAccessibility.ToString().ToLowerInvariant();
         return $"""
                 {Separator}{GetGeneratedCodeAttribute()}
-                {Separator}{modifier} interface {name}
+                {Separator}{modifier} partial interface {name}
                 """;
     }
 }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/Refitter.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/Refitter.g.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Refitter.Tests.AdditionalFiles.NoFilename
 {
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface ISwaggerPetstore
+    public partial interface ISwaggerPetstore
     {
         /// <summary>
         /// Update an existing pet by Id

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
@@ -15,7 +15,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Update an existing pet
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IUpdatePetEndpoint
+    public partial interface IUpdatePetEndpoint
     {
         /// <summary>
         /// Update an existing pet by Id
@@ -28,7 +28,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Add a new pet to the store
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IAddPetEndpoint
+    public partial interface IAddPetEndpoint
     {
         /// <summary>
         /// Add a new pet to the store
@@ -41,7 +41,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Finds Pets by status
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IFindPetsByStatusEndpoint
+    public partial interface IFindPetsByStatusEndpoint
     {
         /// <summary>
         /// Multiple status values can be provided with comma separated strings
@@ -54,7 +54,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Finds Pets by tags
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IFindPetsByTagsEndpoint
+    public partial interface IFindPetsByTagsEndpoint
     {
         /// <summary>
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -67,7 +67,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Find pet by ID
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IGetPetByIdEndpoint
+    public partial interface IGetPetByIdEndpoint
     {
         /// <summary>
         /// Returns a single pet
@@ -80,7 +80,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Updates a pet in the store with form data
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IUpdatePetWithFormEndpoint
+    public partial interface IUpdatePetWithFormEndpoint
     {
         [Post("/pet/{petId}")]
         Task Execute(long petId, [Query] string name, [Query] string status);
@@ -90,7 +90,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Deletes a pet
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IDeletePetEndpoint
+    public partial interface IDeletePetEndpoint
     {
         [Delete("/pet/{petId}")]
         Task Execute(long petId, [Header("api_key")] string api_key);
@@ -100,7 +100,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// uploads an image
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IUploadFileEndpoint
+    public partial interface IUploadFileEndpoint
     {
         [Post("/pet/{petId}/uploadImage")]
         Task<ApiResponse> Execute(long petId, [Query] string additionalMetadata, StreamPart body);
@@ -110,7 +110,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Returns pet inventories by status
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IGetInventoryEndpoint
+    public partial interface IGetInventoryEndpoint
     {
         /// <summary>
         /// Returns a map of status codes to quantities
@@ -123,7 +123,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Place an order for a pet
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IPlaceOrderEndpoint
+    public partial interface IPlaceOrderEndpoint
     {
         /// <summary>
         /// Place a new order in the store
@@ -136,7 +136,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Find purchase order by ID
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IGetOrderByIdEndpoint
+    public partial interface IGetOrderByIdEndpoint
     {
         /// <summary>
         /// For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -149,7 +149,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Delete purchase order by ID
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IDeleteOrderEndpoint
+    public partial interface IDeleteOrderEndpoint
     {
         /// <summary>
         /// For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -162,7 +162,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Create user
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface ICreateUserEndpoint
+    public partial interface ICreateUserEndpoint
     {
         /// <summary>
         /// This can only be done by the logged in user.
@@ -175,7 +175,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Creates list of users with given input array
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface ICreateUsersWithListInputEndpoint
+    public partial interface ICreateUsersWithListInputEndpoint
     {
         /// <summary>
         /// Creates list of users with given input array
@@ -188,7 +188,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Logs user into the system
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface ILoginUserEndpoint
+    public partial interface ILoginUserEndpoint
     {
         [Get("/user/login")]
         Task<string> Execute([Query] string username, [Query] string password);
@@ -198,7 +198,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Logs out current logged in user session
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface ILogoutUserEndpoint
+    public partial interface ILogoutUserEndpoint
     {
         [Get("/user/logout")]
         Task Execute();
@@ -208,7 +208,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Get user by user name
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IGetUserByNameEndpoint
+    public partial interface IGetUserByNameEndpoint
     {
         [Get("/user/{username}")]
         Task<User> Execute(string username);
@@ -218,7 +218,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Update user
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IUpdateUserEndpoint
+    public partial interface IUpdateUserEndpoint
     {
         /// <summary>
         /// This can only be done by the logged in user.
@@ -231,7 +231,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     /// Delete user
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IDeleteUserEndpoint
+    public partial interface IDeleteUserEndpoint
     {
         /// <summary>
         /// This can only be done by the logged in user.

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfacesByTag.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfacesByTag.g.cs
@@ -15,7 +15,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
     /// Update an existing pet
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IPetApi
+    public partial interface IPetApi
     {
         /// <summary>
         /// Update an existing pet by Id
@@ -61,7 +61,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
     /// Returns pet inventories by status
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IStoreApi
+    public partial interface IStoreApi
     {
         /// <summary>
         /// Returns a map of status codes to quantities
@@ -92,7 +92,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
     /// Create user
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface IUserApi
+    public partial interface IUserApi
     {
         /// <summary>
         /// This can only be done by the logged in user.

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterface.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterface.g.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Refitter.Tests.AdditionalFiles.SingeInterface
 {
     [System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
-    public interface ISwaggerPetstore
+    public partial interface ISwaggerPetstore
     {
         /// <summary>
         /// Update an existing pet by Id

--- a/src/Refitter.Tests/Examples/MultipleInterfacesByEndpointTests.cs
+++ b/src/Refitter.Tests/Examples/MultipleInterfacesByEndpointTests.cs
@@ -66,28 +66,28 @@ paths:
     public async Task Generates_IGetAllFooEndpoint()
     {
         string generateCode = await GenerateCode();
-        generateCode.Should().Contain("interface IGetAllFoosEndpoint");
+        generateCode.Should().Contain("partial interface IGetAllFoosEndpoint");
     }
 
     [Fact]
     public async Task Generates_IGetFooDetailsEndpoint()
     {
         string generateCode = await GenerateCode();
-        generateCode.Should().Contain("interface IGetFooDetailsEndpoint");
+        generateCode.Should().Contain("partial interface IGetFooDetailsEndpoint");
     }
 
     [Fact]
     public async Task Generates_IGetAllBarEndpoint()
     {
         string generateCode = await GenerateCode();
-        generateCode.Should().Contain("interface IGetAllBarsEndpoint");
+        generateCode.Should().Contain("partial interface IGetAllBarsEndpoint");
     }
 
     [Fact]
     public async Task Generates_IGetBarDetailsEndpoint()
     {
         string generateCode = await GenerateCode();
-        generateCode.Should().Contain("interface IGetBarDetailsEndpoint");
+        generateCode.Should().Contain("partial interface IGetBarDetailsEndpoint");
     }
 
     [Fact]

--- a/src/Refitter.Tests/Examples/MultipleInterfacesByTagsTests.cs
+++ b/src/Refitter.Tests/Examples/MultipleInterfacesByTagsTests.cs
@@ -66,14 +66,14 @@ paths:
     public async Task Generates_Foo_Interface()
     {
         string generateCode = await GenerateCode();
-        generateCode.Should().Contain("interface IFooApi");
+        generateCode.Should().Contain("partial interface IFooApi");
     }
 
     [Fact]
     public async Task Generates_Bar_Interface()
     {
         string generateCode = await GenerateCode();
-        generateCode.Should().Contain("interface IBarApi");
+        generateCode.Should().Contain("partial interface IBarApi");
     }
 
     [Fact]

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -26,6 +26,17 @@ public class SwaggerPetstoreTests
     [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
     [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]
     [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV2, "SwaggerPetstore.yaml")]
+    public async Task Can_Generate_Partial_Interfaces(SampleOpenSpecifications version, string filename)
+    {
+        var generateCode = await GenerateCode(version, filename);
+        generateCode.Should().Contain("partial interface");
+    }
+
+    [Theory]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV2, "SwaggerPetstore.yaml")]
     public async Task Can_Generate_Code_Without_Contracts(SampleOpenSpecifications version, string filename)
     {
         var generateCode = await GenerateCode(
@@ -126,7 +137,7 @@ public class SwaggerPetstoreTests
         var settings = new RefitGeneratorSettings();
         settings.TypeAccessibility = TypeAccessibility.Internal;
         var generateCode = await GenerateCode(version, filename, settings);
-        generateCode.Should().Contain("internal interface");
+        generateCode.Should().Contain("internal partial interface");
     }
 
     [Theory]

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -87,7 +87,7 @@ using System.Collections.Generic;
 
 namespace Your.Namespace.Of.Choice.GeneratedCode
 {
-    public interface ISwaggerPetstore
+    public partial interface ISwaggerPetstore
     {
         /// <summary>
         /// Update an existing pet by Id
@@ -201,7 +201,7 @@ using System.Collections.Generic;
 
 namespace Your.Namespace.Of.Choice.GeneratedCode.WithApiResponse
 {
-    public interface ISwaggerPetstore
+    public partial interface ISwaggerPetstore
     {
         /// <summary>
         /// Update an existing pet by Id
@@ -317,7 +317,7 @@ $ refitter ./openapi.json --namespace "Your.Namespace.Of.Choice.GeneratedCode" -
 /// <summary>
 /// Update an existing pet
 /// </summary>
-public interface IUpdatePetEndpoint
+public partial interface IUpdatePetEndpoint
 {
     /// <summary>
     /// Update an existing pet by Id
@@ -329,7 +329,7 @@ public interface IUpdatePetEndpoint
 /// <summary>
 /// Add a new pet to the store
 /// </summary>
-public interface IAddPetEndpoint
+public partial interface IAddPetEndpoint
 {
     /// <summary>
     /// Add a new pet to the store
@@ -341,7 +341,7 @@ public interface IAddPetEndpoint
 /// <summary>
 /// Finds Pets by status
 /// </summary>
-public interface IFindPetsByStatusEndpoint
+public partial interface IFindPetsByStatusEndpoint
 {
     /// <summary>
     /// Multiple status values can be provided with comma separated strings
@@ -353,7 +353,7 @@ public interface IFindPetsByStatusEndpoint
 /// <summary>
 /// Finds Pets by tags
 /// </summary>
-public interface IFindPetsByTagsEndpoint
+public partial interface IFindPetsByTagsEndpoint
 {
     /// <summary>
     /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -365,7 +365,7 @@ public interface IFindPetsByTagsEndpoint
 /// <summary>
 /// Find pet by ID
 /// </summary>
-public interface IGetPetByIdEndpoint
+public partial interface IGetPetByIdEndpoint
 {
     /// <summary>
     /// Returns a single pet
@@ -377,7 +377,7 @@ public interface IGetPetByIdEndpoint
 /// <summary>
 /// Updates a pet in the store with form data
 /// </summary>
-public interface IUpdatePetWithFormEndpoint
+public partial interface IUpdatePetWithFormEndpoint
 {
     [Post("/pet/{petId}")]
     Task Execute(long petId, [Query] string name, [Query] string status);
@@ -386,7 +386,7 @@ public interface IUpdatePetWithFormEndpoint
 /// <summary>
 /// Deletes a pet
 /// </summary>
-public interface IDeletePetEndpoint
+public partial interface IDeletePetEndpoint
 {
     [Delete("/pet/{petId}")]
     Task Execute(long petId, [Header("api_key")] string api_key);
@@ -395,7 +395,7 @@ public interface IDeletePetEndpoint
 /// <summary>
 /// uploads an image
 /// </summary>
-public interface IUploadFileEndpoint
+public partial interface IUploadFileEndpoint
 {
     [Post("/pet/{petId}/uploadImage")]
     Task<ApiResponse> Execute(long petId, [Query] string additionalMetadata, StreamPart body);
@@ -404,7 +404,7 @@ public interface IUploadFileEndpoint
 /// <summary>
 /// Returns pet inventories by status
 /// </summary>
-public interface IGetInventoryEndpoint
+public partial interface IGetInventoryEndpoint
 {
     /// <summary>
     /// Returns a map of status codes to quantities
@@ -416,7 +416,7 @@ public interface IGetInventoryEndpoint
 /// <summary>
 /// Place an order for a pet
 /// </summary>
-public interface IPlaceOrderEndpoint
+public partial interface IPlaceOrderEndpoint
 {
     /// <summary>
     /// Place a new order in the store
@@ -428,7 +428,7 @@ public interface IPlaceOrderEndpoint
 /// <summary>
 /// Find purchase order by ID
 /// </summary>
-public interface IGetOrderByIdEndpoint
+public partial interface IGetOrderByIdEndpoint
 {
     /// <summary>
     /// For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -440,7 +440,7 @@ public interface IGetOrderByIdEndpoint
 /// <summary>
 /// Delete purchase order by ID
 /// </summary>
-public interface IDeleteOrderEndpoint
+public partial interface IDeleteOrderEndpoint
 {
     /// <summary>
     /// For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -452,7 +452,7 @@ public interface IDeleteOrderEndpoint
 /// <summary>
 /// Create user
 /// </summary>
-public interface ICreateUserEndpoint
+public partial interface ICreateUserEndpoint
 {
     /// <summary>
     /// This can only be done by the logged in user.
@@ -464,7 +464,7 @@ public interface ICreateUserEndpoint
 /// <summary>
 /// Creates list of users with given input array
 /// </summary>
-public interface ICreateUsersWithListInputEndpoint
+public partial interface ICreateUsersWithListInputEndpoint
 {
     /// <summary>
     /// Creates list of users with given input array
@@ -476,7 +476,7 @@ public interface ICreateUsersWithListInputEndpoint
 /// <summary>
 /// Logs user into the system
 /// </summary>
-public interface ILoginUserEndpoint
+public partial interface ILoginUserEndpoint
 {
     [Get("/user/login")]
     Task<string> Execute([Query] string username, [Query] string password);
@@ -485,7 +485,7 @@ public interface ILoginUserEndpoint
 /// <summary>
 /// Logs out current logged in user session
 /// </summary>
-public interface ILogoutUserEndpoint
+public partial interface ILogoutUserEndpoint
 {
     [Get("/user/logout")]
     Task Execute();
@@ -494,7 +494,7 @@ public interface ILogoutUserEndpoint
 /// <summary>
 /// Get user by user name
 /// </summary>
-public interface IGetUserByNameEndpoint
+public partial interface IGetUserByNameEndpoint
 {
     [Get("/user/{username}")]
     Task<User> Execute(string username);
@@ -503,7 +503,7 @@ public interface IGetUserByNameEndpoint
 /// <summary>
 /// Update user
 /// </summary>
-public interface IUpdateUserEndpoint
+public partial interface IUpdateUserEndpoint
 {
     /// <summary>
     /// This can only be done by the logged in user.
@@ -515,7 +515,7 @@ public interface IUpdateUserEndpoint
 /// <summary>
 /// Delete user
 /// </summary>
-public interface IDeleteUserEndpoint
+public partial interface IDeleteUserEndpoint
 {
     /// <summary>
     /// This can only be done by the logged in user.


### PR DESCRIPTION
Generated interfaces across the codebase were changed from regular to partial. This change allows the clients to extend the functionality of these interfaces without modifying auto-generated code. Tests were also updated to verify this change