### PR TITLE
Add Action<IHttpClientBuilder>? parameter in ConfigureRefitClients

### DIFF
--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
@@ -248,6 +248,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
 
 
+#nullable enable
 namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 {
     using System;
@@ -255,121 +256,140 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
     public static partial class IServiceCollectionExtensions
     {
-        public static IServiceCollection ConfigureRefitClients(this IServiceCollection services, Uri baseUrl)
+        public static IServiceCollection ConfigureRefitClients(this IServiceCollection services, Uri baseUrl, Action<IHttpClientBuilder>? builder = default)
         {
-            services
+            var clientBuilderIUpdatePetEndpoint = services
                 .AddRefitClient<IUpdatePetEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIUpdatePetEndpoint);
 
-            services
+            var clientBuilderIAddPetEndpoint = services
                 .AddRefitClient<IAddPetEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIAddPetEndpoint);
 
-            services
+            var clientBuilderIFindPetsByStatusEndpoint = services
                 .AddRefitClient<IFindPetsByStatusEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIFindPetsByStatusEndpoint);
 
-            services
+            var clientBuilderIFindPetsByTagsEndpoint = services
                 .AddRefitClient<IFindPetsByTagsEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIFindPetsByTagsEndpoint);
 
-            services
+            var clientBuilderIGetPetByIdEndpoint = services
                 .AddRefitClient<IGetPetByIdEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIGetPetByIdEndpoint);
 
-            services
+            var clientBuilderIUpdatePetWithFormEndpoint = services
                 .AddRefitClient<IUpdatePetWithFormEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIUpdatePetWithFormEndpoint);
 
-            services
+            var clientBuilderIDeletePetEndpoint = services
                 .AddRefitClient<IDeletePetEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIDeletePetEndpoint);
 
-            services
+            var clientBuilderIUploadFileEndpoint = services
                 .AddRefitClient<IUploadFileEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIUploadFileEndpoint);
 
-            services
+            var clientBuilderIGetInventoryEndpoint = services
                 .AddRefitClient<IGetInventoryEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIGetInventoryEndpoint);
 
-            services
+            var clientBuilderIPlaceOrderEndpoint = services
                 .AddRefitClient<IPlaceOrderEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIPlaceOrderEndpoint);
 
-            services
+            var clientBuilderIGetOrderByIdEndpoint = services
                 .AddRefitClient<IGetOrderByIdEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIGetOrderByIdEndpoint);
 
-            services
+            var clientBuilderIDeleteOrderEndpoint = services
                 .AddRefitClient<IDeleteOrderEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIDeleteOrderEndpoint);
 
-            services
+            var clientBuilderICreateUserEndpoint = services
                 .AddRefitClient<ICreateUserEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderICreateUserEndpoint);
 
-            services
+            var clientBuilderICreateUsersWithListInputEndpoint = services
                 .AddRefitClient<ICreateUsersWithListInputEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderICreateUsersWithListInputEndpoint);
 
-            services
+            var clientBuilderILoginUserEndpoint = services
                 .AddRefitClient<ILoginUserEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderILoginUserEndpoint);
 
-            services
+            var clientBuilderILogoutUserEndpoint = services
                 .AddRefitClient<ILogoutUserEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderILogoutUserEndpoint);
 
-            services
+            var clientBuilderIGetUserByNameEndpoint = services
                 .AddRefitClient<IGetUserByNameEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIGetUserByNameEndpoint);
 
-            services
+            var clientBuilderIUpdateUserEndpoint = services
                 .AddRefitClient<IUpdateUserEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIUpdateUserEndpoint);
 
-            services
+            var clientBuilderIDeleteUserEndpoint = services
                 .AddRefitClient<IDeleteUserEndpoint>()
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
+            builder?.Invoke(clientBuilderIDeleteUserEndpoint);
 
             return services;
         }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterface.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterface.g.cs
@@ -543,6 +543,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
 #pragma warning restore 8604
 
 
+#nullable enable
 namespace Refitter.Tests.AdditionalFiles.SingeInterface
 {
     using System;
@@ -553,9 +554,9 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
 
     public static partial class IServiceCollectionExtensions
     {
-        public static IServiceCollection ConfigureRefitClients(this IServiceCollection services)
+        public static IServiceCollection ConfigureRefitClients(this IServiceCollection services, Action<IHttpClientBuilder>? builder = default)
         {
-            services
+            var clientBuilderISwaggerPetstoreInterface = services
                 .AddRefitClient<ISwaggerPetstoreInterface>()
                 .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
                 .AddHttpMessageHandler<EmptyMessageHandler>()
@@ -567,6 +568,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
                             Backoff.DecorrelatedJitterBackoffV2(
                                 TimeSpan.FromSeconds(0.5),
                                 3)));
+            builder?.Invoke(clientBuilderISwaggerPetstoreInterface);
 
             return services;
         }


### PR DESCRIPTION
This allows for passing in a parameter of type Action\<IHttpClientBuilder\> when configuring the Refit client. This can be useful in scenarios where the consumer wants to modify the IHttpClientBuilder. 