### PR TITLE
Fix code generator settings that are not of type string/bool

### DIFF
--- a/src/Refitter.Core/CSharpClientGeneratorFactory.cs
+++ b/src/Refitter.Core/CSharpClientGeneratorFactory.cs
@@ -56,12 +56,6 @@ internal class CSharpClientGeneratorFactory(RefitGeneratorSettings settings, Ope
         var defaultInstance = new CodeGeneratorSettings();
         foreach (var property in source.GetType().GetProperties())
         {
-            if (property.PropertyType != typeof(string) &&
-                property.PropertyType != typeof(bool))
-            {
-                continue;
-            }
-
             var value = property.GetValue(source);
             if (value == null)
             {
@@ -74,7 +68,8 @@ internal class CSharpClientGeneratorFactory(RefitGeneratorSettings settings, Ope
             }
 
             var settingsProperty = destination.GetType().GetProperty(property.Name);
-            if (settingsProperty == null)
+            if (settingsProperty == null ||
+                !settingsProperty.PropertyType.IsAssignableFrom(property.PropertyType))
             {
                 continue;
             }

--- a/src/Refitter.Tests/CustomCSharpGeneratorSettingsTests.cs
+++ b/src/Refitter.Tests/CustomCSharpGeneratorSettingsTests.cs
@@ -115,6 +115,26 @@ public class CustomCSharpGeneratorSettingsTests
         generateCode.Should().Contain("System.Collection.Generic.IList<");
     }
 
+    [Theory]
+    [InlineAutoNSubstituteData(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [InlineAutoNSubstituteData(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    [InlineAutoNSubstituteData(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]
+    [InlineAutoNSubstituteData(SampleOpenSpecifications.SwaggerPetstoreYamlV2, "SwaggerPetstore.yaml")]
+    public async Task Can_Generate_With_ExcludedTypeNames(
+        SampleOpenSpecifications version,
+        string filename)
+    {
+        var settings = new RefitGeneratorSettings();
+        settings.CodeGeneratorSettings = new CodeGeneratorSettings();
+        settings.CodeGeneratorSettings.ExcludedTypeNames = new[]
+        {
+            "User"
+        };
+        var generateCode = await GenerateCode(version, filename, settings);
+        generateCode.Should().NotBeNullOrWhiteSpace();
+        generateCode.Should().NotContain("class User");
+    }
+
     private static async Task<string> GenerateCode(
         SampleOpenSpecifications version,
         string filename,


### PR DESCRIPTION
Fixes #334.  

@christianhelle , I wasn't sure why only string/bool properties are mapped into NSwag.  I added a new check to ensure property types are compatible in hope this may mitigate the problem you were trying to avoid.