### PR TITLE
Serialize OperationNameGenerator enum as string

### DIFF
--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -146,6 +146,7 @@ public class RefitGeneratorSettings
     /// <summary>
     /// The NSwag IOperationNameGenerator implementation to use
     /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public OperationNameGeneratorTypes OperationNameGenerator { get; set; }
 
     /// <summary>

--- a/test/petstore.refitter
+++ b/test/petstore.refitter
@@ -17,5 +17,6 @@
     "dateType": "System.DateTime",
     "dateTimeType": "System.DateTime",
     "arrayType": "System.Collections.Generic.IList"
-  }
+  },
+  "operationNameGenerator": "Default"
 }


### PR DESCRIPTION
This pull request adds the `[JsonConverter(typeof(JsonStringEnumConverter))]` attribute to the `OperationNameGenerator` property in the `RefitGeneratorSettings` class. 

Additionally, it sets the `operationNameGenerator` property to `Default` in the petstore.refitter file.

This resolves #277