### PR TITLE
Update --operation-name-generator options documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ The following is an example `.refitter` file
     "^Model$",
     "^Person.+"
   ],
+  "generateDefaultAdditionalProperties": true, // Optional. default=true
+  "operationNameGenerator": "Default", // Optional. May be one of Default, MultipleClientsFromOperationId, MultipleClientsFromPathSegments, MultipleClientsFromFirstTagAndOperationId, MultipleClientsFromFirstTagAndOperationName, MultipleClientsFromFirstTagAndPathSegments, SingleClientFromOperationId, SingleClientFromPathSegments
   "dependencyInjectionSettings": { // Optional
     "baseUrl": "https://petstore3.swagger.io/api/v3", // Optional. Leave this blank to set the base address manually
     "httpMessageHandlers": [ // Optional

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ OPTIONS:
                                                                  - MultipleClientsFromFirstTagAndPathSegments                                                                                              
                                                                  - SingleClientFromOperationId                                                                                                             
                                                                  - SingleClientFromPathSegments                                                                                                            
+                                                                 See https://refitter.github.io/api/Refitter.Core.OperationNameGeneratorTypes.html for more information                                    
 ```
 
 To generate code from an OpenAPI specifications file, run the following:

--- a/docs/docfx_project/articles/cli-tool.md
+++ b/docs/docfx_project/articles/cli-tool.md
@@ -79,6 +79,7 @@ OPTIONS:
                                                                  - MultipleClientsFromFirstTagAndPathSegments                                                                                              
                                                                  - SingleClientFromOperationId                                                                                                             
                                                                  - SingleClientFromPathSegments                                                                                                            
+                                                                 See https://refitter.github.io/api/Refitter.Core.OperationNameGeneratorTypes.html for more information                                    
 ```
 
 To generate code from an OpenAPI specifications file, run the following:

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -45,6 +45,8 @@ The following is an example `.refitter` file
     "^Model$",
     "^Person.+"
   ],
+  "generateDefaultAdditionalProperties": true, // Optional. default=true
+  "operationNameGenerator": "Default", // Optional. May be one of Default, MultipleClientsFromOperationId, MultipleClientsFromPathSegments, MultipleClientsFromFirstTagAndOperationId, MultipleClientsFromFirstTagAndOperationName, MultipleClientsFromFirstTagAndPathSegments, SingleClientFromOperationId, SingleClientFromPathSegments
   "dependencyInjectionSettings": { // Optional
     "baseUrl": "https://petstore3.swagger.io/api/v3", // Optional. Leave this blank to set the base address manually
     "httpMessageHandlers": [ // Optional

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -130,6 +130,8 @@ The following is an example `.refitter` file
     "^Model$",
     "^Person.+"
   ],
+  "generateDefaultAdditionalProperties": true, // Optional. default=true
+  "operationNameGenerator": "Default", // Optional. May be one of Default, MultipleClientsFromOperationId, MultipleClientsFromPathSegments, MultipleClientsFromFirstTagAndOperationId, MultipleClientsFromFirstTagAndOperationName, MultipleClientsFromFirstTagAndPathSegments, SingleClientFromOperationId, SingleClientFromPathSegments
   "dependencyInjectionSettings": { // Optional
     "baseUrl": "https://petstore3.swagger.io/api/v3", // Optional. Leave this blank to set the base address manually
     "httpMessageHandlers": [ // Optional

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -82,6 +82,7 @@ OPTIONS:
                                                                  - MultipleClientsFromFirstTagAndPathSegments                                                                                              
                                                                  - SingleClientFromOperationId                                                                                                             
                                                                  - SingleClientFromPathSegments                                                                                                            
+                                                                 See https://refitter.github.io/api/Refitter.Core.OperationNameGeneratorTypes.html for more information                                    
 ```
 
 ### .Refitter File format

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -146,6 +146,7 @@ public sealed class Settings : CommandSettings
                  - MultipleClientsFromFirstTagAndPathSegments
                  - SingleClientFromOperationId
                  - SingleClientFromPathSegments
+                 See https://refitter.github.io/api/Refitter.Core.OperationNameGeneratorTypes.html for more information.
                  """)]
     [CommandOption("--operation-name-generator")]
     [DefaultValue(OperationNameGeneratorTypes.Default)]


### PR DESCRIPTION
This pull request updates the documentation for the operation name generator options in the README file. It adds a link to the OperationNameGeneratorTypes documentation for more information. Additionally, it includes a fix for a broken link in the usage instructions.