### PR TITLE
Add support for OAS files with external references

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -44,7 +44,8 @@ jobs:
           "petstore-simple",
           "petstore-with-external-docs",
           "hubspot-events",
-          "hubspot-webhooks"
+          "hubspot-webhooks",
+          "bot.paths"
         ]
     
     uses: ./.github/workflows/template.yml

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -34,7 +34,6 @@ jobs:
           "--internal",
           "--use-api-response",
           "--use-iso-date-format",
-          "--multiple-interfaces ByEndpoint",
           "--match-path ^/pet/.*",
           "--tag pet",
           "--no-deprecated-operations"

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -137,9 +137,9 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         return outputPath;
     }
 
-    private static async Task ValidateOpenApiSpec(Settings settings)
+    private static async Task ValidateOpenApiSpec(string openApiPath)
     {
-        var validationResult = await OpenApiValidator.Validate(settings.OpenApiPath!);
+        var validationResult = await OpenApiValidator.Validate(openApiPath);
         if (!validationResult.IsValid)
         {
             AnsiConsole.MarkupLine($"[red]{Crlf}OpenAPI validation failed:{Crlf}[/]");

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 using Refitter.Core;
+using Refitter.Merger;
+using Refitter.OAS;
 using Refitter.Validation;
 
 using Spectre.Console;
@@ -58,9 +60,6 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                     ? "[green]Support key: Unavailable when logging is disabled[/]"
                     : $"[green]Support key: {SupportInformation.GetSupportKey()}[/]");
 
-            if (!settings.SkipValidation)
-                await ValidateOpenApiSpec(settings);
-
             if (!string.IsNullOrWhiteSpace(settings.SettingsFilePath))
             {
                 var json = await File.ReadAllTextAsync(settings.SettingsFilePath);
@@ -68,7 +67,10 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                 refitGeneratorSettings.OpenApiPath = settings.OpenApiPath!;
             }
 
-            var generator = await RefitGenerator.CreateAsync(refitGeneratorSettings);
+            var generator = await CreateGenerator(refitGeneratorSettings);
+            if (!settings.SkipValidation)
+                await ValidateOpenApiSpec(refitGeneratorSettings.OpenApiPath);
+            
             var code = generator.Generate().ReplaceLineEndings();
             AnsiConsole.MarkupLine($"[green]Length: {code.Length} bytes[/]");
 
@@ -107,6 +109,27 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             await Analytics.LogError(exception, settings);
             return exception.HResult;
         }
+    }
+
+    private static async Task<RefitGenerator> CreateGenerator(RefitGeneratorSettings refitGeneratorSettings)
+    {
+        var result = await OpenApiReader.ParseOpenApi(refitGeneratorSettings.OpenApiPath);
+        var document = result.OpenApiDocument;
+
+        if (document.Paths.Any(pair => pair.Value.Parameters.Any(parameter=> parameter.Reference?.IsExternal == true)))
+        {
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("[yellow]OpenAPI specifications contains external references[/]");
+            AnsiConsole.MarkupLine("[yellow]Attempting to merge of all external references...[/]");
+        }
+        
+        var contents = await OpenApiMerger.Merge(refitGeneratorSettings.OpenApiPath!);
+        var mergedPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        mergedPath = Path.ChangeExtension(mergedPath, Path.GetExtension(refitGeneratorSettings.OpenApiPath));
+        await File.WriteAllTextAsync(mergedPath, contents);
+        
+        refitGeneratorSettings.OpenApiPath = mergedPath;
+        return await RefitGenerator.CreateAsync(refitGeneratorSettings);
     }
 
     private static void DonationBanner()

--- a/src/Refitter/Merger/OpenApiMerger.cs
+++ b/src/Refitter/Merger/OpenApiMerger.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.OpenApi;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Services;
+
+using Refitter.Merger.Visitors;
+using Refitter.OAS;
+
+using Spectre.Console;
+
+namespace Refitter.Merger
+{
+    public static class OpenApiMerger
+    {
+        public static async Task<string> Merge(string input)
+        {
+            var result = await OpenApiReader.ParseOpenApi(input);
+            var document = result.OpenApiDocument;
+            var cache = new Dictionary<string, OpenApiDocument>();
+
+            int missingCount;
+            do
+            {
+                var referenceVisitor = new OpenApiReferenceResolverVisitor(input, cache);
+                var referenceWalker = new OpenApiWalker(referenceVisitor);
+                referenceWalker.Walk(document);
+                referenceVisitor.Cache.UpdateDocument(document);
+            
+                var missingVisitor = new OpenApiMissingReferenceVisitor(document, cache);
+                var missingWalker = new OpenApiWalker(missingVisitor);
+                missingWalker.Walk(document);
+                missingCount = missingVisitor.Cache.Count;
+                missingVisitor.Cache.UpdateDocument(document);
+            }
+            while (missingCount > 0);
+            
+            document.Components.Schemas = document.Components.Schemas
+                .OrderBy(kvp => kvp.Key)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+            return input.EndsWith("yaml", StringComparison.OrdinalIgnoreCase) ||
+                   input.EndsWith("yml", StringComparison.OrdinalIgnoreCase)
+                ? document.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0)
+                : document.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+        }
+    }
+}

--- a/src/Refitter/Merger/OpenApiMissingReferenceVisitor.cs
+++ b/src/Refitter/Merger/OpenApiMissingReferenceVisitor.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Services;
+
+namespace Refitter.Merger.Visitors
+{
+    public class OpenApiMissingReferenceVisitor(
+        OpenApiDocument document,
+        Dictionary<string, OpenApiDocument> documentCache)
+        : OpenApiVisitorBase
+    {
+        internal ReferenceCache Cache { get; } = new();
+
+        public override void Visit(IOpenApiReferenceable referenceable)
+        {
+            if (referenceable is not OpenApiSchema ||
+                document.Components.Schemas.ContainsKey(referenceable.Reference.Id))
+            {
+                return;
+            }
+
+            foreach (var kvp in documentCache)
+            {
+                try
+                {
+                    if (kvp.Value.ResolveReference(referenceable.Reference) is OpenApiSchema schema)
+                    {
+                        Cache.Add(schema);
+                    }
+                }
+                catch
+                {
+                    // Ignored.
+                    // When the reference cannot be found, an error is thrown.
+                    // Do not log, but just continue searching...
+                }
+            }
+        }
+    }
+}

--- a/src/Refitter/Merger/OpenApiReferenceResolverVisitor.cs
+++ b/src/Refitter/Merger/OpenApiReferenceResolverVisitor.cs
@@ -1,0 +1,131 @@
+﻿using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi.Services;
+
+using Spectre.Console;
+
+namespace Refitter.Merger.Visitors
+{
+    public class OpenApiReferenceResolverVisitor : OpenApiVisitorBase
+    {
+        private readonly Dictionary<string, OpenApiDocument> documentCache;
+        private static readonly Lazy<HttpClient> HttpClient = new();
+        private readonly List<FileInfo> files;
+        
+        internal ReferenceCache Cache { get; } = new();
+
+        public OpenApiReferenceResolverVisitor(
+            string input,
+            Dictionary<string, OpenApiDocument> documentCache)
+        {
+            this.documentCache = documentCache;
+
+            files = Directory
+                .GetFiles(Path.GetDirectoryName(input)!, $"*{Path.GetExtension(input)}", SearchOption.AllDirectories)
+                .Select(f => new FileInfo(f))
+                .Where(f => f.Exists)
+                .ToList();
+        }
+
+        public override void Visit(IOpenApiReferenceable referenceable)
+        {
+            if (!(referenceable.Reference?.IsExternal ?? false) ||
+                !TryLoadDocument(referenceable, out var externalDocument) ||
+                externalDocument == null)
+            {
+                return;
+            }
+
+            var localReference = new OpenApiReference
+            {
+                Id = referenceable.Reference!.Id.Split('/').Last(),
+                Type = referenceable.Reference.Type ?? ReferenceType.Schema
+            };
+
+            if (externalDocument.ResolveReference(localReference) is { } reference)
+            {
+                Cache.Add(reference);
+            }
+
+            referenceable.Reference = localReference;
+        }
+
+        private bool TryLoadDocument(IOpenApiReferenceable referenceable, out OpenApiDocument? document)
+        {
+            document = null;
+            var reference = referenceable.Reference?.IsExternal ?? false
+                ? referenceable.Reference.ExternalResource
+                : null;
+            if (reference == null)
+            {
+                return false;
+            }
+
+            if (documentCache.TryGetValue(reference, out OpenApiDocument? value))
+            {
+                document = value;
+                return true;
+            }
+
+            var externalDocument = GetDocument(reference);
+            if (externalDocument == null)
+            {
+                return false;
+            }
+
+            documentCache[reference] = externalDocument;
+            document = documentCache[reference];
+            return true;
+        }
+
+        private OpenApiDocument? GetDocument(string reference)
+        {
+            if (string.IsNullOrWhiteSpace(reference))
+            {
+                return null;
+            }
+
+            if (reference.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            {
+                return GetDocumentFromStream(
+                    reference,
+                    HttpClient.Value.GetStreamAsync(new Uri(reference)).GetAwaiter().GetResult());
+            }
+
+            var file = files.FirstOrDefault(
+                f => f.FullName.EndsWith(
+                    reference
+                        .Replace('\\', Path.DirectorySeparatorChar)
+                        .Replace('/', Path.DirectorySeparatorChar)));
+
+            if (file == null)
+            {
+                return null;
+            }
+
+            using var fs = file.OpenRead();
+            return GetDocumentFromStream(reference, fs);
+        }
+
+        private static OpenApiDocument? GetDocumentFromStream(string reference, Stream stream)
+        {
+            try
+            {
+                var document = new OpenApiStreamReader().Read(stream, out var results);
+                foreach (var error in results?.Errors ?? Enumerable.Empty<OpenApiError>())
+                {
+                    AnsiConsole.MarkupLine($"[yellow]{reference} - {error.Message}[/]");
+                }
+
+                return document;
+            }
+            catch (Exception e)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to load OpenApi document for: {reference}[/]");
+                AnsiConsole.MarkupLine(e.Message);
+                return null;
+            }
+        }
+    }
+}

--- a/src/Refitter/Merger/ReferenceCache.cs
+++ b/src/Refitter/Merger/ReferenceCache.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+
+namespace Refitter.Merger;
+
+internal class ReferenceCache
+{
+    private readonly Dictionary<ReferenceType, Dictionary<string, IOpenApiReferenceable>> data = new();
+
+    public int Count => data.Sum(x => x.Value.Count);
+
+    public void Add(IOpenApiReferenceable referenceable)
+    {
+        var type = referenceable.Reference.Type ?? ReferenceType.Schema;
+        if (!data.ContainsKey(type))
+        {
+            data[type] = new Dictionary<string, IOpenApiReferenceable>();
+        }
+
+        if (data[type].TryGetValue(referenceable.Reference.Id, out _))
+        {
+            return;
+        }
+
+        data[type][referenceable.Reference.Id] = referenceable;
+    }
+
+    public void UpdateDocument(OpenApiDocument document)
+    {
+        foreach (var kvp in data)
+        {
+            switch (kvp.Key)
+            {
+                case ReferenceType.Schema:
+                    Update(document.Components.Schemas, kvp.Value);
+                    break;
+                case ReferenceType.Response:
+                    Update(document.Components.Responses, kvp.Value);
+                    break;
+                case ReferenceType.Parameter:
+                    Update(document.Components.Parameters, kvp.Value);
+                    break;
+                case ReferenceType.Example:
+                    Update(document.Components.Examples, kvp.Value);
+                    break;
+                case ReferenceType.RequestBody:
+                    Update(document.Components.RequestBodies, kvp.Value);
+                    break;
+                case ReferenceType.Header:
+                    Update(document.Components.Headers, kvp.Value);
+                    break;
+                case ReferenceType.SecurityScheme:
+                    Update(document.Components.SecuritySchemes, kvp.Value);
+                    break;
+                case ReferenceType.Link:
+                    Update(document.Components.Links, kvp.Value);
+                    break;
+                case ReferenceType.Callback:
+                    Update(document.Components.Callbacks, kvp.Value);
+                    break;
+                case ReferenceType.Tag:
+                    Update(document.Tags, kvp.Value);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(kvp.Key));
+            }
+        }
+    }
+
+    private static void Update<T>(IDictionary<string, T> collection, Dictionary<string, IOpenApiReferenceable> data)
+        where T : IOpenApiReferenceable
+    {
+        foreach (var kvp in data)
+        {
+            collection[kvp.Key] = (T)kvp.Value;
+        }
+    }
+
+    private static void Update<T>(ICollection<T> collection, Dictionary<string, IOpenApiReferenceable> data)
+        where T : IOpenApiReferenceable
+    {
+        foreach (var kvp in data)
+        {
+            collection.Add((T)kvp.Value);
+        }
+    }
+}

--- a/src/Refitter/OAS/OpenApiReader.cs
+++ b/src/Refitter/OAS/OpenApiReader.cs
@@ -1,0 +1,64 @@
+﻿using System.Net;
+using System.Security;
+
+using Microsoft.OpenApi.Readers;
+
+namespace Refitter.OAS;
+
+public static class OpenApiReader
+{
+    public static async Task<ReadResult> ParseOpenApi(string openApiFile)
+    {
+        var directoryName = new FileInfo(openApiFile).DirectoryName;
+        var openApiReaderSettings = new OpenApiReaderSettings
+        {
+            BaseUrl = openApiFile.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? new Uri(openApiFile)
+                : new Uri($"file://{directoryName}{Path.DirectorySeparatorChar}")
+        };
+
+        await using var stream = await GetStream(openApiFile, CancellationToken.None);
+        var reader = new OpenApiStreamReader(openApiReaderSettings);
+        return await reader.ReadAsync(stream, CancellationToken.None);
+    }
+
+    private static async Task<Stream> GetStream(
+        string input,
+        CancellationToken cancellationToken)
+    {
+        if (input.StartsWith("http"))
+        {
+            try
+            {
+                var httpClientHandler = new HttpClientHandler()
+                {
+                    SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+                };
+                using var httpClient = new HttpClient(httpClientHandler);
+                httpClient.DefaultRequestVersion = HttpVersion.Version20;
+                return await httpClient.GetStreamAsync(input, cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new InvalidOperationException($"Could not download the file at {input}", ex);
+            }
+        }
+
+        try
+        {
+            var fileInput = new FileInfo(input);
+            return fileInput.OpenRead();
+        }
+        catch (Exception ex) when (ex is FileNotFoundException ||
+                                   ex is PathTooLongException ||
+                                   ex is DirectoryNotFoundException ||
+                                   ex is IOException ||
+                                   ex is UnauthorizedAccessException ||
+                                   ex is SecurityException ||
+                                   ex is NotSupportedException)
+        {
+            throw new InvalidOperationException($"Could not open the file at {input}", ex);
+        }
+    }
+}

--- a/src/Refitter/Refitter.csproj
+++ b/src/Refitter/Refitter.csproj
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="Exceptionless" Version="6.0.3" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.5.0" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.11" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.48.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />

--- a/src/Refitter/Validation/OpenApiValidator.cs
+++ b/src/Refitter/Validation/OpenApiValidator.cs
@@ -1,8 +1,6 @@
-﻿using System.Net;
-using System.Security;
+﻿using Microsoft.OpenApi.Services;
 
-using Microsoft.OpenApi.Readers;
-using Microsoft.OpenApi.Services;
+using Refitter.OAS;
 
 namespace Refitter.Validation;
 
@@ -10,7 +8,7 @@ public static class OpenApiValidator
 {
     public static async Task<OpenApiValidationResult> Validate(string openApiPath)
     {
-        var result = await ParseOpenApi(openApiPath);
+        var result = await OpenApiReader.ParseOpenApi(openApiPath);
 
         var statsVisitor = new OpenApiStats();
         var walker = new OpenApiWalker(statsVisitor);
@@ -19,60 +17,5 @@ public static class OpenApiValidator
         return new(
             result.OpenApiDiagnostic,
             statsVisitor);
-    }
-
-    private static async Task<Stream> GetStream(
-        string input,
-        CancellationToken cancellationToken)
-    {
-        if (input.StartsWith("http"))
-        {
-            try
-            {
-                var httpClientHandler = new HttpClientHandler()
-                {
-                    SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
-                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-                };
-                using var httpClient = new HttpClient(httpClientHandler);
-                httpClient.DefaultRequestVersion = HttpVersion.Version20;
-                return await httpClient.GetStreamAsync(input, cancellationToken);
-            }
-            catch (HttpRequestException ex)
-            {
-                throw new InvalidOperationException($"Could not download the file at {input}", ex);
-            }
-        }
-
-        try
-        {
-            var fileInput = new FileInfo(input);
-            return fileInput.OpenRead();
-        }
-        catch (Exception ex) when (ex is FileNotFoundException ||
-                                   ex is PathTooLongException ||
-                                   ex is DirectoryNotFoundException ||
-                                   ex is IOException ||
-                                   ex is UnauthorizedAccessException ||
-                                   ex is SecurityException ||
-                                   ex is NotSupportedException)
-        {
-            throw new InvalidOperationException($"Could not open the file at {input}", ex);
-        }
-    }
-
-    private static async Task<ReadResult> ParseOpenApi(string openApiFile)
-    {
-        var directoryName = new FileInfo(openApiFile).DirectoryName;
-        var openApiReaderSettings = new OpenApiReaderSettings
-        {
-            BaseUrl = openApiFile.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-                ? new Uri(openApiFile)
-                : new Uri($"file://{directoryName}{Path.DirectorySeparatorChar}")
-        };
-
-        await using var stream = await GetStream(openApiFile, CancellationToken.None);
-        var reader = new OpenApiStreamReader(openApiReaderSettings);
-        return await reader.ReadAsync(stream, CancellationToken.None);
     }
 }

--- a/test/OpenAPI/v3.0/bot.components.yaml
+++ b/test/OpenAPI/v3.0/bot.components.yaml
@@ -1,0 +1,818 @@
+openapi: 3.0.3
+info:
+  title: QQ 机器人 OpenAPI 对象定义
+  version: v1.0.0
+paths:
+  # 这里只是放置个 path 配置避免格式检查报错
+# 对象定义
+components:
+  # path 参数统一定义在这里
+  parameters:
+    PathGuildID:
+      name: guild_id
+      description: 频道ID
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/BaseGuildID'
+    PathChannelID:
+      name: channel_id
+      description: 子频道ID
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/BaseChannelID'
+    PathUserID:
+      name: user_id
+      description: 成员ID
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/BaseUserID'
+    PathRoleID:
+      name: role_id
+      description: 身份组ID
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/BaseRoleID'
+    PathMessageID:
+      name: message_id
+      description: 消息ID
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/BaseMessageID'
+    PathScheduleID:
+      name: schedule_id
+      description: 日程ID
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/BaseScheduleID'
+  schemas:
+    BaseGuildID:
+      type: string
+      format: int64
+      description: 频道ID
+    BaseChannelID:
+      type: string
+      format: int64
+      description: 子频道ID
+    BaseChannelCategoryID:
+      type: string
+      format: int64
+      description: 子频道分组ID，仅子频道支持分组
+    BaseUserID:
+      type: string
+      format: int64
+      description: 用户ID
+    BaseRoleID:
+      type: string
+      format: int64
+      description: 身份组ID
+    BaseMessageID:
+      type: string
+      description: 消息ID
+    BaseSequenceInChannel:
+      type: string
+      description: |
+        子频道消息 seq，用于消息间的排序，seq 在同一子频道中按从先到后的顺序递增，不同的子频道之间消息无法排序
+    BaseScheduleID:
+      type: string
+      format: int64
+      description: 日程ID
+    Guild:
+      description: |
+        频道对象,频道对象中所涉及的 ID 类数据，都仅在机器人场景流通，与真实的 ID 无关。
+        请不要理解为真实的 ID
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/BaseGuildID'
+        name:
+          type: string
+          description: 频道名称
+        icon:
+          type: string
+          description: 频道头像地址
+        owner_id:
+          $ref: '#/components/schemas/BaseUserID'
+        owner:
+          type: boolean
+          description: 当前人是否是创建人
+        member_count:
+          type: integer
+          description: 成员数
+          format: int32
+        max_members:
+          type: integer
+          description: 最大成员数
+          format: int32
+        description:
+          type: string
+          description: 描述
+        joined_at:
+          type: string
+          description: 加入时间
+    User:
+      description: |
+        用户对象中所涉及的 ID 类数据，都仅在机器人场景流通，与真实的 ID 无关。
+        请不要理解为真实的 ID
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/BaseUserID'
+        username:
+          type: string
+          description: 用户名
+        avatar:
+          type: string
+          description: 用户头像地址
+        bot:
+          type: boolean
+          description: 是否是机器人
+        union_openid:
+          type: string
+          description: |
+            特殊关联应用的 openid，需要特殊申请并配置后才会返回。如需申请，请联系平台运营人员
+        union_user_account:
+          type: string
+          description: |
+            机器人关联的互联应用的用户信息，与union_openid关联的应用是同一个。
+            如需申请，请联系平台运营人员
+    Channel:
+      description: 子频道对象,子频道对象中所涉及的 ID 类数据，都仅在机器人场景流通，与真实的 ID 无关。请不要理解为真实的 ID
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/BaseChannelID'
+        guild_id:
+          $ref: '#/components/schemas/BaseGuildID'
+        name:
+          type: string
+          description: 子频道名称
+        type:
+          $ref: '#/components/schemas/ChannelType'
+        sub_type:
+          $ref: '#/components/schemas/ChannelSubType'
+        position:
+          type: integer
+          description: 排序值
+        parent_id:
+          type: string
+          description: 所属分组 id，仅对子频道有效，对 子频道分组（ChannelType=4） 无效
+        owner_id:
+          $ref: '#/components/schemas/BaseUserID'
+        private_type:
+          $ref: '#/components/schemas/PrivateType'
+        speak_permission:
+          $ref: '#/components/schemas/SpeakPermission'
+        application_id:
+          $ref: '#/components/schemas/Application'
+    Member:
+      description: 成员对象
+      type: object
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+        nick:
+          type: string
+          description: 用户的昵称
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/BaseRoleID'
+          description: 用户在频道内的身份组ID
+        joined_at:
+          type: string
+          format: date-time
+          description: '用户加入频道的时间, ISO8601格式'
+    Role:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/BaseRoleID'
+        name:
+          type: string
+          description: 名称
+        color:
+          type: integer
+          description: ARGB的HEX十六进制颜色值转换后的十进制数值
+        hoist:
+          type: integer
+          description: '是否在成员列表中单独展示: 0-否, 1-是'
+        number:
+          type: integer
+          description: 人数
+        member_limit:
+          type: integer
+          description: 成员上限
+          format: uint32
+      description: 频道身份组对象
+    ChannelPermissions:
+      description: |
+        子频道权限对象, 权限是QQ频道管理频道成员的一种方式，管理员可以对不同的人、不同的子频道设置特定的权限。
+          * 用户的权限包括个人权限和身份组权限两部分，最终生效是取两种权限的并集。
+          * 权限使用位图表示，传递时序列化为十进制数值字符串。如权限值为0x6FFF，会被序列化为十进制'28671'
+      type: object
+      properties:
+        channel_id:
+          $ref: '#/components/schemas/BaseChannelID'
+        user_id:
+          $ref: '#/components/schemas/BaseUserID'
+        role_id:
+          $ref: '#/components/schemas/BaseRoleID'
+        permissions:
+          $ref: '#/components/schemas/Permissions'
+    Message:
+      type: object
+      description: 消息对象
+      properties:
+        id:
+          $ref: '#/components/schemas/BaseMessageID'
+        channel_id:
+          $ref: '#/components/schemas/BaseChannelID'
+        guild_id:
+          $ref: '#/components/schemas/BaseGuildID'
+        content:
+          type: string
+          description: 消息内容
+        timestamp:
+          type: string
+          format: date-time
+          description: '消息创建时间,ISO8601 timestamp'
+        edited_timestamp:
+          type: string
+          format: date-time
+          description: '消息编辑时间,ISO8601 timestamp'
+        mention_everyone:
+          type: boolean
+          description: 是否是@全员消息
+        author:
+          $ref: '#/components/schemas/User'
+        attachments:
+          type: array
+          description: 附件
+          items:
+            $ref: '#/components/schemas/MessageAttachment'
+        embeds:
+          type: array
+          description: embed
+          items:
+            $ref: '#/components/schemas/MessageEmbed'
+        mentions:
+          type: array
+          description: 消息中@的人
+          items:
+            $ref: '#/components/schemas/User'
+        member:
+          $ref: '#/components/schemas/Member'
+        ark:
+          $ref: '#/components/schemas/MessageArk'
+        seq:
+          type: integer
+          description: |
+            用于消息间的排序，seq 在同一子频道中按从先到后的顺序递增，不同的子频道之前消息无法排序
+        seq_in_channel:
+          $ref: "#/components/schemas/BaseSequenceInChannel"
+        message_reference:
+          $ref: "#/components/schemas/MessageReference"
+    MessageReference:
+      type: object
+      description: 引用消息对象
+      properties:
+        message_id:
+          $ref: '#/components/schemas/BaseMessageID'
+        ignore_get_message_error:
+          type: boolean
+          description: 是否忽略获取引用消息详情错误，默认否，仅在发送引用消息的时候使用
+    MessageAttachment:
+      type: object
+      description: 消息附件
+      properties:
+        url:
+          type: string
+          description: 下载地址
+    MessageEmbed:
+      type: object
+      description: embed消息
+      properties:
+        title:
+          type: string
+          description: 标题
+        prompt:
+          type: string
+          description: 消息弹窗内容
+        thumbnail:
+          $ref: '#/components/schemas/MessageEmbedThumbnail'
+        fields:
+          type: array
+          description: embed 字段数据
+          items:
+            $ref: '#/components/schemas/MessageEmbedField'
+    MessageEmbedThumbnail:
+      type: object
+      description: 消息封面
+      properties:
+        url:
+          type: string
+          description: 图片地址
+    MessageEmbedField:
+      type: object
+      description: embed字段
+      properties:
+        name:
+          type: string
+          description: 字段
+    MessageArk:
+      type: object
+      description: ark消息
+      properties:
+        template_id:
+          type: integer
+          description: ark模板id（需要先申请）
+        kv:
+          type: array
+          description: kv值列表
+          items:
+            $ref: '#/components/schemas/MessageArkKv'
+    MessageArkKv:
+      description: ARK消息KV
+      type: object
+      properties:
+        key:
+          type: string
+          description: key
+        value:
+          type: string
+          description: value
+        obj:
+          type: array
+          description: ark obj类型的列表
+          items:
+            $ref: '#/components/schemas/MessageArkObj'
+    MessageArkObj:
+      type: object
+      description: MessageArkObj
+      properties:
+        obj_kv:
+          type: array
+          description: ark objkv列表
+          items:
+            $ref: '#/components/schemas/MessageArkObjKv'
+    MessageArkObjKv:
+      type: object
+      description: MessageArkObjKv
+      properties:
+        key:
+          type: string
+          description: key
+        value:
+          type: string
+          description: value
+    MessageAudited:
+      type: object
+      description: 消息审核对象
+      properties:
+        audit_id:
+          type: string
+          description: 消息审核 id
+        message_id:
+          type: string
+          description: 消息 id，只有审核通过事件才会有值
+        guild_id:
+          type: string
+          description: 频道 id
+        channel_id:
+          type: string
+          description: 子频道 id
+        audit_time:
+          type: string
+          format: date-time
+          description: '消息审核时间,ISO8601 timestamp'
+        create_time:
+          type: string
+          format: date-time
+          description: '消息创建时间,ISO8601 timestamp'
+        seq_in_channel:
+          $ref: "#/components/schemas/BaseSequenceInChannel"
+    DMS:
+      type: object
+      description: 私信会话对象
+      properties:
+        guild_id:
+          type: string
+          description: 私信会话关联的频道ID
+          format: int64
+        channel_id:
+          type: string
+          description: 私信会话关联的子频道ID
+        create_time:
+          type: string
+          format: int64
+          description: 创建私信会话时间戳
+    Announces:
+      type: object
+      description: 公告对象
+      properties:
+        guild_id:
+          $ref: '#/components/schemas/BaseGuildID'
+        channel_id:
+          $ref: '#/components/schemas/BaseChannelID'
+        message_id:
+          $ref: '#/components/schemas/BaseMessageID'
+    Schedule:
+      type: object
+      description: 日程对象
+      properties:
+        id:
+          $ref: '#/components/schemas/BaseScheduleID'
+        name:
+          type: string
+          description: 日程名称
+        description:
+          type: string
+          description: 日程描述
+        start_timestamp:
+          type: string
+          description: 日程开始时间戳(ms)
+          format: int64
+        end_timestamp:
+          type: string
+          description: 日程结束时间戳(ms)
+          format: int64
+        creator:
+          $ref: '#/components/schemas/Member'
+        jump_channel_id:
+          description: 日程开始时跳转到的子频道 id
+          type: string
+          format: int64
+        remind_type:
+          $ref: '#/components/schemas/RemindType'
+    Emoji:
+      type: object
+      description: 表情对象
+      properties:
+        id:
+          $ref: '#/components/schemas/EmojiID'
+        type:
+          $ref: '#/components/schemas/EmojiType'
+    MessageReaction:
+      type: object
+      description: 表情表态对象
+      properties:
+        user_id:
+          $ref: '#/components/schemas/BaseUserID'
+        guild_id:
+          $ref: '#/components/schemas/BaseGuildID'
+        channel_id:
+          $ref: '#/components/schemas/BaseChannelID'
+        target:
+          $ref: '#/components/schemas/ReactionTarget'
+        emoji:
+          $ref: '#/components/schemas/Emoji'
+    ReactionTarget:
+      type: object
+      description: 表情表态的目标对象
+      properties:
+        id:
+          type: string
+          description: 表态对象ID
+        type:
+          $ref: '#/components/schemas/ReactionTargetType'
+    AudioControl:
+      type: object
+      description: 语音对象
+      properties:
+        audio_url:
+          type: string
+          description: 音频数据的url status为0时传
+        text:
+          type: string
+          description: 状态文本（比如：简单爱-周杰伦），可选，status为0时传，其他操作不传
+        status:
+          $ref: '#/components/schemas/AudioControlStatus'
+    APIPermission:
+      type: object
+      description: 接口权限对象
+      properties:
+        path:
+          type: string
+          description: 'API 接口名，例如 /guilds/{guild_id}/members/{user_id}'
+        method:
+          type: string
+          description: 请求方法，例如 GET
+        desc:
+          type: string
+          description: API 接口名称，例如 获取频道信
+        auth_status:
+          type: integer
+          description: 授权状态，auth_stats 为 1 时已授权
+    APIPermissionDemand:
+      type: object
+      description: 接口权限需求对象，用于往目标频道的子频道发送申请接口权限消息
+      properties:
+        guild_id:
+          $ref: '#/components/schemas/BaseGuildID'
+        channel_id:
+          $ref: '#/components/schemas/BaseChannelID'
+        api_identify:
+          $ref: '#/components/schemas/APIPermissionDemandIdentify'
+        title:
+          type: string
+          description: 接口权限链接中的接口权限描述信息
+        desc:
+          type: string
+          description: 接口权限链接中的机器人可使用功能的描述信息
+    APIPermissionDemandIdentify:
+      type: object
+      description: 接口权限需求标识对象
+      properties:
+        path:
+          type: string
+          description: 'API 接口名，例如 /guilds/{guild_id}/members/{user_id}'
+        name:
+          type: string
+          description: 请求方法，例如 GET
+    ChannelCreate:
+      type: object
+      description: 创建子频道请求对象
+      properties:
+        name:
+          type: string
+          description: 子频道名称
+        type:
+          $ref: '#/components/schemas/ChannelType'
+        sub_type:
+          $ref: '#/components/schemas/ChannelSubType'
+        position:
+          type: integer
+          description: 排序值
+        parent_id:
+          $ref: '#/components/schemas/BaseChannelCategoryID'
+        private_type:
+          $ref: '#/components/schemas/PrivateType'
+        private_user_ids:
+          type: array
+          items:
+            $ref: '#/components/schemas/BaseUserID'
+          description: 子频道私密类型成员 ID
+      required:
+        - name
+        - type
+        - sub_type
+    ChannelUpdate:
+      type: object
+      description: 修子频道请求对象
+      properties:
+        name:
+          type: string
+          description: 子频道名称
+        type:
+          $ref: '#/components/schemas/ChannelType'
+        sub_type:
+          $ref: '#/components/schemas/ChannelSubType'
+        position:
+          type: integer
+          description: 排序值
+        parent_id:
+          $ref: '#/components/schemas/BaseChannelCategoryID'
+        private_type:
+          $ref: '#/components/schemas/PrivateType'
+    GuildRole:
+      type: object
+      description: 频道身份组对象
+      properties:
+        id:
+          $ref: '#/components/schemas/BaseGuildID'
+        name:
+          type: string
+          description: 名称
+        color:
+          type: number
+          description: ARGB 的 HEX 十六进制颜色值转换后的十进制数值（例：4294927682）
+        hoist:
+          type: number
+          description: 是否在成员列表中单独展示, 0-否, 1-是
+        number:
+          type: number
+          description: 人数
+        member_limit:
+          type: number
+          description: 成员上限
+    MessageSend:
+      type: object
+      description: 用户发送消息的数据对象
+      properties:
+        content:
+          type: string
+          description: 消息内容，文本内容，支持内嵌格式
+        embed:
+          $ref: "#/components/schemas/MessageEmbed"
+        ark:
+          $ref: "#/components/schemas/MessageArk"
+        message_reference:
+          $ref: "#/components/schemas/MessageReference"
+        image:
+          type: string
+          description: 图片url地址，平台会转存该图片，用于下发图片消息
+        msg_id:
+          type: string
+          description: 要回复的消息id(Message.id), 在 AT_CREATE_MESSAGE 事件中获取，携带之后此条回复视为被动消息
+      minProperties: 1
+    ScheduleCreate:
+      type: object
+      description: 日程创建对象
+      properties:
+        name:
+          type: string
+          description: 日程名称
+        description:
+          type: string
+          description: 日程描述
+        start_timestamp:
+          type: string
+          description: 日程开始时间戳(ms)
+          format: int64
+        end_timestamp:
+          type: string
+          description: 日程结束时间戳(ms)
+          format: int64
+        creator:
+          $ref: '#/components/schemas/Member'
+        jump_channel_id:
+          type: string
+          description: 日程开始时跳转到的子频道 id
+          format: int64
+        remind_type:
+          type: string
+          description: 日程提醒类型
+      required:
+        - name
+        - start_timestamp
+        - end_timestamp
+        - remind_type
+    ScheduleUpdate:
+      type: object
+      description: 日程更新对象
+      properties:
+        name:
+          type: string
+          description: 日程名称
+        description:
+          type: string
+          description: 日程描述
+        start_timestamp:
+          type: string
+          description: 日程开始时间戳(ms)
+          format: int64
+        end_timestamp:
+          type: string
+          description: 日程结束时间戳(ms)
+          format: int64
+        creator:
+          $ref: '#/components/schemas/Member'
+        jump_channel_id:
+          type: string
+          description: 日程开始时跳转到的子频道 id
+          format: int64
+        remind_type:
+          type: string
+          description: 日程提醒类型
+    SessionStartLimit:
+      type: object
+      description: 创建 Session 限制信息
+      properties:
+        total:
+          type: integer
+          description: 每 24 小时可创建 Session 数
+        remaining:
+          type: integer
+          description: 目前还可以创建的 Session 数
+        reset_after:
+          type: integer
+          description: 重置计数的剩余时间(ms)
+        max_concurrency:
+          type: integer
+          description: 每 5s 可以创建的 Session 数
+    DefaultRoleIDs:
+      type: string
+      description: |
+        统默认生成下列身份组ID:
+          * `1` - 全体成员
+          * `2` - 管理员
+          * `4` - 群主/创建者
+          * `5` - 子频道管理员
+      enum: [1,2,4,5]
+    ChannelType:
+      type: integer
+      description: |
+        子频道类型:
+          * `0` - 文字子频道
+          * `1` - 保留，不可用
+          * `2` - 语音子频道
+          * `3` - 保留，不可用
+          * `4` - 子频道分组
+          * `10005` - 直播子频道
+          * `10006` - 应用子频道
+          * `10007` - 论坛子频道
+          | 注：由于QQ频道还在持续的迭代中，经常会有新的子频道类型增加，文档更新不一定及时，开发者识别 ChannelType 时，请注意相关的未知 ID 的处理。
+      enum: [0,1,2,3,4,10005,10006,10007]
+    ChannelSubType:
+      type: integer
+      description: |
+        子频道子类型:
+          * `0` - 闲聊
+          * `1` - 公告
+          * `2` - 攻略
+          * `3` - 开黑
+          | 目前只有文字子频道具有 ChannelSubType 二级分类，同时二级分类也可能会不断增加，开发者也需要注意对未知 ID 的处理
+      enum: [0,1,2,3]
+    PrivateType:
+      type: integer
+      description: |
+        子频道私密类型:
+          * `0` - 公开频道
+          * `1` - 群主管理员可见
+          * `2` - 群主管理员+指定成员，可使用 修改子频道权限接口 指定成员
+      enum: [0,1,2]
+    SpeakPermission:
+      type: integer
+      description: |
+        子频道发言权限:
+          * `0` - 无效类型
+          * `1` - 所有人
+          * `2` - 群主管理员+指定成员，可使用 修改子频道权限接口 指定成员
+      enum: [0,1,2]
+    Application:
+      type: string
+      description: |
+        应用子频道的应用类型:
+          * `1000000` - 王者开黑大厅
+          * `1000001` - 互动小游戏
+          * `1000010` - 腾讯投票
+          * `1000051` - 飞车开黑大厅
+          * `1000050` - 日程提醒
+          * `1000070` - CoDM 开黑大厅
+          * `1010000` - 和平精英开黑大厅
+        | 由于QQ频道还在持续的迭代中，应用子频道的 application_id 还会持续新增，后续会不定期补充到文档中
+    Permissions:
+      type: string
+      description: |
+        * 用户/角色拥有的(子)频道权限
+        * 权限是QQ频道管理频道成员的一种方式，管理员可以对不同的人、不同的子频道设置特定的权限。用户的权限包括个人权限和身份组权限两部分，最终生效是取两种权限的并集。
+        * 权限使用位图表示，传递时序列化为十进制数值字符串。如权限值为0x6FFF，会被序列化为十进制"28671"。
+          | 权限 | 值 | 描述 |
+          | --- | --- | --- |
+          | 可查看子频道 | 0x0000000001 (1 << 0) | 支持`指定成员`可见类型，支持`身份组`可见类型 |
+          | 可管理子频道 | 0x0000000002 (1 << 1) | 创建者、管理员、子频道管理员都具有此权限 |
+          | 可发言子频道 | 0x0000000004 (1 << 2) | 支持`指定成员`发言类型，支持`身份组`发言类型  |
+    RemindType:
+      type: string
+      description: |
+        日程提醒类型:
+          * `0` - 不提醒
+          * `1` - 开始时提醒
+          * `2` - 开始前 5 分钟提醒
+          * `3` - 开始前 15 分钟提醒
+          * `4` - 开始前 30 分钟提醒
+          * `5` - 开始前 60 分钟提醒
+    AudioControlStatus:
+      type: integer
+      description: |
+        播放状态:
+          * `0` - 开始播放操作
+          * `1` - 暂停播放操作
+          * `2` - 继续播放操作
+          * `3` - 停止播放操作
+    ReactionTargetType:
+      type: string
+      description: |
+        表态对象类型:
+          * `0` - 消息
+          * `1` - 帖子
+          * `2` - 评论
+          * `3` - 回复
+    EmojiType:
+      type: integer
+      description: |
+        表情类型 :
+          * `1` - 系统表情
+          * `2` - emoji表情
+    EmojiID:
+      type: string
+      description: |
+        emoji 表情列表，请访问 [表情列表](https://bot.q.qq.com/wiki/develop/api/openapi/emoji/model.html#emoji-%E5%88%97%E8%A1%A8)
+    PinsMessage:
+      type: object
+      description: 精华消息对象
+      properties:
+        guild_id:
+          $ref: '#/components/schemas/BaseGuildID'
+        channel_id:
+          $ref: '#/components/schemas/BaseChannelID'
+        message_ids:
+          type: array
+          items:
+            $ref: '#/components/schemas/BaseMessageID'

--- a/test/OpenAPI/v3.0/bot.components.yaml
+++ b/test/OpenAPI/v3.0/bot.components.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: QQ 机器人 OpenAPI 对象定义
+  title: Bot OpenAPI
   version: v1.0.0
 paths:
   # 这里只是放置个 path 配置避免格式检查报错

--- a/test/OpenAPI/v3.0/bot.paths.yaml
+++ b/test/OpenAPI/v3.0/bot.paths.yaml
@@ -1,0 +1,1157 @@
+openapi: 3.0.3
+info:
+  title: QQ 机器人 OpenAPI
+  description: |
+    QQ 频道机器人通过开放的平台承载机器人的定制化功能，让开发者获得更畅快的开发体验。
+  version: v1.0.0
+  contact:
+    name: 加入开发者频道
+    url: https://qun.qq.com/qqweb/qunpro/share?_wv=3&_wwv=128&inviteCode=1MVRbV&from=246610&biz=ka
+servers:
+  - url: https://sandbox.api.sgroup.qq.com
+    description: |
+      沙箱环境
+      沙箱环境调用 openapi 仅能操作沙箱频道
+  - url: https://api.sgroup.qq.com
+    description: 正式环境
+security:
+  - bot_auth: []
+paths:
+  /guilds/{guild_id}:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+    get:
+      summary: 获取频道详情
+      description: 用于获取 guild_id 指定的频道的详情
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/guild/get_guild.html
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/Guild'
+      tags:
+        - GuildManagements
+  /users/@me:
+    get:
+      summary: 获取用户详情
+      description: 用于获取当前用户（机器人）详情
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/user/me.html
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/User'
+      tags:
+        - UserRelations
+  /users/@me/guilds:
+    parameters:
+      - name: before
+        in: query
+        required: false
+        schema:
+          type: string
+        description: 读此 guild id 之前的数据，before 设置时， 先反序，再分页
+      - name: after
+        in: query
+        required: false
+        schema:
+          type: string
+        description: 读取此 id 之后的数据
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: number
+          default: 100
+        description: 每次拉取多少条数据，最大不超过 100，默认 100
+    get:
+      summary: 获取用户频道列表
+      description: |
+        用于获取当前用户（机器人）所加入的频道列表，支持分页，参数 before、after 同时存在时，以 before 为准。
+      externalDocs:
+        url: 'https://bot.q.qq.com/wiki/develop/api/openapi/user/guilds.html'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'bot.components.yaml#/components/schemas/Guild'
+      tags:
+        - UserRelations
+  /guilds/{guild_id}/channels:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+    get:
+      summary: 获取子频道列表
+      description: 用于获取 guild_id 指定的频道下的子频道列表
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/channel/get_channels.html
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'bot.components.yaml#/components/schemas/Channel'
+      tags:
+        - GuildManagements
+    post:
+      summary: 创建子频道
+      description: |
+        用于在 guild_id 指定的频道下创建一个子频道。
+          * 要求操作人具有管理频道的权限，如果是机器人，则需要将机器人设置为管理员。
+          * 创建成功后，返回创建成功的子频道对象，同时会触发一个频道创建的事件通知。
+          * `公域机器人暂不支持申请，仅私域机器人可用，选择私域机器人后默认开通。`
+          * `注意: 开通后需要先将机器人从频道移除，然后重新添加，方可生效。`
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/channel/post_channels.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'bot.components.yaml#/components/schemas/ChannelCreate'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'bot.components.yaml#/components/schemas/Channel'
+      tags:
+        - GuildManagements
+  /channels/{channel_id}:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+    get:
+      summary: 获取子频道详情
+      description: 用于获取 channel_id 指定的子频道的详情
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/channel/get_channel.html
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/Channel'
+      tags:
+        - GuildManagements
+    patch:
+      summary: 修改子频道
+      description: |
+        用于修改 channel_id 指定的子频道的信息。
+          * 要求操作人具有管理子频道的权限，如果是机器人，则需要将机器人设置为管理员。
+          * 修改成功后，会触发子频道更新事件。
+          * `公域机器人暂不支持申请，仅私域机器人可用，选择私域机器人后默认开通。`
+          * `注意: 开通后需要先将机器人从频道移除，然后重新添加，方可生效。`
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/channel/patch_channel.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'bot.components.yaml#/components/schemas/ChannelUpdate'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/Channel'
+      tags:
+        - GuildManagements
+    delete:
+      summary: 删除子频道
+      description: |
+        用于删除 channel_id 指定的子频道。
+          * 要求操作人具有管理子频道的权限，如果是机器人，则需要将机器人设置为管理员。
+          * 修改成功后，会触发子频道删除事件。
+          * `公域机器人暂不支持申请，仅私域机器人可用，选择私域机器人后默认开通。`
+          * `注意: 开通后需要先将机器人从频道移除，然后重新添加，方可生效。`
+      externalDocs:
+        url: 'https://bot.q.qq.com/wiki/develop/api/openapi/channel/delete_channel.html'
+      responses:
+        200:
+          description: 成功
+      tags:
+        - GuildManagements   
+  /guilds/{guild_id}/members:
+    get:
+      summary: 获取频道成员列表
+      description: |
+        用于获取 guild_id 指定的频道中所有成员的详情列表，支持分页。
+          * `公域机器人暂不支持申请，仅私域机器人可用，选择私域机器人后默认开通。`
+          * `注意: 开通后需要先将机器人从频道移除，然后重新添加，方可生效。`
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/member/get_members.html
+      parameters:
+        - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+        - name: after
+          in: query
+          required: false
+          schema:
+            type: string
+          description: 上一次回包中最后一个member的user id， 如果是第一次请求填 0，默认为 0
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: number
+            default: 1
+          description: 分页大小，1-400，默认是 1。成员较多的频道尽量使用较大的limit值，以减少请求数
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'bot.components.yaml#/components/schemas/Member'
+      tags:
+        - UserRelations
+  /guilds/{guild_id}/members/{user_id}:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathUserID'
+    get:
+      summary: 获取成员详情
+      description: 用于获取 guild_id 指定的频道中 user_id 对应成员的详细信息
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/member/get_member.html
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/Member'
+      tags:
+        - UserRelations
+    delete:
+      summary: 删除频道成员
+      description: |
+        用于删除 guild_id 指定的频道下的成员 user_id。
+          * 需要使用的 token 对应的用户具备踢人权限。如果是机器人，要求被添加为管理员。
+          * 操作成功后，会触发频道成员删除事件。
+          * 无法移除身份为管理员的成员
+          * `公域机器人暂不支持申请，仅私域机器人可用，选择私域机器人后默认开通。`
+          * `注意: 开通后需要先将机器人从频道移除，然后重新添加，方可生效。`
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/member/delete_member.html
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              properties:
+                add_blacklist:
+                  type: boolean
+                  description: 删除成员的同时，将该用户添加到频道黑名单中
+      responses:
+        204:
+          description: 成功
+      tags:
+        - UserRelations
+  /guilds/{guild_id}/roles:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+    get:
+      summary: 获取频道身份组列表
+      description: 用于获取 guild_id指定的频道下的身份组列表
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/guild/get_guild_roles.html
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  guild_id:
+                    type: string
+                    description: 频道 ID
+                  roles:
+                    type: array
+                    items:
+                      $ref: 'bot.components.yaml#/components/schemas/Role'
+                    description: 频道身份组对象列表
+                  role_num_limit:
+                    type: string
+                    description: 默认分组上限
+      tags: [UserRelations]
+    post:
+      summary: 创建频道身份组
+      description: |
+        用于在guild_id 指定的频道下创建一个身份组。
+          * 需要使用的 token 对应的用户具备创建身份组权限。如果是机器人，要求被添加为管理员。
+          * 参数为非必填，但至少需要传其中之一，默认为空或 0。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/guild/post_guild_role.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  description: 名称
+                color:
+                  type: number
+                  description: ARGB 的 HEX 十六进制颜色值转换后的十进制数值（例:4294927682）
+                hoist:
+                  type: number
+                  description: 在成员列表中单独展示,0-否, 1-是
+              required:
+                - name
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  role_id:
+                    type: string
+                    description: 频道身份组 ID
+                  role:
+                    $ref: 'bot.components.yaml#/components/schemas/GuildRole'
+      tags: [UserRelations]
+
+  /guilds/{guild_id}/roles/{role_id}:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathRoleID'
+    patch:
+      summary: 修改频道身份组
+      description: |
+        用于修改频道 guild_id 下 role_id 指定的身份组。
+          * 需要使用的 token 对应的用户具备修改身份组权限。如果是机器人，要求被添加为管理员。
+          * 接口会修改传入的字段，不传入的默认不会修改，至少要传入一个参数。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/guild/patch_guild_role.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  description: 名称
+                color:
+                  type: number
+                  description: ARGB 的 HEX 十六进制颜色值转换后的十进制数值（例：4294927682）
+                hoist:
+                  type: number
+                  description: 在成员列表中单独展示,0-否, 1-是
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  guild_id:
+                    type: string
+                    description: 频道 ID
+                  role_id:
+                    type: string
+                    description: 频道身份组 ID
+                  role:
+                    $ref: 'bot.components.yaml#/components/schemas/GuildRole'
+      tags: [UserRelations]
+    delete:
+      summary: 删除频道身份组
+      description: |
+        用于删除频道guild_id下 role_id 对应的身份组。
+        * 需要使用的 token 对应的用户具备`删除身份组权限`。如果是机器人，要求被添加为管理员。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/guild/delete_guild_role.html
+      responses:
+        204:
+          description: 成功
+      tags: [UserRelations]
+
+  /guilds/{guild_id}/members/{user_id}/roles/{role_id}:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathRoleID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathUserID'
+    put:
+      summary: 创建频道身份组成员
+      description: |
+        用于将频道guild_id下的用户 user_id 添加到身份组 role_id 。
+          * 需要使用的 token 对应的用户具备增加身份组成员权限。如果是机器人，要求被添加为管理员。
+          * 如果要增加的身份组 ID 是5-子频道管理员，需要增加 channel 对象来指定具体是哪个子频道。
+      externalDocs:
+        url: 'https://bot.q.qq.com/wiki/develop/api/openapi/guild/put_guild_member_role.html'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                id:
+                  type: string
+                  description: 子频道 id
+      responses:
+        204:
+          description: 成功
+      tags: [UserRelations]
+    delete:
+      summary: 删除频道身份组成员
+      description: |
+        用于将 用户 user_id 从 频道 guild_id 的 role_id 身份组中移除。
+          * 需要使用的 token 对应的用户具备删除身份组成员权限。如果是机器人，要求被添加为管理员。
+          * 如果要删除的身份组 ID 是5-子频道管理员，需要增加 channel 对象来指定具体是哪个子频道。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/guild/delete_guild_member_role.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                id:
+                  type: string
+                  description: 子频道 id
+      responses:
+        204:
+          description: 成功
+      tags: [UserRelations]
+
+  /channels/{channel_id}/members/{user_id}/permissions:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathUserID'
+    get:
+      summary: 获取子频道用户权限
+      description: |
+        用于获取 子频道channel_id 下用户 user_id 的权限。
+          * 获取子频道用户权限。
+          * 要求操作人具有`管理子频道的权限`，如果是机器人，则需要将机器人设置为管理员。
+      externalDocs:
+        url: 'https://bot.q.qq.com/wiki/develop/api/openapi/channel_permissions/get_channel_permissions.html'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/ChannelPermissions'
+      tags:
+        - Permissions
+    put:
+      summary: 修改子频道权限
+      description: |
+        用于修改子频道 channel_id 下用户 user_id 的权限。
+          * 要求操作人具有管理子频道的权限，如果是机器人，则需要将机器人设置为管理员。
+          * 参数包括add和remove两个字段，分别表示授予的权限以及删除的权限。要授予用户权限即把add对应位置 1，删除用户权限即把remove对应位置 1。当两个字段同一位都为 1，表现为删除权限。
+          * `本接口不支持修改可管理子频道权限。`
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/channel_permissions/put_channel_permissions.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                add:
+                  type: string
+                  description: 字符串形式的位图表示赋予用户的权限
+                remove:
+                  type: string
+                  description: 字符串形式的位图表示删除用户的权限
+      responses:
+        204:
+          description: 成功
+      tags:
+        - Permissions
+  /channels/{channel_id}/roles/{role_id}/permissions:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathRoleID'
+    get:
+      summary: 获取子频道身份组权限
+      description: |
+        用于获取子频道 channel_id 下身份组 role_id 的权限。
+        * 要求操作人具有管理子频道的权限，如果是机器人，则需要将机器人设置为管理员。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/channel_permissions/get_channel_roles_permissions.html
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/ChannelPermissions'
+      tags:
+        - Permissions
+    put:
+      summary: 修改子频道身份组权限
+      description: |
+        用于修改子频道 channel_id 下身份组 role_id 的权限。
+          * 要求操作人具有管理子频道的权限，如果是机器人，则需要将机器人设置为管理员。
+          * 参数包括add和remove两个字段，分别表示授予的权限以及删除的权限。要授予身份组权限即把add对应位置 1，删除身份组权限即把remove对应位置 1。当两个字段同一位都为 1，表现为删除权限。
+          * `本接口不支持修改可管理子频道权限。`
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/channel_permissions/put_channel_roles_permissions.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                add:
+                  type: string
+                  description: 字符串形式的位图表示赋予用户的权限
+                remove:
+                  type: string
+                  description: 字符串形式的位图表示删除用户的权限
+      responses:
+        204:
+          description: 成功
+      tags:
+        - Permissions
+  /channels/{channel_id}/messages/{message_id}:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathMessageID'
+    get:
+      summary: 获取指定消息
+      description: 用于获取子频道 channel_id 下的消息 message_id 的详情。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/message/get_message_of_id.html
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/Message'
+      tags:
+        - Messages
+  /channels/{channel_id}/messages:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+    post:
+      summary: 发送消息
+      description: |
+        用于向 channel_id 指定的子频道发送消息。
+        * 要求操作人在该子频道具有发送消息的权限。
+        * 主动推送消息，默认每天往每个频道可推送的消息数是 `20` 条，超过会被限制。
+        * 主动推送消息在每个频道中，每天可以往 `2` 个子频道推送消息。超过后会被限制。
+        * 不论主动消息还是被动消息，在一个子频道中，每 `1s` 只能发送 `5` 条消息。
+        * 被动回复消息有效期为 `5` 分钟。超时会报错。
+        * 发送消息接口要求机器人接口需要连接到 websocket 上保持在线状态
+        * 有关主动消息审核，可以通过 Intents 中审核事件 MESSAGE_AUDIT 返回 MessageAudited 对象获取结果。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/message/post_messages.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'bot.components.yaml#/components/schemas/MessageSend'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/Message'
+      tags:
+        - Messages
+  /users/@me/dms:
+    post:
+      summary: 创建私信会话
+      description: |
+        用于机器人和在同一个频道内的成员创建私信会话。
+          * 机器人和用户存在共同频道才能创建私信会话。
+          * 创建成功后，返回创建成功的频道 id ，子频道 id 和创建时间。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/dms/post_dms.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                recipient_id:
+                  type: string
+                  description: 接收者 id
+                source_guild_id:
+                  type: string
+                  description: 源频道 id
+              required:
+                - recipient_id
+                - source_guild_id
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'bot.components.yaml#/components/schemas/DMS'
+      tags:
+        - Messages
+  /dms/{guild_id}/messages:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+    post:
+      summary: 发送私信
+      description: |
+        用于发送私信消息，前提是已经创建了私信会话。
+        * 私信的 guild_id 在创建私信会话时以及私信消息事件中获取。
+        * 私信场景下，每个机器人每天可以对一个用户发 `2` 条主动消息。
+        * 私信场景下，每个机器人每天累计可以发 `200` 条主动消息。
+        * 私信场景下，被动消息没有条数限制。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/dms/post_dms_messages.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'bot.components.yaml#/components/schemas/MessageSend'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'bot.components.yaml#/components/schemas/Message'
+      tags:
+        - Messages
+  /guilds/{guild_id}/mute:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+    patch:
+      summary: 禁言全员
+      description: |
+        用于将频道的全体成员（非管理员）禁言。
+          * 需要使用的 token 对应的用户具备管理员权限。如果是机器人，要求被添加为管理员。
+          * 该接口同样可用于解除禁言，具体使用见解除全员禁言。
+          * `该接口同样支持解除全员禁言，将mute_end_timestamp或mute_seconds传值为字符串'0'即可`。
+      externalDocs:
+        url: 'https://bot.q.qq.com/wiki/develop/api/openapi/guild/patch_guild_mute.html'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                mute_end_timestamp:
+                  type: string
+                  description: 禁言到期时间戳，绝对时间戳，单位:秒（与 mute_seconds 字段同时赋值的话，以该字段为准）
+                mute_seconds:
+                  type: string
+                  description: 禁言多少秒（两个字段二选一，默认以 mute_end_timestamp 为准）
+              minProperties: 1
+      responses:
+        204:
+          description: 成功
+      tags:
+        - Permissions
+  /guilds/{guild_id}/members/{user_id}/mute:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathUserID'
+    patch:
+      summary: 禁言指定成员
+      description: |
+        用于禁言频道 guild_id 下的成员 user_id。
+        * 需要使用的 token 对应的用户具备管理员权限。如果是机器人，要求被添加为管理员。
+        * `该接口同样可用于解除禁言，具体使用见解除指定成员禁言`。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/guild/patch_guild_member_mute.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                mute_end_timestamp:
+                  type: string
+                  description: 禁言到期时间戳，绝对时间戳，单位:秒（与 mute_seconds 字段同时赋值的话，以该字段为准）
+                mute_seconds:
+                  type: string
+                  description: 禁言多少秒（两个字段二选一，默认以 mute_end_timestamp 为准）
+              minProperties: 1
+      responses:
+        204:
+          description: 成功
+      tags:
+        - Permissions
+  /guilds/{guild_id}/announces:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+    post:
+      summary: 创建频道公告
+      description: |
+        用于将频道内的某条消息设置为频道全局公告
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/announces/post_guild_announces.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                message_id:
+                  type: string
+                  description: 消息 id
+                channel_id:
+                  type: string
+                  description: 子频道 id
+              required:
+                - message_id
+                - channel_id
+      responses:
+        204:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/Announces'
+      tags: [GuildManagements]
+  /guilds/{guild_id}/announces/{message_id}:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathMessageID'
+    delete:
+      summary: 删除频道公告
+      description: |
+        用于删除频道 guild_id 下 message_id 指定的全局公告。
+          * message_id 有值时，会校验 message_id 合法性，若不校验校验 message_id，请将 message_id 设置为 all。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/announces/delete_guild_announces.html
+      responses:
+        204:
+          description: 成功
+      tags: [GuildManagements]
+  /channels/{channel_id}/announces:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+    post:
+      summary: 创建子频道公告
+      description: 用于将子频道 channel_id 内的某条消息设置为子频道公告。
+      deprecated: true
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/announces/post_channel_announces.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                message_id:
+                  type: string
+                  description: 消息 id
+              required:
+                - message_id
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/Announces'
+      tags: [GuildManagements]
+
+  /channels/{channel_id}/announces/{message_id}:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathMessageID'
+    delete:
+      summary: 删除子频道公告
+      description: |
+        用于删除子频道 channel_id 下 message_id 指定的子频道公告。
+        * message_id 有值时，会校验 message_id 合法性，若不校验校验 message_id，请将 message_id 设置为 all。
+      deprecated: true
+      externalDocs:
+        url: 'https://bot.q.qq.com/wiki/develop/api/openapi/announces/delete_channel_announces.html'
+      responses:
+        204:
+          description: 成功
+      tags: [GuildManagements]
+
+  /channels/{channel_id}/schedules:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+    get:
+      summary: 获取频道日程列表
+      description: |
+        用于获取channel_id指定的子频道中当天的日程列表。
+        * 若带了参数 since，则返回结束时间在 since 之后的日程列表；若未带参数 since，则默认返回当天的日程列表。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/schedule/get_schedules.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                since:
+                  type: integer
+                  description: 起始时间戳(ms) 
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'bot.components.yaml#/components/schemas/Schedule'
+      tags:
+        - Applications
+    post:
+      summary: 创建日程
+      description: |
+        用于在 channel_id 指定的日程子频道下创建一个日程。
+          * 要求操作人具有管理频道的权限，如果是机器人，则需要将机器人设置为管理员。
+          * 创建成功后，返回创建成功的日程对象。
+          * 创建操作频次限制: 单个管理员每天限`10`次, 单个频道每天`100`次。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/schedule/post_schedule.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'bot.components.yaml#/components/schemas/ScheduleCreate' 
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/Schedule'
+      tags:
+        - Applications
+  /channels/{channel_id}/schedules/{schedule_id}:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathScheduleID'
+    get:
+      summary: 获取日程详情
+      description: 获取日程子频道 channel_id 下 schedule_id 指定的的日程的详情。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/schedule/get_schedule.html
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/Schedule'
+      tags:
+        - Applications
+    patch:
+      summary: 修改日程
+      description: |
+        用于修改日程子频道 channel_id 下 schedule_id 指定的日程的详情。
+        * 要求操作人具有管理频道的权限，如果是机器人，则需要将机器人设置为管理员。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/schedule/patch_schedule.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'bot.components.yaml#/components/schemas/ScheduleUpdate'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/Schedule'
+      tags:
+        - Applications
+    delete:
+      summary: 删除日程
+      description: |
+        用于删除日程子频道 channel_id 下 schedule_id 指定的日程。
+        * 要求操作人具有`管理频道的权限`，如果是机器人，则需要将机器人设置为管理员。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/schedule/delete_schedule.html
+      responses:
+        204:
+          description: 成功
+      tags:
+        - Applications
+  /channels/{channel_id}/audio:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+    post:
+      summary: 音频控制
+      description: |
+        用于控制子频道 channel_id 下的音频。
+        * 音频接口:仅限音频类机器人才能使用，后续会根据机器人类型自动开通接口权限，现如需调用，需联系平台申请权限。
+      externalDocs:
+        url: 'https://bot.q.qq.com/wiki/develop/api/openapi/audio/audio_control.html'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'bot.components.yaml#/components/schemas/AudioControl'
+      responses:
+        200:
+          description: 成功
+      tags:
+        - Audio
+  /guilds/{guild_id}/api_permission:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+    get:
+      summary: 获取频道可用权限列表
+      description: |
+        用于获取机器人在频道 guild_id 内可以使用的权限列表。
+      externalDocs:
+        url: 'https://bot.q.qq.com/wiki/develop/api/openapi/api_permissions/get_guild_api_permission.html'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'bot.components.yaml#/components/schemas/APIPermission'
+      tags:
+        - BotAPI
+  /guilds/{guild_id}/api_permission/demand:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathGuildID'
+    post:
+      summary: 创建频道 API 接口权限授权链接
+      description: |
+        用于创建 API 接口权限授权链接，该链接指向guild_id对应的频道 。
+        * 每天只能在一个频道内发 `3` 条（默认值）频道权限授权链接。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/api_permissions/post_api_permission_demand.html
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                channel_id:
+                  type: string
+                  description: 授权链接发送的子频道 id
+                api_identify:
+                  $ref: 'bot.components.yaml#/components/schemas/APIPermissionDemandIdentify'
+                desc:
+                  type: string
+                  description: 机器人申请对应的 API 接口权限后可以使用功能的描述
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'bot.components.yaml#/components/schemas/APIPermissionDemand'
+      tags:
+        - BotAPI
+  /gateway:
+    get:
+      summary: 获取通用 WSS 接入点
+      description: 用于获取 WSS 接入地址，通过该地址可建立 websocket 长连接。
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/wss/url_get.html
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                    description: websocket 的地址
+      tags:
+        - BotAPI
+  /gateway/bot:
+    get:
+      summary: 获取带分片 WSS 接入点
+      description: |
+        用于获取 WSS 接入地址及相关信息，通过该地址可建立 websocket 长连接。相关信息包括：
+          * 建议的分片数。
+          * 目前连接数使用情况。
+      externalDocs:
+        url: 'https://bot.q.qq.com/wiki/develop/api/openapi/wss/shard_url_get.html'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                    description: websocket 的地址
+                  shards:
+                    type: integer
+                    description: 建议的 shard 数
+                  session_start_limit:
+                    $ref: 'bot.components.yaml#/components/schemas/SessionStartLimit'
+      tags:
+        - BotAPI
+  /channels/{channel_id}/messages/{message_id}/reactions/{type}/{id}:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathMessageID'
+      - name: type
+        in: path
+        required: true
+        schema:
+          $ref: 'bot.components.yaml#/components/schemas/EmojiType'
+        description: 表情类型
+      - name: id
+        in: path
+        required: true
+        schema:
+          $ref: 'bot.components.yaml#/components/schemas/EmojiID'
+        description: 表情ID
+    put:
+      tags:
+        - Messages
+      summary: 对消息 `message_id` 进行表情表态
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/reaction/put_message_reaction.html
+      responses:
+        204:
+          description: 成功
+    delete:
+      tags:
+        - Messages
+      summary: 删除自己对消息 `message_id` 的表情表态
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/reaction/delete_own_message_reaction.html
+      responses:
+        204:
+          description: 成功
+  /channels/{channel_id}/pins/{message_id}:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+      - $ref: 'bot.components.yaml#/components/parameters/PathMessageID'
+    put:
+      tags:
+        - Messages
+      summary: 将消息 `message_id` 添加到精华消息中
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/pins/put_pins_message.html
+      responses:
+        200:
+          description: 成功
+          content:
+            applicztion/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/PinsMessage'
+    delete:
+      tags:
+        - Messages
+      summary: 将消息 `message_id` 从精华消息中删除
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/pins/delete_pins_message.html
+      responses:
+        204:
+          description: 成功
+  /channels/{channel_id}/pins:
+    parameters:
+      - $ref: 'bot.components.yaml#/components/parameters/PathChannelID'
+    get:
+      tags: [Messages]
+      summary: 获取精华消息列表
+      externalDocs:
+        url: https://bot.q.qq.com/wiki/develop/api/openapi/pins/get_pins_message.html
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: 'bot.components.yaml#/components/schemas/PinsMessage'
+
+
+#================
+# 接口分类说明，不与 wiki 的分类对齐，而是按照实际的功能大类进行归类
+tags:
+  - name: Messages
+    description: 频道消息、私信等相关接口
+  - name: UserRelations
+    description: 用户关系链相关接口API，包括用户信息，成员信息，用户的频道列表等
+  - name: GuildManagements
+    description: 频道、子频道信息管理类的接口
+  - name: Permissions
+    description: 频道管理相关接口，如身份组管理，权限管理等
+  - name: Applications
+    description: 垂直应用类接口，如日程功能
+  - name: Audio
+    description: 音频相关API集合
+  - name: Forums
+    description: 论坛类接口，操作论坛帖子，回复等
+  - name: BotAPI
+    description: 机器人提供的基础接口
+
+
+# 文档地址
+externalDocs:
+  description: 'Reference: QQ 机器人文档'
+  url: https://bot.q.qq.com/wiki
+
+# 对象定义，parameters 和 schemes 在独立文件中定义
+components:
+  securitySchemes:
+    bot_auth:
+      description: 机器人 API 鉴权，格式为 `Bot {appID}.{appToken}`
+      type: apiKey
+      name: Authorization
+      in: header
+  responses:
+    401:
+      description: |
+        请求异常，请检查参数传递是否正确
+    403:
+      description: |
+        权限检查失败，请检查如下几点：
+          - 头部的 token 是否正确
+          - 频道主是否授予了机器人对应的权限
+          - 频道ID等ID是否正确
+    500:
+      description: |
+        内部逻辑处理失败，大部分情况下可以重试，如果重试仍然失败，请检查参数是否正确
+    502:
+      description: |
+        内部处理超时，请稍后重试

--- a/test/OpenAPI/v3.0/bot.paths.yaml
+++ b/test/OpenAPI/v3.0/bot.paths.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: QQ 机器人 OpenAPI
+  title: Bot OpenAPI
   description: |
     QQ 频道机器人通过开放的平台承载机器人的定制化功能，让开发者获得更畅快的开发体验。
   version: v1.0.0

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -86,7 +86,8 @@ function RunTests {
         "uber",
         "uspto",
         "hubspot-events",
-        "hubspot-webhooks"
+        "hubspot-webhooks",
+        "bot.paths.yaml"
     )
     
     Write-Host "dotnet publish ../src/Refitter/Refitter.csproj -p:TreatWarningsAsErrors=true -p:PublishReadyToRun=true -o bin"

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -74,7 +74,8 @@ function RunTests {
         $Parallel = $false
     )
 
-    $filenames = @(
+    $filenames = @(        
+        "bot.paths",
         "petstore",
         "petstore-expanded",
         "petstore-minimal",
@@ -86,8 +87,7 @@ function RunTests {
         "uber",
         "uspto",
         "hubspot-events",
-        "hubspot-webhooks",
-        "bot.paths.yaml"
+        "hubspot-webhooks"
     )
     
     Write-Host "dotnet publish ../src/Refitter/Refitter.csproj -p:TreatWarningsAsErrors=true -p:PublishReadyToRun=true -o bin"


### PR DESCRIPTION
This resolves #192 

```
refitter openapi.yaml

...

OpenAPI specifications contains external references.                  
Attempting to merge of all external references into single document...
components.yaml - Paths must be a map/object
components.yaml - The field 'paths' in 'document' object is REQUIRED.

OpenAPI statistics:  
 - Path Items: 32    
 - Operations: 46    
 - Parameters: 13    
 - Request Bodies: 21
 - Responses: 46     
 - Links: 0          
 - Callbacks: 0      
 - Schemas: 210

Length: 90275 bytes
Output: C:\projects\christianhelle\refitter\src\Refitter\bin\Release\net8.0\Output.cs
Duration: 00:00:02.5172435
```

Currently, it supports having external references to files within the same folder, or remotely. But it won't work if the remote file has local external references. 

These scenarios work:
- The OAS file `/home/christian/openapi.yaml` has external references to `components.yaml` then I expect `components.yaml` to be in the same folder as `/home/christian/openapi.yaml`. 
- The OAS file `/home/christian/openapi.yaml` will also work if it has external references to `https://somewhere.over.the.rainbow/components.yaml` 

This scenario doesn't work:
- The OAS file `https://somewhere.over.the.rainbow/openapi.yaml` has external references to `components.yaml`