### PR TITLE
Remove unreferenced schema, add `--trim-unused-schema` & `--keep-schema`

### DIFF
--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -22,7 +22,19 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
         ProcessTagFilters(openApiDocument, settings.IncludeTags);
         ProcessPathFilters(openApiDocument, settings.IncludePathMatches);
 
+        ProcessContractFilter(openApiDocument, settings.TrimUnusedSchema);
+
         return new RefitGenerator(settings, openApiDocument);
+    }
+
+    private static void ProcessContractFilter(OpenApiDocument openApiDocument, bool removeUnusedSchema)
+    {
+        if (!removeUnusedSchema)
+        {
+            return;
+        }
+        var cleaner = new SchemaCleaner(openApiDocument);
+        cleaner.RemoveUnreferencedSchema();
     }
 
     private static void ProcessTagFilters(OpenApiDocument document, IReadOnlyCollection<string> includeTags)

--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -22,18 +22,18 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
         ProcessTagFilters(openApiDocument, settings.IncludeTags);
         ProcessPathFilters(openApiDocument, settings.IncludePathMatches);
 
-        ProcessContractFilter(openApiDocument, settings.TrimUnusedSchema);
+        ProcessContractFilter(openApiDocument, settings.TrimUnusedSchema, settings.KeepSchemaPatterns);
 
         return new RefitGenerator(settings, openApiDocument);
     }
 
-    private static void ProcessContractFilter(OpenApiDocument openApiDocument, bool removeUnusedSchema)
+    private static void ProcessContractFilter(OpenApiDocument openApiDocument, bool removeUnusedSchema, string[] includeSchemaMatches)
     {
         if (!removeUnusedSchema)
         {
             return;
         }
-        var cleaner = new SchemaCleaner(openApiDocument);
+        var cleaner = new SchemaCleaner(openApiDocument, includeSchemaMatches);
         cleaner.RemoveUnreferencedSchema();
     }
 

--- a/src/Refitter.Core/SchemaCleaner.cs
+++ b/src/Refitter.Core/SchemaCleaner.cs
@@ -42,14 +42,20 @@ public class SchemaCleaner
             }
         }
 
-        var seen = new HashSet<string>();
+        var seenIds = new HashSet<string>();
+        var seen = new HashSet<JsonSchema>();
         while (toProcess.Count > 0)
         {
             var schema = toProcess.Pop();
+            if (!seen.Add(schema.ActualSchema))
+            {
+                continue;
+            }
+
             // NOTE: NSwag schema stuff seems weird, with all their "Actual..."
             if (schemaIdLookup.TryGetValue(schema.ActualSchema, out var refId))
             {
-                if (!seen.Add(refId))
+                if (!seenIds.Add(refId))
                 {
                     // prevent recursion
                     continue;
@@ -62,7 +68,7 @@ public class SchemaCleaner
             }
         }
 
-        return seen;
+        return seenIds;
     }
 
     IEnumerable<JsonSchema?> GetSchemaForPath(OpenApiPathItem pathItem)

--- a/src/Refitter.Core/SchemaCleaner.cs
+++ b/src/Refitter.Core/SchemaCleaner.cs
@@ -1,0 +1,172 @@
+﻿using NJsonSchema;
+
+using NSwag;
+
+namespace Refitter.Core;
+
+public class SchemaCleaner
+{
+    private readonly OpenApiDocument _doc;
+
+    public SchemaCleaner(OpenApiDocument doc)
+    {
+        _doc = doc;
+    }
+    public void RemoveUnreferencedSchema()
+    {
+        var usage = FindUsedSchema(_doc);
+
+        var unused = _doc.Components.Schemas.Where(s => !usage.Contains(s.Key))
+            .ToArray();
+
+        foreach (var unusedSchema in unused)
+        {
+            _doc.Components.Schemas.Remove(unusedSchema);
+        }
+    }
+
+    HashSet<string> FindUsedSchema(OpenApiDocument doc)
+    {
+        var toProcess = new Stack<JsonSchema>();
+        var schemaIdLookup = _doc.Components.Schemas
+            .ToDictionary(x => x.Value,
+                x => x.Key);
+        
+        foreach (var kvp in doc.Paths)
+        {
+            var pathItem = kvp.Value;
+            foreach (JsonSchema? schema in GetSchemaForPath(pathItem))
+            {
+                TryPush(schema, toProcess);
+            }
+        }
+
+        var seen = new HashSet<string>();
+        while (toProcess.Count > 0)
+        {
+            var schema = toProcess.Pop();
+            // NOTE: NSwag schema stuff seems weird, with all their "Actual..."
+            if (schemaIdLookup.TryGetValue(schema.ActualSchema, out var refId))
+            {
+                if (!seen.Add(refId))
+                {
+                    // prevent recursion
+                    continue;
+                }
+            }
+            foreach (var subSchema in EnumerateSchema(schema))
+            {
+                TryPush(subSchema, toProcess);
+            }
+        }
+
+        return seen;
+    }
+
+    IEnumerable<JsonSchema?> GetSchemaForPath(OpenApiPathItem pathItem)
+    {
+        foreach (var p in pathItem.Parameters)
+        {
+            yield return p;
+        }
+        
+        foreach (var op in pathItem.Values)
+        {
+            if (op.RequestBody != null)
+            {
+                var body = op.RequestBody;
+                foreach (var kvpBody in body.Content)
+                {
+                    var content = kvpBody.Value;
+                    yield return content.Schema;
+                }
+            }
+
+            foreach (var p in op.ActualParameters)
+            {
+                yield return p;
+            }
+                
+            foreach (var resp in op.ActualResponses.Select(x => x.Value))
+            {
+                foreach (var header in resp.Headers.Select(x => x.Value))
+                {
+                    yield return header;
+                }
+                foreach (var mediaType in resp.Content.Select(x => x.Value))
+                {
+                    yield return mediaType.Schema;
+                }
+            }
+        }
+    }
+    
+    private void TryPush(JsonSchema? schema, Stack<JsonSchema> stack)
+    {
+        if (schema == null)
+        {
+            return;
+        }
+        stack.Push(schema);
+    }
+
+    IEnumerable<JsonSchema> EnumerateSchema(JsonSchema? schema)
+    {
+        if (schema is null)
+        {
+            return Enumerable.Empty<JsonSchema>();
+        }
+
+        return EnumerateInternal(schema)
+            .Where(x => x != null)
+            .Select(x => x!);
+
+        static IEnumerable<JsonSchema?> EnumerateInternal(JsonSchema schema)
+        {
+            // schema = schema.ActualSchema;
+            yield return schema.AdditionalItemsSchema;
+            yield return schema.AdditionalPropertiesSchema;
+            if (schema.AllInheritedSchemas != null)
+            {
+                foreach (JsonSchema s in schema.AllInheritedSchemas)
+                {
+                    yield return s;
+                }
+            }
+            if (schema.Items != null)
+            {
+                foreach (JsonSchema s in schema.Items)
+                {
+                    yield return s;
+                }
+            }
+            yield return schema.Not;
+            
+            
+            
+            foreach (var subSchema in schema.AllOf)
+            {
+                yield return subSchema;
+            }
+            foreach (var subSchema in schema.AnyOf)
+            {
+                yield return subSchema;
+            }
+            foreach (var subSchema in schema.OneOf)
+            {
+                yield return subSchema;
+            }
+            foreach (var kvp in schema.Properties)
+            {
+                var subSchema = kvp.Value;
+                yield return subSchema;
+            }
+            
+            foreach (var kvp in schema.Definitions)
+            {
+                var subSchema = kvp.Value;
+                yield return subSchema;
+            }
+        }
+    }
+}

--- a/src/Refitter.Core/SchemaCleaner.cs
+++ b/src/Refitter.Core/SchemaCleaner.cs
@@ -54,7 +54,7 @@ public class SchemaCleaner
                     continue;
                 }
             }
-            foreach (var subSchema in EnumerateSchema(schema))
+            foreach (var subSchema in EnumerateSchema(schema.ActualSchema))
             {
                 TryPush(subSchema, toProcess);
             }

--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -131,6 +131,15 @@ public class RefitGeneratorSettings
     /// </summary>
     public CodeGeneratorSettings? CodeGeneratorSettings { get; set; }
     
-    [JsonPropertyName("trimUnusedSchema")]
+    /// <summary>
+    /// Set to <c>true</c> to apply tree-shaking to the OpenApi schema.
+    /// This works in conjunction with <see cref="IncludeTags"/> and <see cref="IncludePathMatches"/>.
+    /// </summary>
     public bool TrimUnusedSchema { get; set; }
+    
+    /// <summary>
+    /// Array of regular expressions that determine if a schema needs to be kept.
+    /// This works in conjunction with <see cref="TrimUnusedSchema"/>.
+    /// </summary>
+    public string[] KeepSchemaPatterns { get; set; } = Array.Empty<string>();
 }

--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -130,4 +130,7 @@ public class RefitGeneratorSettings
     /// Gets or sets the settings describing how to generate types using NSwag
     /// </summary>
     public CodeGeneratorSettings? CodeGeneratorSettings { get; set; }
+    
+    [JsonPropertyName("trimUnusedSchema")]
+    public bool TrimUnusedSchema { get; set; }
 }

--- a/src/Refitter.Tests/Examples/TrimUnusedSchemaTests.cs
+++ b/src/Refitter.Tests/Examples/TrimUnusedSchemaTests.cs
@@ -17,6 +17,12 @@ paths:
       tags:
         - Warehouses
       operationId: CreateWarehouse
+      parameters:
+      - name: 'token'
+        in: 'query'
+        description: 'Some Token'
+        required: false
+        type: 'string'
       requestBody:
         content:
           application/json:
@@ -25,6 +31,11 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            X-Rate-Limit:
+              type: 'integer'
+              format: 'int32'
+              description: 'calls per hour allowed by the user'
           content:
             application/json:
               schema:
@@ -129,6 +140,15 @@ components:
           type: string
           nullable: true
       additionalProperties: false
+    UserComponent2:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UserComponent'
+      properties:
+        info2:
+          type: string
+          nullable: true
+      additionalProperties: false
     ProblemDetails:
       required:
         - $type
@@ -173,7 +193,7 @@ components:
         generateCode.Should().Contain("class Component");
         generateCode.Should().Contain("class ProblemDetails");
 
-        generateCode.Should().Contain("Task<Warehouse> CreateWarehouse([Body] Warehouse ");
+        generateCode.Should().Contain("Task<Warehouse> CreateWarehouse([Query] string token, [Body] Warehouse ");
 
         generateCode.Should().NotContain("class UserComponent");
     }

--- a/src/Refitter.Tests/Examples/TrimUnusedSchemaTests.cs
+++ b/src/Refitter.Tests/Examples/TrimUnusedSchemaTests.cs
@@ -1,0 +1,182 @@
+﻿using FluentAssertions;
+
+using Refitter.Core;
+using Refitter.Tests.Build;
+
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class TrimUnusedSchemaTests
+{
+    private const string OpenApiSpec = @"
+openapi: 3.0.1
+paths:
+  /v1/Logins/login:
+    post:
+      tags:
+        - Logins
+      operationId: PerformLogin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResult'
+        '422':
+          description: Client Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+components:
+  schemas:
+    LoginRequest:
+      type: object
+      properties:
+        username:
+          type: string
+          nullable: true
+        password:
+          type: string
+          nullable: true
+      additionalProperties: false
+    LoginResult:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+        accessToken:
+          type: string
+          nullable: true
+        accessTokenExpiresAt:
+          type: string
+          format: date-time
+        refreshToken:
+          type: string
+          nullable: true
+        refreshTokenExpiresAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+    ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: integer
+          format: int32
+          nullable: true
+        detail:
+          type: string
+          nullable: true
+        instance:
+          type: string
+          nullable: true
+      additionalProperties: { }
+    RefreshLoginRequest:
+      type: object
+      properties:
+        refreshToken:
+          type: string
+          nullable: true
+      additionalProperties: false
+    RefreshLoginResult:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+        accessToken:
+          type: string
+          nullable: true
+        accessTokenExpiresAt:
+          type: string
+          format: date-time
+        refreshToken:
+          type: string
+          nullable: true
+        refreshTokenExpiresAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        username:
+          type: string
+          nullable: true
+      additionalProperties: false
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Removes_Unreferenced_Schema()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().Contain("class LoginRequest");
+        generateCode.Should().Contain("class LoginResult");
+        generateCode.Should().Contain("class ProblemDetails");
+
+        generateCode.Should().Contain("Task<LoginResult> PerformLogin([Body] LoginRequest ");
+        
+        generateCode.Should().NotContain("class User");
+        generateCode.Should().NotContain("class RefreshLoginResult");
+        generateCode.Should().NotContain("class RefreshLoginRequest");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = swaggerFile,
+            TrimUnusedSchema = true
+        };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -46,6 +46,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             OperationNameTemplate = settings.OperationNameTemplate,
             OptionalParameters = settings.OptionalNullableParameters,
             TrimUnusedSchema = settings.TrimUnusedSchema,
+            KeepSchemaPatterns = settings.KeepSchemaPatterns ?? Array.Empty<string>()
         };
 
         try

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -45,6 +45,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             GenerateDeprecatedOperations = !settings.NoDeprecatedOperations,
             OperationNameTemplate = settings.OperationNameTemplate,
             OptionalParameters = settings.OptionalNullableParameters,
+            TrimUnusedSchema = settings.TrimUnusedSchema,
         };
 
         try

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -38,6 +38,8 @@ EXAMPLES:
     refitter ./openapi.json --no-deprecated-operations
     refitter ./openapi.json --operation-name-template '{operationName}Async'
     refitter ./openapi.json --optional-nullable-parameters
+    refitter ./openapi.json --trim-unused-schema
+    refitter ./openapi.json --trim-unused-schema --keep-schema '^Model$' --keep-schema '^Person.+'
 
 ARGUMENTS:
     [URL or input file]    URL or file path to OpenAPI Specification file
@@ -64,7 +66,9 @@ OPTIONS:
         --skip-validation                                  Skip validation of the OpenAPI specification                                                                                              
         --no-deprecated-operations                         Don't generate deprecated operations                                                                                                      
         --operation-name-template                          Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface
-        --optional-nullable-parameters                     Generate nullable parameters as optional parameters                                                                                       
+        --optional-nullable-parameters                     Generate nullable parameters as optional parameters
+        --trim-unused-schema                               Removes unreferenced components schema to keep the generated output to a minimum
+        --keep-schema                                      Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times                                                                                       
 ```
 
 ### .Refitter File format

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -111,4 +111,9 @@ public sealed class Settings : CommandSettings
     [CommandOption("--optional-nullable-parameters")]
     [DefaultValue(false)]
     public bool OptionalNullableParameters { get; set; }
+
+    [Description("Removes unreferenced components schema to keep the generated output to a minimum")]
+    [CommandOption("--trim-unused-schema")]
+    [DefaultValue(false)]
+    public bool TrimUnusedSchema { get; set; }
 }

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -116,4 +116,9 @@ public sealed class Settings : CommandSettings
     [CommandOption("--trim-unused-schema")]
     [DefaultValue(false)]
     public bool TrimUnusedSchema { get; set; }
+    
+    [Description("Force to keep matching schema, uses regular expressions. Use together with \"--trim-unused-schema\". Can be set multiple times.")]
+    [CommandOption("--keep-schema")]
+    [DefaultValue(new string[0])]
+    public string[]? KeepSchemaPatterns { get; set; }
 }


### PR DESCRIPTION
fixes #170 

This **DRAFT** implements the aforementioned feature request.

it adds a new commandline switch (`--trim-unused-schema`) aswell as configuration option (`trimUnusedSchema: true`) which works well in conjunction with `--tag Xyz` filters or similar.

The new option removes any Schema found in `#/components/...` which is not referenced in any way by the operations of the OpenApi document.

This results in much less code being generated for large documents which are filtered to generate only a few endpoints.

