### PR TITLE
Show error reporting suggestion banner upon error

### DIFF
--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -97,6 +97,12 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                 AnsiConsole.MarkupLine($"[red]Exception:{Crlf}{exception.GetType()}[/]");
                 AnsiConsole.MarkupLine($"[yellow]Stack Trace:{Crlf}{exception.StackTrace}[/]");
             }
+            
+            AnsiConsole.MarkupLine("[yellow]#############################################################################[/]");
+            AnsiConsole.MarkupLine("[yellow]#  Consider reporting the problem if you are unable to resolve it yourself  #[/]");
+            AnsiConsole.MarkupLine("[yellow]#  https://github.com/christianhelle/refitter/issues                        #[/]");
+            AnsiConsole.MarkupLine("[yellow]#############################################################################[/]");
+            AnsiConsole.WriteLine();
 
             await Analytics.LogError(exception, settings);
             return exception.HResult;


### PR DESCRIPTION
Added lines to the exception handling code that create a console output encouraging users to report unresolved issues. The output includes a link to the project issues page on GitHub for ease of access and visibility.