### PR TITLE
Fix missing OpenAPI validation result output

### DIFF
--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -107,13 +107,14 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             {
                 AnsiConsole.MarkupLine($"[red]Error: {exception.Message}[/]");
                 AnsiConsole.MarkupLine($"[red]Exception: {exception.GetType()}[/]");
-                AnsiConsole.MarkupLine($"[yellow]Stack Trace:{Crlf}{exception.StackTrace}[/]");               
+                AnsiConsole.MarkupLine($"[yellow]Stack Trace:{Crlf}{exception.StackTrace}[/]");
                 AnsiConsole.WriteLine();
             }
 
             if (!settings.SkipValidation)
             {
-                AnsiConsole.MarkupLine($"[yellow]Try using the --skip-validation argument.[/]");
+                AnsiConsole.MarkupLine("[yellow]Try using the --skip-validation argument.[/]");
+                AnsiConsole.WriteLine();
             }
 
             AnsiConsole.MarkupLine("[yellow]#############################################################################[/]");

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -100,7 +100,6 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             if (exception is OpenApiUnsupportedSpecVersionException unsupportedSpecVersionException)
             {
                 AnsiConsole.MarkupLine($"[red]Unsupported OpenAPI version: {unsupportedSpecVersionException.SpecificationVersion}[/]");
-                AnsiConsole.MarkupLine($"[yellow]Try using the --skip-validation argument.[/]");                
                 AnsiConsole.WriteLine();
             }
 
@@ -110,6 +109,11 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                 AnsiConsole.MarkupLine($"[red]Exception: {exception.GetType()}[/]");
                 AnsiConsole.MarkupLine($"[yellow]Stack Trace:{Crlf}{exception.StackTrace}[/]");               
                 AnsiConsole.WriteLine();
+            }
+
+            if (!settings.SkipValidation)
+            {
+                AnsiConsole.MarkupLine($"[yellow]Try using the --skip-validation argument.[/]");
             }
 
             AnsiConsole.MarkupLine("[yellow]#############################################################################[/]");

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -185,7 +185,17 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         }
         catch
         {
-            // ignored
+            var originalColor = Console.ForegroundColor;
+            Console.ForegroundColor = color switch
+            {
+                "red" => ConsoleColor.Red,
+                "yellow" => ConsoleColor.Yellow,
+                _ => originalColor
+            };
+
+            Console.WriteLine($"{label}:{Crlf}{error}{Crlf}");
+
+            Console.ForegroundColor = originalColor;
         }
     }
 }


### PR DESCRIPTION
#### PR Classification
This pull request enhances error handling in the `GenerateCommand` class by providing more informative and visually distinct error messages to the console.

#### PR Summary
The `catch` block in the `GenerateCommand` class has been updated to improve error message visibility and information.
- In `GenerateCommand` class, a new variable `originalColor` is declared to store the current console color.
- The console color is then changed based on the `color` variable value.
- An error message, including the `label` and `error`, is written to the console.
- The console color is reset to the original color after the error message is displayed.
