### PR TITLE
Added Optional Setting to name the IServiceCollection Extension Method

### DIFF
--- a/src/Refitter.Core/DependencyInjectionGenerator.cs
+++ b/src/Refitter.Core/DependencyInjectionGenerator.cs
@@ -16,8 +16,8 @@ internal static class DependencyInjectionGenerator
         var code = new StringBuilder();
 
         var methodDeclaration = string.IsNullOrEmpty(iocSettings.BaseUrl)
-            ? "public static IServiceCollection ConfigureRefitClients(this IServiceCollection services, Uri baseUrl, Action<IHttpClientBuilder>? builder = default)"
-            : "public static IServiceCollection ConfigureRefitClients(this IServiceCollection services, Action<IHttpClientBuilder>? builder = default)";
+            ? $"public static IServiceCollection {iocSettings.ExtensionMethodName}(this IServiceCollection services, Uri baseUrl, Action<IHttpClientBuilder>? builder = default)"
+            : $"public static IServiceCollection {iocSettings.ExtensionMethodName}(this IServiceCollection services, Action<IHttpClientBuilder>? builder = default)";
         
         var configureRefitClient = string.IsNullOrEmpty(iocSettings.BaseUrl)
             ? ".ConfigureHttpClient(c => c.BaseAddress = baseUrl)"

--- a/src/Refitter.Core/Settings/DependencyInjectionSettings.cs
+++ b/src/Refitter.Core/Settings/DependencyInjectionSettings.cs
@@ -31,4 +31,9 @@ public class DependencyInjectionSettings
     /// The median delay to target before the first retry in seconds. Default is 1 second
     /// </summary>
     public double FirstBackoffRetryInSeconds { get; set; } = 1.0;
+
+    /// <summary>
+    /// Name of IServiceCollection Extension Method. Default is ConfigureRefitClients
+    /// </summary>
+    public string ExtensionMethodName { get; set; } = "ConfigureRefitClients";
 }


### PR DESCRIPTION
Added a new **DependencyInjectionSettings** Property **ExtensionMethodName** with DefaultValue **ConfigureRefitClients**.

It can be set if you want to have control over the IServiceCollection Extension Method Name, or if you have multiple generated Client Api's with Dependency Injection support. Then the Extension Method will conflict.


Fixes #294