### PR TITLE
Fix response type always nullable under `generateNullableReferenceTypes`

### DIFF
--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -93,7 +93,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
     private string GetTypeName(string code, OpenApiOperation operation)
     {
         var schema = operation.Responses[code].ActualResponse.Schema;
-        var typeName = generator.GetTypeName(schema, true, null);
+        var typeName = generator.GetTypeName(schema, false, null);
 
         if (!string.IsNullOrWhiteSpace(settings.CodeGeneratorSettings?.ArrayType) &&
             schema?.Type == NJsonSchema.JsonObjectType.Array)

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -561,4 +561,39 @@ public class SwaggerPetstoreTests
         var generateCode = await GenerateCode(version, filename, settings);
         generateCode.Should().NotContain("Dictionary<string, object> AdditionalProperties");
     }
+
+    [Theory]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV2, "SwaggerPetstore.yaml")]
+    public async Task Can_Generate_Code_With_NonNullable_Return_Types(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings();
+        settings.CodeGeneratorSettings = new CodeGeneratorSettings
+        {
+            GenerateNullableReferenceTypes = true,
+            GenerateOptionalPropertiesAsNullable = true
+        };
+        var generateCode = await GenerateCode(version, filename, settings);
+        generateCode.Should().NotContain("Task<Pet?>");
+    }
+
+    [Theory]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV2, "SwaggerPetstore.yaml")]
+    public async Task Can_Generate_Code_With_NonNullable_Return_Types_In_ApiResponse(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings();
+        settings.ReturnIApiResponse = true;
+        settings.CodeGeneratorSettings = new CodeGeneratorSettings
+        {
+            GenerateNullableReferenceTypes = true,
+            GenerateOptionalPropertiesAsNullable = true
+        };
+        var generateCode = await GenerateCode(version, filename, settings);
+        generateCode.Should().NotContain("Task<IApiResponse<Pet?>>");
+    }
 }

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -576,6 +576,7 @@ public class SwaggerPetstoreTests
             GenerateOptionalPropertiesAsNullable = true
         };
         var generateCode = await GenerateCode(version, filename, settings);
+        generateCode.Should().Contain("Task<Pet>");
         generateCode.Should().NotContain("Task<Pet?>");
     }
 
@@ -594,6 +595,7 @@ public class SwaggerPetstoreTests
             GenerateOptionalPropertiesAsNullable = true
         };
         var generateCode = await GenerateCode(version, filename, settings);
+        generateCode.Should().Contain("Task<IApiResponse<Pet>>");
         generateCode.Should().NotContain("Task<IApiResponse<Pet?>>");
     }
 }


### PR DESCRIPTION
This pull request fixes the issue where nullable types were being returned from the Refit interface when the setting `generateNullableReferenceTypes` is enabled. 

This also adds tests for generating code with non-nullable return types and includes an assert for nullable return type tests. 

Additionally, it updates the code to generate non-nullable return types in the ApiResponse.

This resolves #302