### PR TITLE
Introduce `--operation-name-template` command line argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 **Implemented enhancements:**
 
+- Generate Refit interfaces as `partial` by default [\#161](https://github.com/christianhelle/refitter/issues/161)
 - Mark deprecated operations [\#147](https://github.com/christianhelle/refitter/issues/147)
+- Generate Refit interfaces as partial [\#162](https://github.com/christianhelle/refitter/pull/162) ([christianhelle](https://github.com/christianhelle))
 - Speed up local smoke tests [\#156](https://github.com/christianhelle/refitter/pull/156) ([christianhelle](https://github.com/christianhelle))
 - GenerateObsoleteAttribute [\#154](https://github.com/christianhelle/refitter/pull/154) ([angelofb](https://github.com/angelofb))
 - Disable support keys if --no-logging is specified [\#153](https://github.com/christianhelle/refitter/pull/153) ([christianhelle](https://github.com/christianhelle))

--- a/src/Refitter.Core/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/RefitGeneratorSettings.cs
@@ -129,6 +129,10 @@ public class RefitGeneratorSettings
     [JsonPropertyName("generateDeprecatedOperations")]
     [JsonProperty("generateDeprecatedOperations")]
     public bool GenerateDeprecatedOperations { get; set; } = true;
+
+    [JsonPropertyName("operationNameTemplate")]
+    [JsonProperty("operationNameTemplate")]
+    public string? OperationNameTemplate { get; set; }
 }
 
 public enum MultipleInterfaces

--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -7,7 +7,7 @@ namespace Refitter.Core;
 
 internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
 {
-    private const string Separator = "    ";
+    protected const string Separator = "    ";
 
     protected readonly RefitGeneratorSettings settings;
     protected readonly OpenApiDocument document;

--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -57,8 +57,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
 
                 var verb = operations.Key.CapitalizeFirstCharacter();
 
-                var name = generator.BaseSettings.OperationNameGenerator
-                    .GetOperationName(document, kv.Key, verb, operation);
+                var name = GetOperationName(kv.Key, operation, verb);
 
                 var operationModel = generator.CreateOperationModel(operation);
                 var parameters = ParameterExtractor.GetParameters(operationModel, operation, settings);
@@ -76,6 +75,22 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
         }
 
         return code.ToString();
+    }
+
+    private string GetOperationName(string path, OpenApiOperation operation, string verb)
+    {
+        const string operationNamePlaceholder = "{operationName}";
+
+        var operationName = generator.BaseSettings.OperationNameGenerator
+                            .GetOperationName(document, path, verb, operation);
+
+        if (settings.OperationNameTemplate?.Contains(operationNamePlaceholder) ?? false)
+        {
+            operationName = settings.OperationNameTemplate!
+                           .Replace(operationNamePlaceholder, operationName);
+        }
+
+        return operationName;
     }
 
     protected static void GenerateForMultipartFormData(CSharpOperationModel operationModel, StringBuilder code)

--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -9,9 +9,9 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
 {
     private const string Separator = "    ";
 
-    private readonly RefitGeneratorSettings settings;
-    private readonly OpenApiDocument document;
-    private readonly CustomCSharpClientGenerator generator;
+    protected readonly RefitGeneratorSettings settings;
+    protected readonly OpenApiDocument document;
+    protected readonly CustomCSharpClientGenerator generator;
 
     internal RefitInterfaceGenerator(
         RefitGeneratorSettings settings,
@@ -57,7 +57,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
 
                 var verb = operations.Key.CapitalizeFirstCharacter();
 
-                var name = GetOperationName(kv.Key, operation, verb);
+                var name = GenerateOperationName(kv.Key, verb, operation);
 
                 var operationModel = generator.CreateOperationModel(operation);
                 var parameters = ParameterExtractor.GetParameters(operationModel, operation, settings);
@@ -77,12 +77,17 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
         return code.ToString();
     }
 
-    private string GetOperationName(string path, OpenApiOperation operation, string verb)
+    protected string GenerateOperationName(string path, string verb, OpenApiOperation operation, bool capitalizeFirstCharacter = false)
     {
         const string operationNamePlaceholder = "{operationName}";
 
-        var operationName = generator.BaseSettings.OperationNameGenerator
-                            .GetOperationName(document, path, verb, operation);
+        var operationName = generator
+            .BaseSettings
+            .OperationNameGenerator
+            .GetOperationName(document, path, verb, operation);
+
+        if (capitalizeFirstCharacter)
+            operationName = operationName.CapitalizeFirstCharacter();
 
         if (settings.OperationNameTemplate?.Contains(operationNamePlaceholder) ?? false)
         {

--- a/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
@@ -8,9 +8,6 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
 {
     private const string Separator = "    ";
 
-    private readonly RefitGeneratorSettings settings;
-    private readonly OpenApiDocument document;
-    private readonly CustomCSharpClientGenerator generator;
     private readonly HashSet<string> knownIdentifiers = new();
 
     internal RefitMultipleInterfaceByTagGenerator(
@@ -19,10 +16,6 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
         CustomCSharpClientGenerator generator)
         : base(settings, document, generator)
     {
-        this.settings = settings;
-        this.document = document;
-        this.generator = generator;
-        generator.BaseSettings.OperationNameGenerator = new OperationNameGenerator(document);
     }
 
     public override string GenerateCode()
@@ -128,11 +121,7 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
         string verb,
         OpenApiOperation operation)
     {
-        var generatedName = IdentifierUtils.Counted(knownIdentifiers,
-            generator
-                .BaseSettings
-                .OperationNameGenerator
-                .GetOperationName(document, name, verb, operation).CapitalizeFirstCharacter());
+        var generatedName = IdentifierUtils.Counted(knownIdentifiers, GenerateOperationName(name, verb, operation, capitalizeFirstCharacter: true));
         knownIdentifiers.Add(generatedName);
         return generatedName;
     }

--- a/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
@@ -6,8 +6,6 @@ namespace Refitter.Core;
 
 internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
 {
-    private const string Separator = "    ";
-
     private readonly HashSet<string> knownIdentifiers = new();
 
     internal RefitMultipleInterfaceByTagGenerator(

--- a/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
@@ -6,8 +6,6 @@ namespace Refitter.Core;
 
 internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
 {
-    private const string Separator = "    ";
-
     private readonly HashSet<string> knownIdentifiers = new();
 
     internal RefitMultipleInterfaceGenerator(
@@ -73,7 +71,10 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
     {
         var name = IdentifierUtils.Counted(
             knownIdentifiers,
-            "I" + GenerateOperationName(kv.Key, verb, operation, capitalizeFirstCharacter: true),
+            "I" + generator
+                .BaseSettings
+                .OperationNameGenerator
+                .GetOperationName(document, kv.Key, verb, operation).CapitalizeFirstCharacter(),
             suffix: "Endpoint");
         knownIdentifiers.Add(name);
         return name;

--- a/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
@@ -8,9 +8,6 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
 {
     private const string Separator = "    ";
 
-    private readonly RefitGeneratorSettings settings;
-    private readonly OpenApiDocument document;
-    private readonly CustomCSharpClientGenerator generator;
     private readonly HashSet<string> knownIdentifiers = new();
 
     internal RefitMultipleInterfaceGenerator(
@@ -19,10 +16,6 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
         CustomCSharpClientGenerator generator)
         : base(settings, document, generator)
     {
-        this.settings = settings;
-        this.document = document;
-        this.generator = generator;
-        generator.BaseSettings.OperationNameGenerator = new OperationNameGenerator(document);
     }
 
     public override string GenerateCode()
@@ -80,10 +73,7 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
     {
         var name = IdentifierUtils.Counted(
             knownIdentifiers,
-            "I" + generator
-                .BaseSettings
-                .OperationNameGenerator
-                .GetOperationName(document, kv.Key, verb, operation).CapitalizeFirstCharacter(),
+            "I" + GenerateOperationName(kv.Key, verb, operation, capitalizeFirstCharacter: true),
             suffix: "Endpoint");
         knownIdentifiers.Add(name);
         return name;

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -405,4 +405,17 @@ public class SwaggerPetstoreTests
         var generateCode = await GenerateCode(version, filename, settings);
         generateCode.Should().NotContain(@"/pet/findByTags");
     }
+
+    [Theory]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV2, "SwaggerPetstore.yaml")]
+    public async Task Can_Generate_Code_With_Operation_Name_Template(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings();
+        settings.OperationNameTemplate = "{operationName}Async";
+        var generateCode = await GenerateCode(version, filename, settings);
+        generateCode.Should().Contain("FindPetsByStatusAsync");
+    }
 }

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -52,6 +52,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             IncludePathMatches = settings.MatchPaths ?? Array.Empty<string>(),
             IncludeTags = settings.Tags ?? Array.Empty<string>(),
             GenerateDeprecatedOperations = !settings.NoDeprecatedOperations,
+            OperationNameTemplate = settings.OperationNameTemplate,
         };
 
         try

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -26,6 +26,9 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         if (IsUrl(settings.OpenApiPath))
             return base.Validate(context, settings);
 
+        if (!string.IsNullOrWhiteSpace(settings.OperationNameTemplate) && !settings.OperationNameTemplate.Contains("{operationName}"))
+            return ValidationResult.Error("'{operationName}' placeholder must be present in operation name template");
+
         return File.Exists(settings.OpenApiPath)
             ? base.Validate(context, settings)
             : ValidationResult.Error($"File not found - {Path.GetFullPath(settings.OpenApiPath)}");

--- a/src/Refitter/Program.cs
+++ b/src/Refitter/Program.cs
@@ -120,6 +120,12 @@ internal static class Program
                     .AddExample(
                         "./openapi.json",
                         "--no-deprecated-operations");
+
+                configuration
+                    .AddExample(
+                        "./openapi.json",
+                        "--operation-name-template",
+                        "'{operationName}Async'");
             });
 
         return app.Run(args);

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -61,7 +61,7 @@ OPTIONS:
         --tag                                          Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation       
         --skip-validation                              Skip validation of the OpenAPI specification                                                                 
         --no-deprecated-operations                     Don't generate deprecated operations                                                                         
-        --operation-name-template                      Generate operation names using pattern like '{operationName}Async'                                                                         
+        --operation-name-template                      Generate operation names using pattern like '{operationName}Async'                                           
 ```
 
 To generate code from an OpenAPI specifications file, run the following:

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -61,6 +61,7 @@ OPTIONS:
         --tag                                          Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation       
         --skip-validation                              Skip validation of the OpenAPI specification                                                                 
         --no-deprecated-operations                     Don't generate deprecated operations                                                                         
+        --operation-name-template                      Generate operation names using pattern like '{operationName}Async'                                                                         
 ```
 
 To generate code from an OpenAPI specifications file, run the following:

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -98,4 +98,9 @@ public sealed class Settings : CommandSettings
     [CommandOption("--no-deprecated-operations")]
     [DefaultValue(false)]
     public bool NoDeprecatedOperations { get; set; }
+
+    [Description("Generate operation names using pattern")]
+    [CommandOption("--operation-name-template")]
+    [DefaultValue(null)]
+    public string? OperationNameTemplate { get; internal set; }
 }


### PR DESCRIPTION
--operation-name-template 

Generate operation names using pattern like '{operationName}Async' 

very simple pattern substitution.
I want to replace nswag with refitter in my codebase and I have so(ooo) many operations already generated with "Async" appended at the end (NSwag generator do this by default, to change the behaviour the template must be edited)

