### PR TITLE
Add optional RefitterSettings in generated IoC registration code

### DIFF
--- a/src/Refitter.Core/DependencyInjectionGenerator.cs
+++ b/src/Refitter.Core/DependencyInjectionGenerator.cs
@@ -16,8 +16,19 @@ internal static class DependencyInjectionGenerator
         var code = new StringBuilder();
 
         var methodDeclaration = string.IsNullOrEmpty(iocSettings.BaseUrl)
-            ? $"public static IServiceCollection {iocSettings.ExtensionMethodName}(this IServiceCollection services, Uri baseUrl, Action<IHttpClientBuilder>? builder = default, RefitSettings? settings = default)"
-            : $"public static IServiceCollection {iocSettings.ExtensionMethodName}(this IServiceCollection services, Action<IHttpClientBuilder>? builder = default, RefitSettings? settings = default)";
+            ? $"""
+               public static IServiceCollection {iocSettings.ExtensionMethodName}(
+                           this IServiceCollection services, 
+                           Uri baseUrl, 
+                           Action<IHttpClientBuilder>? builder = default, 
+                           RefitSettings? settings = default)
+               """
+            : $"""
+               public static IServiceCollection {iocSettings.ExtensionMethodName}(
+                           this IServiceCollection services, 
+                           Action<IHttpClientBuilder>? builder = default, 
+                           RefitSettings? settings = default)
+               """;
         
         var configureRefitClient = string.IsNullOrEmpty(iocSettings.BaseUrl)
             ? ".ConfigureHttpClient(c => c.BaseAddress = baseUrl)"

--- a/src/Refitter.Core/DependencyInjectionGenerator.cs
+++ b/src/Refitter.Core/DependencyInjectionGenerator.cs
@@ -16,8 +16,8 @@ internal static class DependencyInjectionGenerator
         var code = new StringBuilder();
 
         var methodDeclaration = string.IsNullOrEmpty(iocSettings.BaseUrl)
-            ? $"public static IServiceCollection {iocSettings.ExtensionMethodName}(this IServiceCollection services, Uri baseUrl, Action<IHttpClientBuilder>? builder = default)"
-            : $"public static IServiceCollection {iocSettings.ExtensionMethodName}(this IServiceCollection services, Action<IHttpClientBuilder>? builder = default)";
+            ? $"public static IServiceCollection {iocSettings.ExtensionMethodName}(this IServiceCollection services, Uri baseUrl, Action<IHttpClientBuilder>? builder = default, RefitSettings? settings = default)"
+            : $"public static IServiceCollection {iocSettings.ExtensionMethodName}(this IServiceCollection services, Action<IHttpClientBuilder>? builder = default, RefitSettings? settings = default)";
         
         var configureRefitClient = string.IsNullOrEmpty(iocSettings.BaseUrl)
             ? ".ConfigureHttpClient(c => c.BaseAddress = baseUrl)"
@@ -65,7 +65,7 @@ internal static class DependencyInjectionGenerator
             code.Append(
                 $$"""
                               var {{clientBuilderName}} = services
-                                  .AddRefitClient<{{interfaceName}}>()
+                                  .AddRefitClient<{{interfaceName}}>(settings)
                                   {{configureRefitClient}}
                   """);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
@@ -464,10 +464,10 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
     public static partial class IServiceCollectionExtensions
     {
-        public static IServiceCollection ConfigureRefitClients(this IServiceCollection services, Uri baseUrl, Action<IHttpClientBuilder>? builder = default)
+        public static IServiceCollection ConfigureRefitClients(this IServiceCollection services, Uri baseUrl, Action<IHttpClientBuilder>? builder = default, RefitSettings? settings = default)
         {
             var clientBuilderIUpdatePetEndpoint = services
-                .AddRefitClient<IUpdatePetEndpoint>()
+                .AddRefitClient<IUpdatePetEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -475,7 +475,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIUpdatePetEndpoint);
 
             var clientBuilderIAddPetEndpoint = services
-                .AddRefitClient<IAddPetEndpoint>()
+                .AddRefitClient<IAddPetEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -483,7 +483,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIAddPetEndpoint);
 
             var clientBuilderIFindPetsByStatusEndpoint = services
-                .AddRefitClient<IFindPetsByStatusEndpoint>()
+                .AddRefitClient<IFindPetsByStatusEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -491,7 +491,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIFindPetsByStatusEndpoint);
 
             var clientBuilderIFindPetsByTagsEndpoint = services
-                .AddRefitClient<IFindPetsByTagsEndpoint>()
+                .AddRefitClient<IFindPetsByTagsEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -499,7 +499,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIFindPetsByTagsEndpoint);
 
             var clientBuilderIGetPetByIdEndpoint = services
-                .AddRefitClient<IGetPetByIdEndpoint>()
+                .AddRefitClient<IGetPetByIdEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -507,7 +507,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIGetPetByIdEndpoint);
 
             var clientBuilderIUpdatePetWithFormEndpoint = services
-                .AddRefitClient<IUpdatePetWithFormEndpoint>()
+                .AddRefitClient<IUpdatePetWithFormEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -515,7 +515,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIUpdatePetWithFormEndpoint);
 
             var clientBuilderIDeletePetEndpoint = services
-                .AddRefitClient<IDeletePetEndpoint>()
+                .AddRefitClient<IDeletePetEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -523,7 +523,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIDeletePetEndpoint);
 
             var clientBuilderIUploadFileEndpoint = services
-                .AddRefitClient<IUploadFileEndpoint>()
+                .AddRefitClient<IUploadFileEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -531,7 +531,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIUploadFileEndpoint);
 
             var clientBuilderIGetInventoryEndpoint = services
-                .AddRefitClient<IGetInventoryEndpoint>()
+                .AddRefitClient<IGetInventoryEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -539,7 +539,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIGetInventoryEndpoint);
 
             var clientBuilderIPlaceOrderEndpoint = services
-                .AddRefitClient<IPlaceOrderEndpoint>()
+                .AddRefitClient<IPlaceOrderEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -547,7 +547,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIPlaceOrderEndpoint);
 
             var clientBuilderIGetOrderByIdEndpoint = services
-                .AddRefitClient<IGetOrderByIdEndpoint>()
+                .AddRefitClient<IGetOrderByIdEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -555,7 +555,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIGetOrderByIdEndpoint);
 
             var clientBuilderIDeleteOrderEndpoint = services
-                .AddRefitClient<IDeleteOrderEndpoint>()
+                .AddRefitClient<IDeleteOrderEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -563,7 +563,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIDeleteOrderEndpoint);
 
             var clientBuilderICreateUserEndpoint = services
-                .AddRefitClient<ICreateUserEndpoint>()
+                .AddRefitClient<ICreateUserEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -571,7 +571,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderICreateUserEndpoint);
 
             var clientBuilderICreateUsersWithListInputEndpoint = services
-                .AddRefitClient<ICreateUsersWithListInputEndpoint>()
+                .AddRefitClient<ICreateUsersWithListInputEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -579,7 +579,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderICreateUsersWithListInputEndpoint);
 
             var clientBuilderILoginUserEndpoint = services
-                .AddRefitClient<ILoginUserEndpoint>()
+                .AddRefitClient<ILoginUserEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -587,7 +587,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderILoginUserEndpoint);
 
             var clientBuilderILogoutUserEndpoint = services
-                .AddRefitClient<ILogoutUserEndpoint>()
+                .AddRefitClient<ILogoutUserEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -595,7 +595,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderILogoutUserEndpoint);
 
             var clientBuilderIGetUserByNameEndpoint = services
-                .AddRefitClient<IGetUserByNameEndpoint>()
+                .AddRefitClient<IGetUserByNameEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -603,7 +603,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIGetUserByNameEndpoint);
 
             var clientBuilderIUpdateUserEndpoint = services
-                .AddRefitClient<IUpdateUserEndpoint>()
+                .AddRefitClient<IUpdateUserEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -611,7 +611,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
             builder?.Invoke(clientBuilderIUpdateUserEndpoint);
 
             var clientBuilderIDeleteUserEndpoint = services
-                .AddRefitClient<IDeleteUserEndpoint>()
+                .AddRefitClient<IDeleteUserEndpoint>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
@@ -733,10 +733,10 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
 
     public static partial class IServiceCollectionExtensions
     {
-        public static IServiceCollection ConfigureRefitClients(this IServiceCollection services, Action<IHttpClientBuilder>? builder = default)
+        public static IServiceCollection ConfigureRefitClients(this IServiceCollection services, Action<IHttpClientBuilder>? builder = default, RefitSettings? settings = default)
         {
             var clientBuilderISwaggerPetstoreInterfaceWithHttpResilience = services
-                .AddRefitClient<ISwaggerPetstoreInterfaceWithHttpResilience>()
+                .AddRefitClient<ISwaggerPetstoreInterfaceWithHttpResilience>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"));
 
             clientBuilderISwaggerPetstoreInterfaceWithHttpResilience

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
@@ -735,10 +735,10 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
 
     public static partial class IServiceCollectionExtensions
     {
-        public static IServiceCollection ConfigureRefitClients(this IServiceCollection services, Action<IHttpClientBuilder>? builder = default)
+        public static IServiceCollection ConfigureRefitClients(this IServiceCollection services, Action<IHttpClientBuilder>? builder = default, RefitSettings? settings = default)
         {
             var clientBuilderISwaggerPetstoreInterface = services
-                .AddRefitClient<ISwaggerPetstoreInterface>()
+                .AddRefitClient<ISwaggerPetstoreInterface>(settings)
                 .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();

--- a/src/Refitter.Tests/DependencyInjectionGeneratorWithMicrosoftHttpResilienceTests.cs
+++ b/src/Refitter.Tests/DependencyInjectionGeneratorWithMicrosoftHttpResilienceTests.cs
@@ -33,8 +33,8 @@ public class DependencyInjectionGeneratorWithMicrosoftHttpResilienceTests
                 "IStoreApi"
             });
 
-        code.Should().Contain("AddRefitClient<IPetApi>()");
-        code.Should().Contain("AddRefitClient<IStoreApi>()");
+        code.Should().Contain("AddRefitClient<IPetApi>(settings)");
+        code.Should().Contain("AddRefitClient<IStoreApi>(settings)");
     }
 
     [Fact]

--- a/src/Refitter.Tests/DependencyInjectionGeneratorWithPollyTests.cs
+++ b/src/Refitter.Tests/DependencyInjectionGeneratorWithPollyTests.cs
@@ -35,8 +35,8 @@ public class DependencyInjectionGeneratorWithPollyTests
                 "IStoreApi"
             });
 
-        code.Should().Contain("AddRefitClient<IPetApi>()");
-        code.Should().Contain("AddRefitClient<IStoreApi>()");
+        code.Should().Contain("AddRefitClient<IPetApi>(settings)");
+        code.Should().Contain("AddRefitClient<IStoreApi>(settings)");
     }
 
     [Fact]


### PR DESCRIPTION
This pull request adds support for optional `RefitterSettings` in the generated IoC registration code. Previously, the generated code only supported basic configuration options. With this change, developers can now pass in a `RefitterSettings` object to customize the behavior of the generated code. This provides more flexibility and control over the generated code.

With these changes, the following `.refitter` settings file:

```json
{
  "openApiPath": "../OpenAPI/v3.0/petstore.json",
  "namespace": "Petstore",
  "dependencyInjectionSettings": {
    "baseUrl": "https://petstore3.swagger.io/api/v3",
    "httpMessageHandlers": [ "TelemetryDelegatingHandler" ],
    "transientErrorHandler": "Polly",
    "maxRetryCount": 3,
    "firstBackoffRetryInSeconds": 0.5
  }
}
```

now generates:

```csharp
public static IServiceCollection ConfigureRefitClients(
    this IServiceCollection services, 
    Action<IHttpClientBuilder>? builder = default, 
    RefitSettings? settings = default)
{
    var clientBuilderISwaggerPetstore = services
        .AddRefitClient<ISwaggerPetstore>(settings)
        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
        .AddHttpMessageHandler<TelemetryDelegatingHandler>();

    clientBuilderISwaggerPetstore
        .AddPolicyHandler(
            HttpPolicyExtensions
                .HandleTransientHttpError()
                .WaitAndRetryAsync(
                    Backoff.DecorrelatedJitterBackoffV2(
                        TimeSpan.FromSeconds(0.5),
                        3)));

    builder?.Invoke(clientBuilderISwaggerPetstore);

    return services;
}
```