### PR TITLE
Generating IObservable type response

### DIFF
--- a/src/Refitter.Core/RefitInterfaceImports.cs
+++ b/src/Refitter.Core/RefitInterfaceImports.cs
@@ -4,41 +4,37 @@ namespace Refitter.Core;
 
 internal static class RefitInterfaceImports
 {
-    public static string[] GetImportedNamespaces(RefitGeneratorSettings settings) =>
-        settings.UseCancellationTokens
-            ? new[]
-            {
-                "Refit",
-                "System.Collections.Generic",
-                "System.Text.Json.Serialization",
-                "System.Threading",
-                "System.Threading.Tasks"
-            }
-            : new[]
-            {
-                "Refit",
-                "System.Collections.Generic",
-                "System.Text.Json.Serialization",
-                "System.Threading.Tasks"
-            };
+    private static string[] defaultNamespases = new[]
+    {
+        "Refit",
+        "System.Collections.Generic",
+        "System.Text.Json.Serialization",
+    };
+    public static string[] GetImportedNamespaces(RefitGeneratorSettings settings)
+    {
+        var namespaces = new List<string>(defaultNamespases);
+        if (settings.UseCancellationTokens)
+        {
+            namespaces.Add("System.Threading");
+        }
+
+        if (settings.ReturnIObservable)
+        {
+            namespaces.Add("System.Reactive");
+        }
+        else
+        {
+            namespaces.Add("System.Threading.Tasks");
+        }
+        return namespaces.ToArray();
+    }
 
     [SuppressMessage(
         "MicrosoftCodeAnalysisCorrectness",
         "RS1035:Do not use APIs banned for analyzers",
         Justification = "This tool is cross platform")]
     public static string GenerateNamespaceImports(RefitGeneratorSettings settings) =>
-        settings.UseCancellationTokens
-            ? string.Join(
-                Environment.NewLine,
-                "using Refit;",
-                "using System.Collections.Generic;",
-                "using System.Text.Json.Serialization;",
-                "using System.Threading;",
-                "using System.Threading.Tasks;")
-            : string.Join(
-                Environment.NewLine,
-                "using Refit;",
-                "using System.Collections.Generic;",
-                "using System.Text.Json.Serialization;",
-                "using System.Threading.Tasks;");
+        GetImportedNamespaces(settings)
+            .Select(ns => $"using {ns};")
+            .Aggregate((a, b) => $"{a}{Environment.NewLine}{b}");
 }

--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -58,6 +58,11 @@ public class RefitGeneratorSettings
     public bool ReturnIApiResponse { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to return IObservable or Task
+    /// </summary>
+    public bool ReturnIObservable { get; set; }
+
+    /// <summary>
     /// Gets or sets a dictionary of operation ids and a specific response type that they should use. The type is
     /// wrapped in a task, but otherwise unmodified (so make sure that the namespaces are imported or specified).
     /// </summary>
@@ -143,13 +148,13 @@ public class RefitGeneratorSettings
     /// Gets or sets the settings describing how to generate types using NSwag
     /// </summary>
     public CodeGeneratorSettings? CodeGeneratorSettings { get; set; }
-    
+
     /// <summary>
     /// Set to <c>true</c> to apply tree-shaking to the OpenApi schema.
     /// This works in conjunction with <see cref="IncludeTags"/> and <see cref="IncludePathMatches"/>.
     /// </summary>
     public bool TrimUnusedSchema { get; set; }
-    
+
     /// <summary>
     /// Array of regular expressions that determine if a schema needs to be kept.
     /// This works in conjunction with <see cref="TrimUnusedSchema"/>.

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -416,6 +416,25 @@ public class SwaggerPetstoreTests
 
     [Theory]
     [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    public async Task Can_Build_Generated_Code_With_IObservableResponse(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings();
+        settings.ReturnIObservable = true;
+        var generateCode = await GenerateCode(version, filename, settings);
+        //cannot build without it because System.Reactive package has to be installed first
+        generateCode += @"
+namespace System.Reactive
+{
+    public class Unit{}
+}";
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Theory]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
 #if !DEBUG
     [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
     [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -32,6 +32,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             AddAcceptHeaders = !settings.NoAcceptHeaders,
             GenerateContracts = !settings.InterfaceOnly,
             ReturnIApiResponse = settings.ReturnIApiResponse,
+            ReturnIObservable = settings.ReturnIObservable,
             UseCancellationTokens = settings.UseCancellationTokens,
             GenerateOperationHeaders = !settings.NoOperationHeaders,
             UseIsoDateFormat = settings.UseIsoDateFormat,
@@ -70,7 +71,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             var generator = await RefitGenerator.CreateAsync(refitGeneratorSettings);
             if (!settings.SkipValidation)
                 await ValidateOpenApiSpec(refitGeneratorSettings.OpenApiPath);
-            
+
             var code = generator.Generate().ReplaceLineEndings();
             AnsiConsole.MarkupLine($"[green]Length: {code.Length} bytes[/]");
 
@@ -99,7 +100,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                 AnsiConsole.MarkupLine($"[red]Exception:{Crlf}{exception.GetType()}[/]");
                 AnsiConsole.MarkupLine($"[yellow]Stack Trace:{Crlf}{exception.StackTrace}[/]");
             }
-            
+
             AnsiConsole.MarkupLine("[yellow]#############################################################################[/]");
             AnsiConsole.MarkupLine("[yellow]#  Consider reporting the problem if you are unable to resolve it yourself  #[/]");
             AnsiConsole.MarkupLine("[yellow]#  https://github.com/christianhelle/refitter/issues                        #[/]");

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -50,6 +50,11 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool ReturnIApiResponse { get; set; }
 
+    [Description("Return IObservable instead of Task")]
+    [CommandOption("--use-observable-response")]
+    [DefaultValue(false)]
+    public bool ReturnIObservable { get; set; }
+
     [Description("Set the accessibility of the generated types to 'internal'")]
     [CommandOption("--internal")]
     [DefaultValue(false)]
@@ -109,7 +114,7 @@ public sealed class Settings : CommandSettings
     [CommandOption("--operation-name-template")]
     [DefaultValue(null)]
     public string? OperationNameTemplate { get; internal set; }
-    
+
     [Description("Generate nullable parameters as optional parameters")]
     [CommandOption("--optional-nullable-parameters")]
     [DefaultValue(false)]
@@ -119,7 +124,7 @@ public sealed class Settings : CommandSettings
     [CommandOption("--trim-unused-schema")]
     [DefaultValue(false)]
     public bool TrimUnusedSchema { get; set; }
-    
+
     [Description("Force to keep matching schema, uses regular expressions. Use together with \"--trim-unused-schema\". Can be set multiple times.")]
     [CommandOption("--keep-schema")]
     [DefaultValue(new string[0])]
@@ -134,7 +139,7 @@ public sealed class Settings : CommandSettings
     [CommandOption("--skip-default-additional-properties")]
     [DefaultValue(false)]
     public bool SkipDefaultAdditionalProperties { get; set; }
-    
+
     [Description("""
                  The NSwag IOperationNameGenerator implementation to use. 
                  May be one of: 


### PR DESCRIPTION
Refit supports also IObservable reactive response type in interfaces so I added this feature to Refitter because it was missing. 
I added property ReturnIApiResponse to Settings and RefitGeneratorSettings
It replaces System.Threading.Task import by System.Reactive and it generates IObservable<Unit> instead of Task and IObservable<> instead of Task<>. 
I added one unit test to test generated output is compilable. I had to add Unit class manually to mock missing System.Reactive.Unit class.