### PR TITLE
Add donation banner for Github Sponsors and buymeacoffee.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dotnet tool install --global Refitter
 $ refitter --help
 ```
 
-```
+```pwsh
 USAGE:
     refitter [URL or input file] [OPTIONS]
 
@@ -52,11 +52,11 @@ EXAMPLES:
     refitter ./openapi.json --multiple-interfaces ByEndpoint
     refitter ./openapi.json --tag Pet --tag Store --tag User
     refitter ./openapi.json --match-path '^/pet/.*'
+    refitter ./openapi.json --trim-unused-schema
+    refitter ./openapi.json --trim-unused-schema  --keep-schema '^Model$' --keep-schema '^Person.+'
     refitter ./openapi.json --no-deprecated-operations
     refitter ./openapi.json --operation-name-template '{operationName}Async'
     refitter ./openapi.json --optional-nullable-parameters
-    refitter ./openapi.json --trim-unused-schema
-    refitter ./openapi.json --trim-unused-schema --keep-schema '^Model$' --keep-schema '^Person.+'
 
 ARGUMENTS:
     [URL or input file]    URL or file path to OpenAPI Specification file
@@ -64,6 +64,7 @@ ARGUMENTS:
 OPTIONS:
                                           DEFAULT                                                                                                                                                    
     -h, --help                                             Prints help information                                                                                                                   
+    -v, --version                                          Prints version information                                                                                                                
     -s, --settings-file                                    Path to .refitter settings file. Specifying this will ignore all other settings (except for --output)                                     
     -n, --namespace                       GeneratedCode    Default namespace to use for generated types                                                                                              
     -o, --output                          Output.cs        Path to Output file                                                                                                                       
@@ -83,9 +84,10 @@ OPTIONS:
         --skip-validation                                  Skip validation of the OpenAPI specification                                                                                              
         --no-deprecated-operations                         Don't generate deprecated operations                                                                                                      
         --operation-name-template                          Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface
-        --optional-nullable-parameters                     Generate nullable parameters as optional parameters
-        --trim-unused-schema                               Removes unreferenced components schema to keep the generated output to a minimum
-        --keep-schema                                      Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times                                                                                       
+        --optional-nullable-parameters                     Generate nullable parameters as optional parameters                                                                                       
+        --trim-unused-schema                               Removes unreferenced components schema to keep the generated output to a minimum                                                          
+        --keep-schema                                      Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times              
+        --no-banner                                        Don't show donation banner                                                                                                                           
 ```
 
 To generate code from an OpenAPI specifications file, run the following:

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -83,6 +83,8 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             await Analytics.LogFeatureUsage(settings);
 
             AnsiConsole.MarkupLine($"[green]Duration: {stopwatch.Elapsed}{Crlf}[/]");
+
+            DonationBanner();
             return 0;
         }
         catch (Exception exception)
@@ -97,6 +99,19 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             await Analytics.LogError(exception, settings);
             return exception.HResult;
         }
+    }
+
+    private static void DonationBanner()
+    {
+        AnsiConsole.MarkupLine("[dim]###################################################################[/]");
+        AnsiConsole.MarkupLine("[dim]#  Do you find this tool useful and feel a bit generous?          #[/]");
+        AnsiConsole.MarkupLine("[dim]#  https://github.com/sponsors/christianhelle                     #[/]");
+        AnsiConsole.MarkupLine("[dim]#  https://www.buymeacoffee.com/christianhelle                    #[/]");
+        AnsiConsole.MarkupLine("[dim]#                                                                 #[/]");
+        AnsiConsole.MarkupLine("[dim]#  Does this tool not work or does it lack something you need?    #[/]");
+        AnsiConsole.MarkupLine("[dim]#  https://github.com/christianhelle/refitter/issues              #[/]");
+        AnsiConsole.MarkupLine("[dim]###################################################################[/]");
+        AnsiConsole.WriteLine();
     }
 
     private static string GetOutputPath(Settings settings, RefitGeneratorSettings refitGeneratorSettings)

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -84,7 +84,9 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
 
             AnsiConsole.MarkupLine($"[green]Duration: {stopwatch.Elapsed}{Crlf}[/]");
 
-            DonationBanner();
+            if (!settings.NoBanner)
+                DonationBanner();
+
             return 0;
         }
         catch (Exception exception)

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -15,7 +15,7 @@ dotnet tool install --global Refitter
 $ refitter --help
 ```
 
-```
+```pwsh
 USAGE:
     refitter [URL or input file] [OPTIONS]
 
@@ -35,11 +35,11 @@ EXAMPLES:
     refitter ./openapi.json --multiple-interfaces ByEndpoint
     refitter ./openapi.json --tag Pet --tag Store --tag User
     refitter ./openapi.json --match-path '^/pet/.*'
+    refitter ./openapi.json --trim-unused-schema
+    refitter ./openapi.json --trim-unused-schema  --keep-schema '^Model$' --keep-schema '^Person.+'
     refitter ./openapi.json --no-deprecated-operations
     refitter ./openapi.json --operation-name-template '{operationName}Async'
     refitter ./openapi.json --optional-nullable-parameters
-    refitter ./openapi.json --trim-unused-schema
-    refitter ./openapi.json --trim-unused-schema --keep-schema '^Model$' --keep-schema '^Person.+'
 
 ARGUMENTS:
     [URL or input file]    URL or file path to OpenAPI Specification file
@@ -47,6 +47,7 @@ ARGUMENTS:
 OPTIONS:
                                           DEFAULT                                                                                                                                                    
     -h, --help                                             Prints help information                                                                                                                   
+    -v, --version                                          Prints version information                                                                                                                
     -s, --settings-file                                    Path to .refitter settings file. Specifying this will ignore all other settings (except for --output)                                     
     -n, --namespace                       GeneratedCode    Default namespace to use for generated types                                                                                              
     -o, --output                          Output.cs        Path to Output file                                                                                                                       
@@ -66,9 +67,10 @@ OPTIONS:
         --skip-validation                                  Skip validation of the OpenAPI specification                                                                                              
         --no-deprecated-operations                         Don't generate deprecated operations                                                                                                      
         --operation-name-template                          Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface
-        --optional-nullable-parameters                     Generate nullable parameters as optional parameters
-        --trim-unused-schema                               Removes unreferenced components schema to keep the generated output to a minimum
-        --keep-schema                                      Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times                                                                                       
+        --optional-nullable-parameters                     Generate nullable parameters as optional parameters                                                                                       
+        --trim-unused-schema                               Removes unreferenced components schema to keep the generated output to a minimum                                                          
+        --keep-schema                                      Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times              
+        --no-banner                                        Don't show donation banner                                                                                                                           
 ```
 
 ### .Refitter File format

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -121,4 +121,9 @@ public sealed class Settings : CommandSettings
     [CommandOption("--keep-schema")]
     [DefaultValue(new string[0])]
     public string[]? KeepSchemaPatterns { get; set; }
+
+    [Description("Don't show donation banner")]
+    [CommandOption("--no-banner")]
+    [DefaultValue(false)]
+    public bool NoBanner { get; set; }
 }


### PR DESCRIPTION
This introduces a tin can donation banner at the end after successfully generating the code

The banner looks like this:

```
###################################################################
#  Do you find this tool useful and feel a bit generous?          #
#  https://github.com/sponsors/christianhelle                     #
#  https://www.buymeacoffee.com/christianhelle                    #
#                                                                 #
#  Does this tool not work or does it lack something you need?    #
#  https://github.com/christianhelle/refitter/issues              #
###################################################################
```

and can be suppressed by passing the `--no-banner` CLI tool argument