### PR TITLE
Remove `namespace` settings from `codeGeneratorSettings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using `"multipleIinterfaces": "ByEndpoint"`, This is name of the Execute() method in the interface
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL

--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ The following is an example `.refitter` file
     "firstBackoffRetryInSeconds": 0.5 // Optional. Default=1.0
   },
   "codeGeneratorSettings": { // Optional. Default settings are the values set in this example
-    "namespace": "GeneratedCode",
     "requiredPropertiesMustBeDefined": true,
     "generateDataAnnotations": true,
     "anyType": "object",
@@ -228,7 +227,6 @@ The following is an example `.refitter` file
   - `pollyMaxRetryCount` - This is the max retry count used in the Polly retry policy. Default is 6
   - `firstBackoffRetryInSeconds` - This is the duration of the initial retry backoff. Default is 1 second
 - `codeGeneratorSettings` - Setting this allows customization of the NSwag generated types and contracts
-  - `namespace` - Default is `GeneratedCode`,
   - `requiredPropertiesMustBeDefined` - Default is true,
   - `generateDataAnnotations` - Default is true,
   - `anyType` - Default is `object`,

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -50,7 +50,6 @@ The following is an example `.refitter` file
     "firstBackoffRetryInSeconds": 0.5 // Optional. Default=1.0
   },
   "codeGeneratorSettings": { // Optional. Default settings are the values set in this example
-    "namespace": "GeneratedCode",
     "requiredPropertiesMustBeDefined": true,
     "generateDataAnnotations": true,
     "anyType": "object",
@@ -90,7 +89,6 @@ The following is an example `.refitter` file
 Here are some basic explanations of each property:
 
 - `openApiPath` - points to the OpenAPI Specifications file. This can be the path to a file stored on disk, relative to the `.refitter` file. This can also be a URL to a remote file that will be downloaded over HTTP/HTTPS
-- `namespace` - the namespace used in the generated code. If not specified, this defaults to `GeneratedCode`
 - `naming.useOpenApiTitle` - a boolean indicating whether the OpenApi title should be used. Default is `true`
 - `naming.interfaceName` - the name of the generated interface. The generated code will automatically prefix this with `I` so if this set to `MyApiClient` then the generated interface is called `IMyApiClient`. Default is `ApiClient`
 - `generateContracts` - a boolean indicating whether contracts should be generated. A use case for this is several API clients use the same contracts. Default is `true`
@@ -117,7 +115,6 @@ Here are some basic explanations of each property:
   - `pollyMaxRetryCount` - This is the max retry count used in the Polly retry policy. Default is 6
   - `firstBackoffRetryInSeconds` - This is the duration of the initial retry backoff. Default is 1 second
 - `codeGeneratorSettings` - Setting this allows customization of the NSwag generated types and contracts
-  - `namespace` - Default is `GeneratedCode`,
   - `requiredPropertiesMustBeDefined` - Default is true,
   - `generateDataAnnotations` - Default is true,
   - `anyType` - Default is `object`,

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -106,7 +106,7 @@ Here are some basic explanations of each property:
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using `"multipleIinterfaces": "ByEndpoint"`, This is name of the Execute() method in the interface
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL

--- a/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
@@ -6,11 +6,6 @@
 public class CodeGeneratorSettings
 {
     /// <summary>
-    /// Gets or sets the .NET namespace of the generated types (default: GeneratedCode).
-    /// </summary>
-    public string Namespace { get; set; } = "GeneratedCode";
-
-    /// <summary>
     /// Gets or sets a value indicating whether a required property must be defined in JSON
     /// (sets Required.Always when the property is required) (default: true).
     /// </summary>

--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -115,7 +115,7 @@ public class RefitGeneratorSettings
 
     /// <summary>
     /// Generate operation names using pattern. 
-    /// When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface.
+    /// When using <see cref="MultipleInterfaces"/> <see cref="ByEndpoint"/>, this is name of the Execute() method in the interface.
     /// </summary>
     [JsonPropertyName("operationNameTemplate")]
     public string? OperationNameTemplate { get; set; }

--- a/src/Refitter.SourceGenerator/README.md
+++ b/src/Refitter.SourceGenerator/README.md
@@ -126,7 +126,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using `"multipleIinterfaces": "ByEndpoint"`, This is name of the Execute() method in the interface
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL

--- a/src/Refitter.SourceGenerator/README.md
+++ b/src/Refitter.SourceGenerator/README.md
@@ -135,7 +135,6 @@ The following is an example `.refitter` file
   - `pollyMaxRetryCount` - This is the max retry count used in the Polly retry policy. Default is 6
   - `firstBackoffRetryInSeconds` - This is the duration of the initial retry backoff. Default is 1 second
 - `codeGeneratorSettings` - Setting this allows customization of the NSwag generated types and contracts
-  - `namespace` - Default is `GeneratedCode`,
   - `requiredPropertiesMustBeDefined` - Default is true,
   - `generateDataAnnotations` - Default is true,
   - `anyType` - Default is `object`,

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -138,7 +138,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multipleIinterfaces=ByEndpoint, This is name of the Execute() method in the interface
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL
@@ -146,6 +146,36 @@ The following is an example `.refitter` file
   - `usePolly` - Set this to true to configure the HttpClient to use Polly using a retry policy with a jittered backoff
   - `pollyMaxRetryCount` - This is the max retry count used in the Polly retry policy. Default is 6
   - `firstBackoffRetryInSeconds` - This is the duration of the initial retry backoff. Default is 1 second
+- `codeGeneratorSettings` - Setting this allows customization of the NSwag generated types and contracts
+  - `requiredPropertiesMustBeDefined` - Default is true,
+  - `generateDataAnnotations` - Default is true,
+  - `anyType` - Default is `object`,
+  - `dateType` - Default is `System.DateTimeOffset`,
+  - `dateTimeType` - Default is `System.DateTimeOffset`,
+  - `timeType` - Default is `System.TimeSpan`,
+  - `timeSpanType` - Default is `System.TimeSpan`,
+  - `arrayType` - Default is `System.Collections.Generic.ICollection`,
+  - `dictionaryType` - Default is `System.Collections.Generic.IDictionary`,
+  - `arrayInstanceType` - Default is `System.Collections.ObjectModel.Collection`,
+  - `dictionaryInstanceType` - Default is `System.Collections.Generic.Dictionary`,
+  - `arrayBaseType` - Default is `System.Collections.ObjectModel.Collection`,
+  - `dictionaryBaseType` - Default is `System.Collections.Generic.Dictionary`,
+  - `propertySetterAccessModifier` - Default is ``,
+  - `generateImmutableArrayProperties` - Default is false,
+  - `generateImmutableDictionaryProperties` - Default is false,
+  - `handleReferences` - Default is false,
+  - `jsonSerializerSettingsTransformationMethod` - Default is null,
+  - `generateJsonMethods` - Default is false,
+  - `enforceFlagEnums` - Default is false,
+  - `inlineNamedDictionaries` - Default is false,
+  - `inlineNamedTuples` - Default is true,
+  - `inlineNamedArrays` - Default is false,
+  - `generateOptionalPropertiesAsNullable` - Default is false,
+  - `generateNullableReferenceTypes` - Default is false,
+  - `generateNativeRecords` - Default is false
+  - `generateDefaultValues` - Default is true
+  - `inlineNamedAny` - Default is false
+  - `excludedTypeNames` - Default is empty
 
 To generate code from an OpenAPI specifications file, run the following:
 

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -138,7 +138,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using `"multipleIinterfaces": "ByEndpoint"`, This is name of the Execute() method in the interface
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL


### PR DESCRIPTION
The namespace setting in `codeGeneratorSettings` and related documentation was removed. This setting is a duplicated and was never respected, it was just causing confusion and was deemed unnecessary. The `namespace` property is already defined in `RefitGeneratorSettings` and from the CLI argument `--namespace`

This resolves the recent issue mentioned in #186 reported by @alrz