### PR TITLE
Added InterfaceName to avoid counting in operation names

### DIFF
--- a/src/Refitter.Core/IdentifierUtils.cs
+++ b/src/Refitter.Core/IdentifierUtils.cs
@@ -6,20 +6,20 @@ internal static class IdentifierUtils
     /// Returns <c>{value}{counter}{suffix}</c> if <c>{value}{name}</c> exists in <paramref name="knownIdentifiers"/>
     /// else returns <c>{value}{name}</c>.
     /// </summary>
-    public static string Counted(ISet<string> knownIdentifiers, string name, string suffix = "")
+    public static string Counted(ISet<string> knownIdentifiers, string name, string suffix = "", string parent = null)
     {
-        if (!knownIdentifiers.Contains($"{name}{suffix}"))
+        if (!knownIdentifiers.Contains(string.IsNullOrEmpty(parent) ? $"{name}{suffix}" : $"{parent}.{name}{suffix}"))
         {
             return $"{name}{suffix}";
         }
 
         var counter = 2;
-        while (knownIdentifiers.Contains($"{name}{counter}{suffix}"))
+        while (knownIdentifiers.Contains(string.IsNullOrEmpty(parent) ? $"{name}{counter}{suffix}" : $"{parent}.{name}{counter}{suffix}"))
             counter++;
 
         return $"{name}{counter}{suffix}";
     }
-    
+
     /// <summary>
     /// Removes invalid character from an identifier string
     /// </summary>

--- a/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
@@ -51,12 +51,13 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
 
                 var verb = operations.Key.CapitalizeFirstCharacter();
 
+                string interfaceName = null;
                 if (!interfacesByGroup.TryGetValue(kv.Key, out var sb))
                 {
                     interfacesByGroup[kv.Key] = sb = new StringBuilder();
                     GenerateInterfaceXmlDocComments(operation, sb);
 
-                    var interfaceName = GetInterfaceName(kv.Key);
+                    interfaceName = GetInterfaceName(kv.Key);
                     interfaceNames.Add(interfaceName);
                     sb.AppendLine($$"""
                                     {{GenerateInterfaceDeclaration(interfaceName)}}
@@ -73,7 +74,7 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
                 GenerateForMultipartFormData(operationModel, sb);
                 GenerateAcceptHeaders(operations, operation, sb);
 
-                var opName = GetOperationName(op.PathItem.Key, operations.Key, operation);
+                var opName = GetOperationName(interfaceName, op.PathItem.Key, operations.Key, operation);
                 sb.AppendLine($"{Separator}{Separator}[{verb}(\"{op.PathItem.Key}\")]")
                     .AppendLine($"{Separator}{Separator}{returnType} {opName}({parametersString});")
                     .AppendLine();
@@ -120,12 +121,13 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
     }
 
     private string GetOperationName(
+        string interfaceName,
         string name,
         string verb,
         OpenApiOperation operation)
     {
-        var generatedName = IdentifierUtils.Counted(knownIdentifiers, GenerateOperationName(name, verb, operation, capitalizeFirstCharacter: true));
-        knownIdentifiers.Add(generatedName);
+        var generatedName = IdentifierUtils.Counted(knownIdentifiers, GenerateOperationName(name, verb, operation, capitalizeFirstCharacter: true), parent: interfaceName);
+        knownIdentifiers.Add($"{interfaceName}.{generatedName}");
         return generatedName;
     }
 


### PR DESCRIPTION
Added InterfaceName to avoid counting in operation names with parameter "multipleInterfaces". This solves a problem on apis with many tags with same operations.