### PR TITLE
UsePolly deprecation warning banner

### DIFF
--- a/src/Refitter.Core/Settings/DependencyInjectionSettings.cs
+++ b/src/Refitter.Core/Settings/DependencyInjectionSettings.cs
@@ -21,9 +21,14 @@ public class DependencyInjectionSettings
 
     /// <summary>
     /// Set this to true to use Polly for transient fault handling.
+    /// This is deprecated. Use TransientErrorHandler instead.
     /// </summary>
     [Obsolete("Use TransientErrorHandler instead")]
-    public bool UsePolly { get; set; }
+    public bool UsePolly
+    {
+        get => TransientErrorHandler == TransientErrorHandler.Polly;
+        set => TransientErrorHandler = value ? TransientErrorHandler.Polly : TransientErrorHandler.None;
+    }
     
     /// <summary>
     /// Library to use for transient error handling

--- a/src/Refitter.Core/Settings/DependencyInjectionSettings.cs
+++ b/src/Refitter.Core/Settings/DependencyInjectionSettings.cs
@@ -42,6 +42,17 @@ public class DependencyInjectionSettings
 
     /// <summary>
     /// Default max retry count for transient error handling. Default is 6.
+    /// This is deprecated. Use MaxRetryCount instead.
+    /// </summary>
+    [Obsolete("Use MaxRetryCount instead")]
+    public int PollyMaxRetryCount
+    {
+        get => MaxRetryCount;
+        set => MaxRetryCount = value;
+    }
+
+    /// <summary>
+    /// Default max retry count for transient error handling. Default is 6.
     /// </summary>
     public int MaxRetryCount { get; set; } = 6;
 

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -68,6 +68,8 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                 var json = await File.ReadAllTextAsync(settings.SettingsFilePath);
                 refitGeneratorSettings = Serializer.Deserialize<RefitGeneratorSettings>(json);
                 refitGeneratorSettings.OpenApiPath = settings.OpenApiPath!;
+
+                ShowDeprecationWarning(refitGeneratorSettings);
             }
 
             var generator = await RefitGenerator.CreateAsync(refitGeneratorSettings);
@@ -117,14 +119,30 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                 AnsiConsole.WriteLine();
             }
 
-            AnsiConsole.MarkupLine("[yellow]#############################################################################[/]");
-            AnsiConsole.MarkupLine("[yellow]#  Consider reporting the problem if you are unable to resolve it yourself  #[/]");
-            AnsiConsole.MarkupLine("[yellow]#  https://github.com/christianhelle/refitter/issues                        #[/]");
-            AnsiConsole.MarkupLine("[yellow]#############################################################################[/]");
+            AnsiConsole.MarkupLine("[yellow]####################################################################[/]");
+            AnsiConsole.MarkupLine("[yellow]#  Consider reporting the problem if you are unable to resolve it  #[/]");
+            AnsiConsole.MarkupLine("[yellow]#  https://github.com/christianhelle/refitter/issues               #[/]");
+            AnsiConsole.MarkupLine("[yellow]####################################################################[/]");
             AnsiConsole.WriteLine();
 
             await Analytics.LogError(exception, settings);
             return exception.HResult;
+        }
+    }
+
+    private static void ShowDeprecationWarning(RefitGeneratorSettings refitGeneratorSettings)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        if (refitGeneratorSettings.DependencyInjectionSettings?.UsePolly is true)
+#pragma warning restore CS0618 // Type or member is obsolete
+        {
+            AnsiConsole.MarkupLine("[yellow]###############################################################[/]");
+            AnsiConsole.MarkupLine("[yellow]#  The 'usePolly' property in the settings file is deprecated #[/]");
+            AnsiConsole.MarkupLine("[yellow]#  and will be removed in the near future.                    #[/]");
+            AnsiConsole.MarkupLine("[yellow]#                                                             #[/]");
+            AnsiConsole.MarkupLine("[yellow]#  Use 'transientErrorHandler: Polly' instead                 #[/]");
+            AnsiConsole.MarkupLine("[yellow]###############################################################[/]");
+            AnsiConsole.WriteLine();
         }
     }
 

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -68,8 +68,6 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                 var json = await File.ReadAllTextAsync(settings.SettingsFilePath);
                 refitGeneratorSettings = Serializer.Deserialize<RefitGeneratorSettings>(json);
                 refitGeneratorSettings.OpenApiPath = settings.OpenApiPath!;
-
-                ShowDeprecationWarning(refitGeneratorSettings);
             }
 
             var generator = await RefitGenerator.CreateAsync(refitGeneratorSettings);
@@ -93,7 +91,8 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
 
             if (!settings.NoBanner)
                 DonationBanner();
-
+            
+            ShowDeprecationWarning(refitGeneratorSettings);
             return 0;
         }
         catch (Exception exception)

--- a/src/Refitter/SettingsValidator.cs
+++ b/src/Refitter/SettingsValidator.cs
@@ -51,18 +51,6 @@ public static class SettingsValidator
         Settings settings,
         RefitGeneratorSettings refitGeneratorSettings)
     {
-        if (refitGeneratorSettings.DependencyInjectionSettings is not null)
-        {
-#pragma warning disable CS0618 // Type or member is obsolete
-            if (refitGeneratorSettings.DependencyInjectionSettings.UsePolly)
-#pragma warning restore CS0618 // Type or member is obsolete
-            {
-                return ValidationResult.Error(
-                    "The 'usePolly' property in the settings file is deprecated. " +
-                    "Use 'transientErrorHandler' instead");
-            }
-        }
-        
         if (string.IsNullOrWhiteSpace(refitGeneratorSettings.OpenApiPath))
         {
             return GetValidationErrorForOpenApiPath();


### PR DESCRIPTION
This pull request updates the `UsePolly` property in the `DependencyInjectionSettings` class to be a calculated property that reads/writes the `TransientErrorHandler` property. Additionally, it updates the `PollyMaxRetryCount` property to be a calculated property that updates the `MaxRetryCount` property. The `UsePolly` property is deprecated and a deprecation warning is shown. The pull request also includes a warning banner at the end of the execution.