### PR TITLE
Add support for generating immutable records

### DIFF
--- a/src/Refitter.Core/CSharpClientGeneratorFactory.cs
+++ b/src/Refitter.Core/CSharpClientGeneratorFactory.cs
@@ -25,15 +25,15 @@ internal class CSharpClientGeneratorFactory(RefitGeneratorSettings settings, Ope
                 GenerateDtoTypes = true,
                 GenerateClientInterfaces = false,
                 GenerateExceptionClasses = false,
-                CodeGeneratorSettings =
-                {
-                    PropertyNameGenerator = new CustomCSharpPropertyNameGenerator(),
-                },
+                CodeGeneratorSettings = { PropertyNameGenerator = new CustomCSharpPropertyNameGenerator(), },
                 CSharpGeneratorSettings =
                 {
                     Namespace = settings.Namespace,
                     JsonLibrary = CSharpJsonLibrary.SystemTextJson,
                     TypeAccessModifier = settings.TypeAccessibility.ToString().ToLowerInvariant(),
+                    ClassStyle = settings.CodeGeneratorSettings?.GenerateNativeRecords is true
+                        ? CSharpClassStyle.Record
+                        : CSharpClassStyle.Poco,
                 }
             });
 

--- a/src/Refitter.Tests/CustomCSharpGeneratorSettingsTests.cs
+++ b/src/Refitter.Tests/CustomCSharpGeneratorSettingsTests.cs
@@ -135,6 +135,22 @@ public class CustomCSharpGeneratorSettingsTests
         generateCode.Should().NotContain("class User");
     }
 
+    [Theory]
+    [InlineAutoNSubstituteData(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [InlineAutoNSubstituteData(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    [InlineAutoNSubstituteData(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]
+    [InlineAutoNSubstituteData(SampleOpenSpecifications.SwaggerPetstoreYamlV2, "SwaggerPetstore.yaml")]
+    public async Task Can_Generate_With_Immutable_Records(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings();
+        settings.ReturnIApiResponse = true;
+        settings.CodeGeneratorSettings = new CodeGeneratorSettings { GenerateNativeRecords = true, };
+        var generateCode = await GenerateCode(version, filename, settings);
+        generateCode.Should().Contain("record Pet");
+        generateCode.Should().Contain("Pet(");
+        generateCode.Should().Contain("[JsonConstructor]");
+    }
+
     private static async Task<string> GenerateCode(
         SampleOpenSpecifications version,
         string filename,

--- a/test/MauiExample/petstore.refitter
+++ b/test/MauiExample/petstore.refitter
@@ -7,5 +7,11 @@
     "transientErrorHandler": "Polly",
     "maxRetryCount": 3,
     "firstBackoffRetryInSeconds": 0.5
+  },  
+  "codeGeneratorSettings": {
+    "dateType": "System.DateTime",
+    "dateTimeType": "System.DateTime",
+    "arrayType": "System.Collections.Generic.IList",
+    "generateNativeRecords": true
   }
 }

--- a/test/MinimalApi/petstore.refitter
+++ b/test/MinimalApi/petstore.refitter
@@ -8,5 +8,11 @@
     "transientErrorHandler": "Polly",
     "maxRetryCount": 3,
     "firstBackoffRetryInSeconds": 0.5
+  },  
+  "codeGeneratorSettings": {
+    "dateType": "System.DateTime",
+    "dateTimeType": "System.DateTime",
+    "arrayType": "System.Collections.Generic.IList",
+    "generateNativeRecords": true
   }
 }

--- a/test/petstore.refitter
+++ b/test/petstore.refitter
@@ -19,5 +19,5 @@
     "arrayType": "System.Collections.Generic.IList"
   },
   "operationNameGenerator": "default",
-  "typeAccessibility": "internal"
+  "typeAccessibility": "public"
 }


### PR DESCRIPTION
This implements #407

This pull request updates the `CSharpClientGeneratorFactory` to use `CSharpClassStyle.Record` when the `GenerateNativeRecords` setting is true. This change adds proper support for generating contracts as immutable records

Here's an example of a generated immutable record using the changes in this pull request

```csharp
[System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))")]
public partial record Tag
{
    [JsonConstructor]
    public Tag(long @id, string @name)
    {
        this.Id = @id;
        this.Name = @name;
    }

    [JsonPropertyName("id")]
    public long Id { get; init; }

    [JsonPropertyName("name")]
    public string Name { get; init; }

    private IDictionary<string, object> _additionalProperties;

    [JsonExtensionData]
    public IDictionary<string, object> AdditionalProperties
    {
        get { return _additionalProperties ?? (_additionalProperties = new Dictionary<string, object>()); }
        set { _additionalProperties = value; }
    }
}
```

using the following .refitter settings file

```json
{
  "openApiPath": "https://petstore3.swagger.io/api/v3/openapi.json",
  "codeGeneratorSettings": {
    "generateNativeRecords": true
  }
}
```