### PR TITLE
fix: AliasAs attribute generation for StreamPart type

### DIFF
--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -18,12 +18,14 @@ internal static class ParameterExtractor
 
         var queryParameters = operationModel.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Query)
-            .Select(p => $"{JoinAttributes(GetQueryAttribute(p, settings), GetAliasAsAttribute(p))}{GetQueryParameterType(p, settings)} {p.VariableName}")
+            .Select(p =>
+                $"{JoinAttributes(GetQueryAttribute(p, settings), GetAliasAsAttribute(p))}{GetQueryParameterType(p, settings)} {p.VariableName}")
             .ToList();
 
         var bodyParameters = operationModel.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Body && !p.IsBinaryBodyParameter)
-            .Select(p => $"{JoinAttributes("Body", GetAliasAsAttribute(p))}{GetParameterType(p, settings)} {p.VariableName}")
+            .Select(p =>
+                $"{JoinAttributes("Body", GetAliasAsAttribute(p))}{GetParameterType(p, settings)} {p.VariableName}")
             .ToList();
 
         var headerParameters = new List<string>();
@@ -32,13 +34,21 @@ internal static class ParameterExtractor
         {
             headerParameters = operationModel.Parameters
                 .Where(p => p.Kind == OpenApiParameterKind.Header && p.IsHeader)
-                .Select(p => $"{JoinAttributes($"Header(\"{p.Name}\")")}{GetParameterType(p, settings)} {p.VariableName}")
+                .Select(p =>
+                    $"{JoinAttributes($"Header(\"{p.Name}\")")}{GetParameterType(p, settings)} {p.VariableName}")
                 .ToList();
         }
 
         var binaryBodyParameters = operationModel.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Body && p.IsBinaryBodyParameter || p.IsFile)
-            .Select(p => $"[{GetAliasAsAttribute(p)}] StreamPart {p.VariableName}")
+            .Select(p =>
+            {
+                var generatedAliasAsAttribute = string.IsNullOrWhiteSpace(GetAliasAsAttribute(p))
+                    ? string.Empty
+                    : $"[{GetAliasAsAttribute(p)}]";
+                
+                return $"{generatedAliasAsAttribute} StreamPart {p.VariableName}";
+            })
             .ToList();
 
         var parameters = new List<string>();
@@ -62,7 +72,7 @@ internal static class ParameterExtractor
     {
         if (!settings.OptionalParameters)
             return parameters;
-        
+
         parameters = parameters.OrderBy(c => c.Contains("?")).ToList();
         for (int index = 0; index < parameters.Count; index++)
         {
@@ -121,7 +131,7 @@ internal static class ParameterExtractor
     {
         var type = GetParameterType(parameterModel, settings);
 
-        if (parameterModel.IsQuery && 
+        if (parameterModel.IsQuery &&
             parameterModel.Type.Equals("object", StringComparison.OrdinalIgnoreCase))
             type = "string";
 

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -38,7 +38,7 @@ internal static class ParameterExtractor
 
         var binaryBodyParameters = operationModel.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Body && p.IsBinaryBodyParameter || p.IsFile)
-            .Select(p => $"{GetAliasAsAttribute(p)}StreamPart {p.VariableName}")
+            .Select(p => $"[{GetAliasAsAttribute(p)}] StreamPart {p.VariableName}")
             .ToList();
 
         var parameters = new List<string>();


### PR DESCRIPTION
hi ,
its a basic fix for issue #231.
AliasAs attribute should inside square brackets if it is a single attribute.

before fix : 
![image](https://github.com/christianhelle/refitter/assets/57223732/44a0d4ce-2de6-43bb-a3ca-e4a0f184fd57)

after fix : 
![image](https://github.com/christianhelle/refitter/assets/57223732/b6e2c832-3909-4c90-b8b3-6bfdec1c1e5b)
