### PR TITLE
Remove SonarAnalyzer.CSharp dependency

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -37,8 +37,4 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.26.0.92422" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This pull request removes the SonarAnalyzer.CSharp dependency from all projects