### PR TITLE
Handle paths that contain colons

### DIFF
--- a/src/Refitter.Core/OperationNameGenerator.cs
+++ b/src/Refitter.Core/OperationNameGenerator.cs
@@ -35,7 +35,8 @@ internal class OperationNameGenerator : IOperationNameGenerator
             .CapitalizeFirstCharacter()
             .ConvertKebabCaseToPascalCase()
             .ConvertRouteToCamelCase()
-            .ConvertSpacesToPascalCase();
+            .ConvertSpacesToPascalCase()
+            .ConvertColonsToPascalCase();
 
     public bool CheckForDuplicateOperationIds(
         OpenApiDocument document)

--- a/src/Refitter.Core/StringCasingExtensions.cs
+++ b/src/Refitter.Core/StringCasingExtensions.cs
@@ -38,6 +38,9 @@ internal static class StringCasingExtensions
 
     public static string CapitalizeFirstCharacter(this string str)
     {
+        if (string.IsNullOrEmpty(str))
+            return str;
+
         return str.Substring(0, 1).ToUpperInvariant() +
                str.Substring(1, str.Length - 1);
     }

--- a/src/Refitter.Core/StringCasingExtensions.cs
+++ b/src/Refitter.Core/StringCasingExtensions.cs
@@ -52,4 +52,15 @@ internal static class StringCasingExtensions
 
         return string.Join(string.Empty, parts);
     }
+
+    public static string ConvertColonsToPascalCase(this string str)
+    {
+        var parts = str.Split(':');
+        for (var i = 0; i < parts.Length; i++)
+        {
+            parts[i] = parts[i].CapitalizeFirstCharacter();
+        }
+
+        return string.Join(string.Empty, parts);
+    }
 }

--- a/src/Refitter.Tests/Examples/ColonsInPathTests.cs
+++ b/src/Refitter.Tests/Examples/ColonsInPathTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class ColonsInPathTests
+{
+    private const string OpenApiSpec = @"
+swagger: '2.0'
+info:
+  title: Reference parameters
+  version: v0.0.1
+paths:
+  '/orders/{orderId}/:orderItems/{orderItemId}':
+    parameters:
+      - $ref: '#/parameters/OrderId'
+      - $ref: '#/parameters/OrderItemId'
+    delete:
+      summary: Delete an order item
+      description: >-
+        This method allows to remove an order item from an order, by specifying
+        their ids.
+      responses:
+        '204':
+          description: No Content.
+parameters:
+  OrderId:
+    name: orderId
+    in: path
+    description: Identifier of the order.
+    required: true
+    type: string
+    format: uuid
+  OrderItemId:
+    name: orderItemId
+    in: path
+    description: Identifier of the order item.
+    required: true
+    type: string
+    format: uuid
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        var generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Generates_Path_Without_Colons()
+    {
+        var generateCode = await GenerateCode();
+        using var scope = new AssertionScope();
+        generateCode.Should().NotContain("/:");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        var generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/src/Refitter.Tests/StringCasingExtensionTests.cs
+++ b/src/Refitter.Tests/StringCasingExtensionTests.cs
@@ -22,6 +22,11 @@ public class StringCasingExtensionTests
         => input.CapitalizeFirstCharacter().Should().Be(expected);
 
     [Theory]
+    [InlineData("", "")]
+    public void CaptilalizeFirstLetterHandlesEmptyStrings(string input, string expected)
+        => input.CapitalizeFirstCharacter().Should().Be(expected);
+
+    [Theory]
     [InlineData("foo/bar", "fooBar")]
     public void CanConvertRouteToCamelCase(string input, string expected)
         => input.ConvertRouteToCamelCase().Should().Be(expected);

--- a/src/Refitter.Tests/StringCasingExtensionTests.cs
+++ b/src/Refitter.Tests/StringCasingExtensionTests.cs
@@ -30,4 +30,9 @@ public class StringCasingExtensionTests
     [InlineData("foo bar", "FooBar")]
     public void CanConvertSpacesToPascalCase(string input, string expected)
         => input.ConvertSpacesToPascalCase().Should().Be(expected);
+
+    [Theory]
+    [InlineData("foo:bar", "FooBar")]
+    public void CanConvertColonsToPascalCase(string input, string expected)
+        => input.ConvertColonsToPascalCase().Should().Be(expected);
 }


### PR DESCRIPTION
This resolves #225 reported by @safakkesikci regarding OpenAPI specifications where paths include colons resulting in the generated code not being able to build

![](https://user-images.githubusercontent.com/7067252/284491914-34be809f-8bfe-47db-8ac8-e5d9c5b64e79.png)

### OpenApi spec:
[customer.json](https://github.com/christianhelle/refitter/files/13431924/customer.json)

### Refitter configuration file
```json
{
    "openApiPath": "./customer.json",
    "namespace": "Customer",
    "naming": {
        "useOpenApiTitle": false
    },
    "multipleInterfaces": "ByTag",
    "operationNameTemplate": "{operationName}Async",
    "outputFolder": "Generated",
    "outputFilename": "Customer.cs",
    "codeGeneratorSettings": {
        "requiredPropertiesMustBeDefined": true,
        "generateDataAnnotations": true,
        "anyType": "object",
        "dateType": "System.DateTimeOffset",
        "dateTimeType": "System.DateTimeOffset",
        "timeType": "System.TimeSpan",
        "timeSpanType": "System.TimeSpan",
        "arrayType": "System.Collections.Generic.ICollection",
        "dictionaryType": "System.Collections.Generic.IDictionary",
        "arrayInstanceType": "System.Collections.ObjectModel.Collection",
        "dictionaryInstanceType": "System.Collections.Generic.Dictionary",
        "arrayBaseType": "System.Collections.ObjectModel.Collection",
        "dictionaryBaseType": "System.Collections.Generic.Dictionary",
        "propertySetterAccessModifier": "",
        "generateImmutableArrayProperties": false,
        "generateImmutableDictionaryProperties": false,
        "handleReferences": false,
        "jsonSerializerSettingsTransformationMethod": null,
        "generateJsonMethods": false,
        "enforceFlagEnums": false,
        "inlineNamedDictionaries": false,
        "inlineNamedTuples": true,
        "inlineNamedArrays": false,
        "generateOptionalPropertiesAsNullable": false,
        "generateNullableReferenceTypes": false,
        "generateNativeRecords": false,
        "generateDefaultValues": true,
        "inlineNamedAny": false,
        "excludedTypeNames": []
    }
}
```

### Output
```csharp
[Headers("Accept: application/json")]
[Get("/customers/passportinfo")]
Task<ICollection<CustomerResponse>> PassportinfoAsync(
    [Query, AliasAs("PassportNumber")] string passportNumber, 
    [Query, AliasAs("FirstName")] string firstName, 
    [Query, AliasAs("LastName")] string lastName, 
    [Query, AliasAs("CountryId")] int? countryId);
```