### PR TITLE
Disable app data backup in AndroidManifest.xml for example MAUI app

### DIFF
--- a/test/MauiExample/Platforms/Android/AndroidManifest.xml
+++ b/test/MauiExample/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true" android:usesCleartextTraffic="false"></application>
+	<application android:allowBackup="false" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true" android:usesCleartextTraffic="false"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
The android:allowBackup attribute in the AndroidManifest.xml file for the MauiExample app has been updated. It was previously set to true, which allowed the Android system to backup app data. Now, it's been changed to false, effectively disabling the data backup feature for this application.