### PR TITLE
Implement CustomCSharpPropertyNameGenerator 

### DIFF
--- a/src/Refitter.Core/CustomCSharpPropertyNameGenerator.cs
+++ b/src/Refitter.Core/CustomCSharpPropertyNameGenerator.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 using NJsonSchema;
 using NJsonSchema.CodeGeneration;
 
@@ -8,7 +10,18 @@ internal class CustomCSharpPropertyNameGenerator : IPropertyNameGenerator
     private static readonly char[] ReservedFirstPassChars = ['"', '\'', '@', '?', '!', '$', '[', ']', '(', ')', '.', '=', '+'];
     private static readonly char[] ReservedSecondPassChars = ['*', ':', '-', '#', '&'];
     
-    public string Generate(JsonSchemaProperty property)
+    public string Generate(JsonSchemaProperty property) =>
+        string.IsNullOrWhiteSpace(property.Name)
+            ? "_"
+            : ReplaceNameContainingReservedCharacters(property);
+
+    /// <summary>
+    /// This code is taken directly from NJsonSchema.CodeGeneration.CSharp.CSharpPropertyNameGenerator
+    /// which since v14.0.0 is no longer extensible.
+    /// See https://github.com/RicoSuter/NJsonSchema/blob/3585d60e949e43284601e0bea16c33de4c6c21f5/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs#L12" 
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    private static string ReplaceNameContainingReservedCharacters(JsonSchemaProperty property)
     {
         var name = property.Name;
 
@@ -42,8 +55,6 @@ internal class CustomCSharpPropertyNameGenerator : IPropertyNameGenerator
                 .Replace("&", "And");
         }
 
-        return string.IsNullOrWhiteSpace(property.Name)
-            ? "_"
-            : name;
+        return name;
     }
 }


### PR DESCRIPTION
This pull request implements the CustomCSharpPropertyNameGenerator class, which is used to generate property names in C# code based on a given JsonSchemaProperty. The implementation includes handling reserved characters and converting the property names to upper camel case. This implementation is taken directly from v14.0.0 of NSwag where it has changed the class accessibility to be `sealed`

This change is a prerequisite for upgrading to NSwag v14.0.0