### PR TITLE
Tweak xml docs

### DIFF
--- a/src/Refitter.Core/XmlDocumentationGenerator.cs
+++ b/src/Refitter.Core/XmlDocumentationGenerator.cs
@@ -177,16 +177,38 @@ public class XmlDocumentationGenerator
     {
         var description = new StringBuilder(text);
         var responseList = responses.ToList();
+
         if (!this._settings.GenerateStatusCodeComments || !responseList.Any())
             return description.Append(".").ToString();
 
-        description.Append(":");
+        description.AppendLine(":")
+            .AppendLine("<list type=\"table\">")
+            .AppendLine("<listheader>")
+            .AppendLine("<term>Status</term>")
+            .AppendLine("<description>Description</description>")
+            .AppendLine("</listheader>");
+
         foreach (var response in responseList)
         {
-            description.AppendLine().Append(response.StatusCode);
+            description
+                .AppendLine("<item>")
+                .Append("<term>")
+                .Append(response.StatusCode)
+                .AppendLine("</term>");
+
             if (!string.IsNullOrWhiteSpace(response.ExceptionDescription))
-                description.Append(": ").Append(response.ExceptionDescription);
+            {
+                description
+                    .Append("<description>")
+                    .Append(response.ExceptionDescription)
+                    .AppendLine("</description>");
+            }
+
+            description.AppendLine("</item>");
         }
+
+        description
+            .Append("</list>");
 
         return description.ToString();
     }

--- a/src/Refitter.Core/XmlDocumentationGenerator.cs
+++ b/src/Refitter.Core/XmlDocumentationGenerator.cs
@@ -92,7 +92,7 @@ public class XmlDocumentationGenerator
             }
 
             this.AppendXmlCommentBlock(
-                "throws",
+                "exception",
                 this.BuildErrorDescription(method.Responses),
                 code,
                 new Dictionary<string, string> { ["cref"] = "ApiException" });

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/Refitter.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/Refitter.g.cs
@@ -17,12 +17,27 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>Update an existing pet by Id</remarks>
         /// <param name="body">Update an existent pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// 405: Validation exception
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Validation exception</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Put("/pet")]
         Task<Pet> UpdatePet([Body] Pet body);
@@ -31,10 +46,19 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>Add a new pet to the store</remarks>
         /// <param name="body">Create a new pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Post("/pet")]
         Task<Pet> AddPet([Body] Pet body);
@@ -43,10 +67,19 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>Multiple status values can be provided with comma separated strings</remarks>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid status value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid status value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
@@ -55,10 +88,19 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</remarks>
         /// <param name="tags">Tags to filter by</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid tag value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid tag value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
@@ -67,11 +109,23 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>Returns a single pet</remarks>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
@@ -81,20 +135,38 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <param name="name">Name of pet that needs to be updated</param>
         /// <param name="status">Status of pet that needs to be updated</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
         /// <summary>Deletes a pet</summary>
         /// <param name="petId">Pet id to delete</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid pet value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid pet value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -103,7 +175,16 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <param name="additionalMetadata">Additional Metadata</param>
         /// <returns>
         /// A <see cref="Task"/> representing the <see cref="IApiResponse"/> instance containing the result:
-        /// 200: successful operation
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>200</term>
+        /// <description>successful operation</description>
+        /// </item>
+        /// </list>
         /// </returns>
         [Headers("Accept: application/json")]
         [Post("/pet/{petId}/uploadImage")]
@@ -112,7 +193,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <summary>Returns pet inventories by status</summary>
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/json")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
@@ -120,10 +201,19 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <summary>Place an order for a pet</summary>
         /// <remarks>Place a new order in the store</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Post("/store/order")]
         Task<Order> PlaceOrder([Body] Order body);
@@ -132,11 +222,23 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
@@ -145,11 +247,23 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -157,7 +271,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/json, application/xml")]
         [Post("/user")]
         Task CreateUser([Body] User body);
@@ -165,7 +279,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <summary>Creates list of users with given input array</summary>
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/xml, application/json")]
         [Post("/user/createWithList")]
         Task<User> CreateUsersWithListInput([Body] IEnumerable<User> body);
@@ -174,28 +288,49 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username/password supplied
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username/password supplied</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Get("/user/logout")]
         Task LogoutUser();
 
         /// <summary>Get user by user name</summary>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
@@ -205,7 +340,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <param name="username">name that need to be deleted</param>
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Put("/user/{username}")]
         Task UpdateUser(string username, [Body] User body);
 
@@ -213,11 +348,23 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="username">The name that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
@@ -20,12 +20,27 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>Update an existing pet by Id</remarks>
         /// <param name="body">Update an existent pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// 405: Validation exception
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Validation exception</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Put("/pet")]
         Task<Pet> Execute([Body] Pet body);
     }
@@ -38,10 +53,19 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>Add a new pet to the store</remarks>
         /// <param name="body">Create a new pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Post("/pet")]
         Task<Pet> Execute([Body] Pet body);
     }
@@ -54,10 +78,19 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>Multiple status values can be provided with comma separated strings</remarks>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid status value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid status value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> Execute([Query] Status? status);
     }
@@ -70,10 +103,19 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</remarks>
         /// <param name="tags">Tags to filter by</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid tag value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid tag value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> Execute([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
     }
@@ -86,11 +128,23 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>Returns a single pet</remarks>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/pet/{petId}")]
         Task<Pet> Execute(long petId);
     }
@@ -104,10 +158,19 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <param name="name">Name of pet that needs to be updated</param>
         /// <param name="status">Status of pet that needs to be updated</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Post("/pet/{petId}")]
         Task Execute(long petId, [Query] string name, [Query] string status);
     }
@@ -119,10 +182,19 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <summary>Deletes a pet</summary>
         /// <param name="petId">Pet id to delete</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid pet value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid pet value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/pet/{petId}")]
         Task Execute(long petId, [Header("api_key")] string api_key);
     }
@@ -136,7 +208,16 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <param name="additionalMetadata">Additional Metadata</param>
         /// <returns>
         /// A <see cref="Task"/> representing the <see cref="IApiResponse"/> instance containing the result:
-        /// 200: successful operation
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>200</term>
+        /// <description>successful operation</description>
+        /// </item>
+        /// </list>
         /// </returns>
         [Post("/pet/{petId}/uploadImage")]
         Task<ApiResponse> Execute(long petId, [Query] string additionalMetadata,  StreamPart body);
@@ -149,7 +230,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <summary>Returns pet inventories by status</summary>
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> Execute();
     }
@@ -161,10 +242,19 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <summary>Place an order for a pet</summary>
         /// <remarks>Place a new order in the store</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Post("/store/order")]
         Task<Order> Execute([Body] Order body);
     }
@@ -177,11 +267,23 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/store/order/{orderId}")]
         Task<Order> Execute(long orderId);
     }
@@ -194,11 +296,23 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/store/order/{orderId}")]
         Task Execute(long orderId);
     }
@@ -211,7 +325,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Post("/user")]
         Task Execute([Body] User body);
     }
@@ -223,7 +337,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <summary>Creates list of users with given input array</summary>
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Post("/user/createWithList")]
         Task<User> Execute([Body] IEnumerable<User> body);
     }
@@ -236,10 +350,19 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username/password supplied
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username/password supplied</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/user/login")]
         Task<string> Execute([Query] string username, [Query] string password);
     }
@@ -250,7 +373,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     {
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Get("/user/logout")]
         Task Execute();
     }
@@ -262,11 +385,23 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <summary>Get user by user name</summary>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/user/{username}")]
         Task<User> Execute(string username);
     }
@@ -280,7 +415,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <param name="username">name that need to be deleted</param>
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Put("/user/{username}")]
         Task Execute(string username, [Body] User body);
     }
@@ -293,11 +428,23 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="username">The name that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/user/{username}")]
         Task Execute(string username);
     }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfacesByTag.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfacesByTag.g.cs
@@ -20,12 +20,27 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>Update an existing pet by Id</remarks>
         /// <param name="body">Update an existent pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// 405: Validation exception
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Validation exception</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Put("/pet")]
         Task<Pet> UpdatePet([Body] Pet body);
 
@@ -33,10 +48,19 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>Add a new pet to the store</remarks>
         /// <param name="body">Create a new pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Post("/pet")]
         Task<Pet> AddPet([Body] Pet body);
 
@@ -44,10 +68,19 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>Multiple status values can be provided with comma separated strings</remarks>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid status value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid status value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
 
@@ -55,10 +88,19 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</remarks>
         /// <param name="tags">Tags to filter by</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid tag value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid tag value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
 
@@ -66,11 +108,23 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>Returns a single pet</remarks>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -79,20 +133,38 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <param name="name">Name of pet that needs to be updated</param>
         /// <param name="status">Status of pet that needs to be updated</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
         /// <summary>Deletes a pet</summary>
         /// <param name="petId">Pet id to delete</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid pet value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid pet value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -101,7 +173,16 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <param name="additionalMetadata">Additional Metadata</param>
         /// <returns>
         /// A <see cref="Task"/> representing the <see cref="IApiResponse"/> instance containing the result:
-        /// 200: successful operation
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>200</term>
+        /// <description>successful operation</description>
+        /// </item>
+        /// </list>
         /// </returns>
         [Post("/pet/{petId}/uploadImage")]
         Task<ApiResponse> UploadFile(long petId, [Query] string additionalMetadata,  StreamPart body);
@@ -114,17 +195,26 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <summary>Returns pet inventories by status</summary>
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
         /// <summary>Place an order for a pet</summary>
         /// <remarks>Place a new order in the store</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Post("/store/order")]
         Task<Order> PlaceOrder([Body] Order body);
 
@@ -132,11 +222,23 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -144,11 +246,23 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
     }
@@ -161,14 +275,14 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Post("/user")]
         Task CreateUser([Body] User body);
 
         /// <summary>Creates list of users with given input array</summary>
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Post("/user/createWithList")]
         Task<User> CreateUsersWithListInput([Body] IEnumerable<User> body);
 
@@ -176,27 +290,48 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username/password supplied
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username/password supplied</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Get("/user/logout")]
         Task LogoutUser();
 
         /// <summary>Get user by user name</summary>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -205,7 +340,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <param name="username">name that need to be deleted</param>
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Put("/user/{username}")]
         Task UpdateUser(string username, [Body] User body);
 
@@ -213,11 +348,23 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="username">The name that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
     }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreOptionalParameters.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreOptionalParameters.g.cs
@@ -18,12 +18,27 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>Update an existing pet by Id</remarks>
         /// <param name="body">Update an existent pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// 405: Validation exception
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Validation exception</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Put("/pet")]
         Task<Pet> UpdatePet([Body] Pet body);
@@ -32,10 +47,19 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>Add a new pet to the store</remarks>
         /// <param name="body">Create a new pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Post("/pet")]
         Task<Pet> AddPet([Body] Pet body);
@@ -44,10 +68,19 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>Multiple status values can be provided with comma separated strings</remarks>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid status value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid status value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status = default);
@@ -56,10 +89,19 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</remarks>
         /// <param name="tags">Tags to filter by</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid tag value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid tag value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string>? tags = default);
@@ -68,11 +110,23 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>Returns a single pet</remarks>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
@@ -82,20 +136,38 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <param name="name">Name of pet that needs to be updated</param>
         /// <param name="status">Status of pet that needs to be updated</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string? name = default, [Query] string? status = default);
 
         /// <summary>Deletes a pet</summary>
         /// <param name="petId">Pet id to delete</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid pet value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid pet value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string? api_key = default);
 
@@ -104,7 +176,16 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <param name="additionalMetadata">Additional Metadata</param>
         /// <returns>
         /// A <see cref="Task"/> representing the <see cref="IApiResponse"/> instance containing the result:
-        /// 200: successful operation
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>200</term>
+        /// <description>successful operation</description>
+        /// </item>
+        /// </list>
         /// </returns>
         [Headers("Accept: application/json")]
         [Post("/pet/{petId}/uploadImage")]
@@ -113,7 +194,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <summary>Returns pet inventories by status</summary>
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/json")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
@@ -121,10 +202,19 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <summary>Place an order for a pet</summary>
         /// <remarks>Place a new order in the store</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Post("/store/order")]
         Task<Order> PlaceOrder([Body] Order? body = default);
@@ -133,11 +223,23 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
@@ -146,11 +248,23 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -158,7 +272,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/json, application/xml")]
         [Post("/user")]
         Task CreateUser([Body] User? body = default);
@@ -166,7 +280,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <summary>Creates list of users with given input array</summary>
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/xml, application/json")]
         [Post("/user/createWithList")]
         Task<User> CreateUsersWithListInput([Body] IEnumerable<User>? body = default);
@@ -175,28 +289,49 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username/password supplied
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username/password supplied</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string? username = default, [Query] string? password = default);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Get("/user/logout")]
         Task LogoutUser();
 
         /// <summary>Get user by user name</summary>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
@@ -206,7 +341,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <param name="username">name that need to be deleted</param>
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Put("/user/{username}")]
         Task UpdateUser(string username, [Body] User? body = default);
 
@@ -214,11 +349,23 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="username">The name that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterface.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterface.g.cs
@@ -17,12 +17,27 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>Update an existing pet by Id</remarks>
         /// <param name="body">Update an existent pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// 405: Validation exception
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Validation exception</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Put("/pet")]
         Task<Pet> UpdatePet([Body] Pet body);
@@ -31,10 +46,19 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>Add a new pet to the store</remarks>
         /// <param name="body">Create a new pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Post("/pet")]
         Task<Pet> AddPet([Body] Pet body);
@@ -43,10 +67,19 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>Multiple status values can be provided with comma separated strings</remarks>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid status value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid status value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
@@ -55,10 +88,19 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</remarks>
         /// <param name="tags">Tags to filter by</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid tag value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid tag value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
@@ -67,11 +109,23 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>Returns a single pet</remarks>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
@@ -81,20 +135,38 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <param name="name">Name of pet that needs to be updated</param>
         /// <param name="status">Status of pet that needs to be updated</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
         /// <summary>Deletes a pet</summary>
         /// <param name="petId">Pet id to delete</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid pet value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid pet value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -103,7 +175,16 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <param name="additionalMetadata">Additional Metadata</param>
         /// <returns>
         /// A <see cref="Task"/> representing the <see cref="IApiResponse"/> instance containing the result:
-        /// 200: successful operation
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>200</term>
+        /// <description>successful operation</description>
+        /// </item>
+        /// </list>
         /// </returns>
         [Headers("Accept: application/json")]
         [Post("/pet/{petId}/uploadImage")]
@@ -112,7 +193,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <summary>Returns pet inventories by status</summary>
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/json")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
@@ -120,10 +201,19 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <summary>Place an order for a pet</summary>
         /// <remarks>Place a new order in the store</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Post("/store/order")]
         Task<Order> PlaceOrder([Body] Order body);
@@ -132,11 +222,23 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
@@ -145,11 +247,23 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -157,7 +271,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/json, application/xml")]
         [Post("/user")]
         Task CreateUser([Body] User body);
@@ -165,7 +279,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <summary>Creates list of users with given input array</summary>
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/xml, application/json")]
         [Post("/user/createWithList")]
         Task<User> CreateUsersWithListInput([Body] IEnumerable<User> body);
@@ -174,28 +288,49 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username/password supplied
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username/password supplied</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Get("/user/logout")]
         Task LogoutUser();
 
         /// <summary>Get user by user name</summary>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
@@ -205,7 +340,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <param name="username">name that need to be deleted</param>
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Put("/user/{username}")]
         Task UpdateUser(string username, [Body] User body);
 
@@ -213,11 +348,23 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="username">The name that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/CustomGenerated/CustomGenerated.cs
+++ b/src/Refitter.SourceGenerator.Tests/CustomGenerated/CustomGenerated.cs
@@ -19,12 +19,27 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>Update an existing pet by Id</remarks>
         /// <param name="body">Update an existent pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// 405: Validation exception
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Validation exception</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Put("/pet")]
         Task<Pet> UpdatePet([Body] Pet body);
@@ -33,10 +48,19 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>Add a new pet to the store</remarks>
         /// <param name="body">Create a new pet in the store</param>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Post("/pet")]
         Task<Pet> AddPet([Body] Pet body);
@@ -45,10 +69,19 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>Multiple status values can be provided with comma separated strings</remarks>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid status value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid status value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
@@ -57,10 +90,19 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</remarks>
         /// <param name="tags">Tags to filter by</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid tag value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid tag value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
@@ -69,11 +111,23 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>Returns a single pet</remarks>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Pet not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Pet not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/xml, application/json")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
@@ -83,20 +137,38 @@ namespace Refitter.Tests.CustomGenerated
         /// <param name="name">Name of pet that needs to be updated</param>
         /// <param name="status">Status of pet that needs to be updated</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
         /// <summary>Deletes a pet</summary>
         /// <param name="petId">Pet id to delete</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid pet value
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid pet value</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -105,7 +177,16 @@ namespace Refitter.Tests.CustomGenerated
         /// <param name="additionalMetadata">Additional Metadata</param>
         /// <returns>
         /// A <see cref="Task"/> representing the <see cref="IApiResponse"/> instance containing the result:
-        /// 200: successful operation
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>200</term>
+        /// <description>successful operation</description>
+        /// </item>
+        /// </list>
         /// </returns>
         [Headers("Accept: application/json")]
         [Post("/pet/{petId}/uploadImage")]
@@ -114,7 +195,7 @@ namespace Refitter.Tests.CustomGenerated
         /// <summary>Returns pet inventories by status</summary>
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/json")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
@@ -122,10 +203,19 @@ namespace Refitter.Tests.CustomGenerated
         /// <summary>Place an order for a pet</summary>
         /// <remarks>Place a new order in the store</remarks>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 405: Invalid input
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>405</term>
+        /// <description>Invalid input</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Post("/store/order")]
         Task<Order> PlaceOrder([Body] Order body);
@@ -134,11 +224,23 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
@@ -147,11 +249,23 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid ID supplied
-        /// 404: Order not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid ID supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>Order not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -159,7 +273,7 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/json, application/xml")]
         [Post("/user")]
         Task CreateUser([Body] User body);
@@ -167,7 +281,7 @@ namespace Refitter.Tests.CustomGenerated
         /// <summary>Creates list of users with given input array</summary>
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Headers("Accept: application/xml, application/json")]
         [Post("/user/createWithList")]
         Task<User> CreateUsersWithListInput([Body] IEnumerable<User> body);
@@ -176,28 +290,49 @@ namespace Refitter.Tests.CustomGenerated
         /// <param name="username">The user name for login</param>
         /// <param name="password">The password for login in clear text</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username/password supplied
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username/password supplied</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Get("/user/logout")]
         Task LogoutUser();
 
         /// <summary>Get user by user name</summary>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <returns>successful operation</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Headers("Accept: application/json")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
@@ -207,7 +342,7 @@ namespace Refitter.Tests.CustomGenerated
         /// <param name="username">name that need to be deleted</param>
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">Thrown when the request returns a non-success status code.</throws>
+        /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
         [Put("/user/{username}")]
         Task UpdateUser(string username, [Body] User body);
 
@@ -215,11 +350,23 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>This can only be done by the logged in user.</remarks>
         /// <param name="username">The name that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
-        /// <throws cref="ApiException">
+        /// <exception cref="ApiException">
         /// Thrown when the request returns a non-success status code:
-        /// 400: Invalid username supplied
-        /// 404: User not found
-        /// </throws>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>400</term>
+        /// <description>Invalid username supplied</description>
+        /// </item>
+        /// <item>
+        /// <term>404</term>
+        /// <description>User not found</description>
+        /// </item>
+        /// </list>
+        /// </exception>
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.Tests/XmlDocumentationGeneratorTests.cs
+++ b/src/Refitter.Tests/XmlDocumentationGeneratorTests.cs
@@ -129,7 +129,7 @@ namespace Refitter.Tests
             var docs = new StringBuilder();
             var method = CreateOperationModel(new OpenApiOperation());
             this._generator.AppendMethodDocumentation(method, false, docs);
-            docs.ToString().Should().Contain("/// <throws cref=\"ApiException\">");
+            docs.ToString().Should().Contain("/// <exception cref=\"ApiException\">");
         }
 
         [Fact]
@@ -146,8 +146,8 @@ namespace Refitter.Tests
                 Responses = { ["400"] = new OpenApiResponse { Description = "TestResponse" } },
             });
             this._generator.AppendMethodDocumentation(method, false, docs);
-            docs.ToString().Should().Contain("/// <throws cref=\"ApiException\">")
-                .And.Contain("/// 400: TestResponse");
+            docs.ToString().Should().Contain("/// <exception cref=\"ApiException\">")
+                .And.Contain("<term>400</term>");
         }
 
         [Fact]
@@ -164,8 +164,8 @@ namespace Refitter.Tests
                 Responses = { ["400"] = new OpenApiResponse { Description = "TestResponse" } },
             });
             this._generator.AppendMethodDocumentation(method, false, docs);
-            docs.ToString().Should().Contain("/// <throws cref=\"ApiException\">")
-                .And.NotContain("/// 400: TestResponse");
+            docs.ToString().Should().Contain("/// <exception cref=\"ApiException\">")
+                .And.NotContain("<term>400</term>");
         }
 
         [Fact]
@@ -182,9 +182,9 @@ namespace Refitter.Tests
                 Responses = { ["400"] = new OpenApiResponse { Description = "TestResponse" } },
             });
             this._generator.AppendMethodDocumentation(method, true, docs);
-            docs.ToString().Should().NotContain("/// <throws cref=\"ApiException\">")
+            docs.ToString().Should().NotContain("/// <exception cref=\"ApiException\">")
                 .And.Contain("/// <returns>")
-                .And.Contain("/// 400: TestResponse");
+                .And.Contain("<term>400</term>");
         }
     }
 }


### PR DESCRIPTION
- Use the [recommended tag](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#document-members) "exception" instead of "throws"
- Format response status code list as a `<list type="table">`

Both of these somewhat improve the rendering of the generated comments in Visual Studio and Rider.

Before (Rider):
![image](https://github.com/christianhelle/refitter/assets/133910309/688efcbf-f45c-402d-ba40-af63b0ac8bcf)

After (Rider):
![image](https://github.com/christianhelle/refitter/assets/133910309/e3f90940-578a-48ac-ada4-135afa597ad1)

Before (Visual Studio):
![image](https://github.com/christianhelle/refitter/assets/133910309/0739de2a-9061-4abf-bb40-29a9bdf6608f)


After (Visual Studio):
![image](https://github.com/christianhelle/refitter/assets/133910309/0b1789c9-2834-44be-8a96-2ce196fc1d32)

The generated code is a little uglier due to the flat nested XML. One could avoid this by refactoring the string builder utility methods.
