### PR TITLE
Ensure Task<ApiResponse> is Returned for Void Methods in Generator

### DIFF
--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -79,7 +79,11 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
         return code.ToString();
     }
 
-    protected string GenerateOperationName(string path, string verb, OpenApiOperation operation, bool capitalizeFirstCharacter = false)
+    protected string GenerateOperationName(
+        string path,
+        string verb,
+        OpenApiOperation operation,
+        bool capitalizeFirstCharacter = false)
     {
         const string operationNamePlaceholder = "{operationName}";
 
@@ -94,7 +98,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
         if (settings.OperationNameTemplate?.Contains(operationNamePlaceholder) ?? false)
         {
             operationName = settings.OperationNameTemplate!
-                           .Replace(operationNamePlaceholder, operationName);
+                .Replace(operationNamePlaceholder, operationName);
         }
 
         return operationName;
@@ -135,8 +139,15 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
     protected string GetReturnType(string? returnTypeParameter)
     {
         return returnTypeParameter is null or "void"
-            ? "Task"
+            ? GetDefaultReturnType()
             : GetConfiguredReturnType(returnTypeParameter);
+    }
+
+    private string GetDefaultReturnType()
+    {
+        return settings.ReturnIApiResponse
+            ? "Task<IApiResponse>"
+            : "Task";
     }
 
     private string GetConfiguredReturnType(string returnTypeParameter)

--- a/src/Refitter.Tests/Examples/NoContentApiResponseTests.cs
+++ b/src/Refitter.Tests/Examples/NoContentApiResponseTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class NoContentApiResponseTests
+{
+    private const string OpenApiSpec = @"
+openapi: 3.0.0
+info:
+  title: Reference parameters
+  version: v0.0.1
+paths:
+  '/orders/{orderId}/order-items/{orderItemId}':
+    parameters:
+      - $ref: '#/parameters/OrderId'
+      - $ref: '#/parameters/OrderItemId'
+    delete:
+      summary: Delete an order item
+      description: >-
+        This method allows to remove an order item from an order, by specifying
+        their ids.
+      responses:
+        '204':
+          description: No Content.
+        default:
+          description: Default response
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Error:
+    type: object
+    properties:
+      message:
+          type: string
+parameters:
+  OrderId:
+    name: orderId
+    in: path
+    description: Identifier of the order.
+    required: true
+    type: string
+    format: uuid
+  OrderItemId:
+    name: orderItemId
+    in: path
+    description: Identifier of the order item.
+    required: true
+    type: string
+    format: uuid
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        var generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Generates_IApiResponse_For_NoContent()
+    {
+        var generateCode = await GenerateCode();
+        using var scope = new AssertionScope();
+        generateCode.Should().Contain("Task<IApiResponse>");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        var generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+        settings.ReturnIApiResponse = true;
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}


### PR DESCRIPTION
Updated logic to wrap void return types in `Task<ApiResponse>` when `settings.ReturnIApiResponse` is true.