### PR TITLE
Add Dependency Injection section to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1671,6 +1671,7 @@ app.UseSwagger();
 app.Run();
 ```
 
+
 .NET Core supports registering the generated `ISwaggerPetstore` interface via `HttpClientFactory`
 
 The following request to the API above
@@ -1690,6 +1691,133 @@ Returns a response that looks something like this:
   "status": "Sold"
 }
 ```
+
+## Dependency Injection
+
+Refitter supports generating bootstrapping code that allows the user to conveniently configure all generated Refit interfaces by calling a single extension method to `IServiceCollection`.
+
+This is enabled through the `.refitter` settings file like this:
+
+```json
+{
+  "openApiPath": "../OpenAPI/v3.0/petstore.json",
+  "namespace": "Petstore",
+  "dependencyInjectionSettings": {
+    "baseUrl": "https://petstore3.swagger.io/api/v3",
+    "httpMessageHandlers": [ "TelemetryDelegatingHandler" ],
+    "transientErrorHandler": "Polly",
+    "maxRetryCount": 3,
+    "firstBackoffRetryInSeconds": 0.5
+  }
+}
+```
+
+which will generate an extension method to `IServiceCollection` called `ConfigureRefitClients()`. The generated extension method depends on [`Refit.HttpClientFactory`](https://www.nuget.org/packages/Refit.HttpClientFactory) library and looks like this:
+
+```cs
+public static IServiceCollection ConfigureRefitClients(
+    this IServiceCollection services, 
+    Action<IHttpClientBuilder>? builder = default, 
+    RefitSettings? settings = default)
+{
+    var clientBuilderISwaggerPetstore = services
+        .AddRefitClient<ISwaggerPetstore>(settings)
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
+        .AddHttpMessageHandler<TelemetryDelegatingHandler>();
+
+    clientBuilderISwaggerPetstore
+        .AddPolicyHandler(
+            HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .WaitAndRetryAsync(
+                    Backoff.DecorrelatedJitterBackoffV2(
+                        TimeSpan.FromSeconds(0.5),
+                        3)));
+
+    builder?.Invoke(clientBuilderISwaggerPetstore);
+
+    return services;
+}
+```
+
+This comes in handy especially when generating multiple interfaces, by tag or endpoint. For example, the following `.refitter` settings file
+
+```json
+{
+  "openApiPath": "../OpenAPI/v3.0/petstore.json",
+  "namespace": "Petstore",
+  "multipleInterfaces": "ByTag",
+  "dependencyInjectionSettings": {
+    "baseUrl": "https://petstore3.swagger.io/api/v3",
+    "httpMessageHandlers": [ "TelemetryDelegatingHandler" ],
+    "transientErrorHandler": "Polly",
+    "maxRetryCount": 3,
+    "firstBackoffRetryInSeconds": 0.5
+  }
+}
+```
+
+Will generate a single `ConfigureRefitClients()` extension methods that may contain dependency injection configuration code for multiple interfaces like this
+
+```csharp
+public static IServiceCollection ConfigureRefitClients(
+    this IServiceCollection services, 
+    Action<IHttpClientBuilder>? builder = default, 
+    RefitSettings? settings = default)
+{
+    var clientBuilderIPetApi = services
+        .AddRefitClient<IPetApi>(settings)
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
+        .AddHttpMessageHandler<TelemetryDelegatingHandler>();
+
+    clientBuilderIPetApi
+        .AddPolicyHandler(
+            HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .WaitAndRetryAsync(
+                    Backoff.DecorrelatedJitterBackoffV2(
+                        TimeSpan.FromSeconds(0.5),
+                        3)));
+
+    builder?.Invoke(clientBuilderIPetApi);
+
+    var clientBuilderIStoreApi = services
+        .AddRefitClient<IStoreApi>(settings)
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
+        .AddHttpMessageHandler<TelemetryDelegatingHandler>();
+
+    clientBuilderIStoreApi
+        .AddPolicyHandler(
+            HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .WaitAndRetryAsync(
+                    Backoff.DecorrelatedJitterBackoffV2(
+                        TimeSpan.FromSeconds(0.5),
+                        3)));
+
+    builder?.Invoke(clientBuilderIStoreApi);
+
+    var clientBuilderIUserApi = services
+        .AddRefitClient<IUserApi>(settings)
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
+        .AddHttpMessageHandler<TelemetryDelegatingHandler>();
+
+    clientBuilderIUserApi
+        .AddPolicyHandler(
+            HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .WaitAndRetryAsync(
+                    Backoff.DecorrelatedJitterBackoffV2(
+                        TimeSpan.FromSeconds(0.5),
+                        3)));
+
+    builder?.Invoke(clientBuilderIUserApi);
+
+    return services;
+}
+```
+
+Personally, they I use Refitter is to generate an interface per endpoint, so when generating code for a large and complex API, I might have several interfaces.
 
 ## System requirements
 .NET 8.0

--- a/docs/docfx_project/articles/using-the-generated-code.md
+++ b/docs/docfx_project/articles/using-the-generated-code.md
@@ -108,3 +108,130 @@ Returns a response that looks something like this:
   "status": "Sold"
 }
 ```
+
+## Dependency Injection
+
+Refitter supports generating bootstrapping code that allows the user to conveniently configure all generated Refit interfaces by calling a single extension method to `IServiceCollection`.
+
+This is enabled through the `.refitter` settings file like this:
+
+```json
+{
+  "openApiPath": "../OpenAPI/v3.0/petstore.json",
+  "namespace": "Petstore",
+  "dependencyInjectionSettings": {
+    "baseUrl": "https://petstore3.swagger.io/api/v3",
+    "httpMessageHandlers": [ "TelemetryDelegatingHandler" ],
+    "transientErrorHandler": "Polly",
+    "maxRetryCount": 3,
+    "firstBackoffRetryInSeconds": 0.5
+  }
+}
+```
+
+which will generate an extension method to `IServiceCollection` called `ConfigureRefitClients()`. The generated extension method depends on [`Refit.HttpClientFactory`](https://www.nuget.org/packages/Refit.HttpClientFactory) library and looks like this:
+
+```cs
+public static IServiceCollection ConfigureRefitClients(
+    this IServiceCollection services, 
+    Action<IHttpClientBuilder>? builder = default, 
+    RefitSettings? settings = default)
+{
+    var clientBuilderISwaggerPetstore = services
+        .AddRefitClient<ISwaggerPetstore>(settings)
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
+        .AddHttpMessageHandler<TelemetryDelegatingHandler>();
+
+    clientBuilderISwaggerPetstore
+        .AddPolicyHandler(
+            HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .WaitAndRetryAsync(
+                    Backoff.DecorrelatedJitterBackoffV2(
+                        TimeSpan.FromSeconds(0.5),
+                        3)));
+
+    builder?.Invoke(clientBuilderISwaggerPetstore);
+
+    return services;
+}
+```
+
+This comes in handy especially when generating multiple interfaces, by tag or endpoint. For example, the following `.refitter` settings file
+
+```json
+{
+  "openApiPath": "../OpenAPI/v3.0/petstore.json",
+  "namespace": "Petstore",
+  "multipleInterfaces": "ByTag",
+  "dependencyInjectionSettings": {
+    "baseUrl": "https://petstore3.swagger.io/api/v3",
+    "httpMessageHandlers": [ "TelemetryDelegatingHandler" ],
+    "transientErrorHandler": "Polly",
+    "maxRetryCount": 3,
+    "firstBackoffRetryInSeconds": 0.5
+  }
+}
+```
+
+Will generate a single `ConfigureRefitClients()` extension methods that may contain dependency injection configuration code for multiple interfaces like this
+
+```csharp
+public static IServiceCollection ConfigureRefitClients(
+    this IServiceCollection services, 
+    Action<IHttpClientBuilder>? builder = default, 
+    RefitSettings? settings = default)
+{
+    var clientBuilderIPetApi = services
+        .AddRefitClient<IPetApi>(settings)
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
+        .AddHttpMessageHandler<TelemetryDelegatingHandler>();
+
+    clientBuilderIPetApi
+        .AddPolicyHandler(
+            HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .WaitAndRetryAsync(
+                    Backoff.DecorrelatedJitterBackoffV2(
+                        TimeSpan.FromSeconds(0.5),
+                        3)));
+
+    builder?.Invoke(clientBuilderIPetApi);
+
+    var clientBuilderIStoreApi = services
+        .AddRefitClient<IStoreApi>(settings)
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
+        .AddHttpMessageHandler<TelemetryDelegatingHandler>();
+
+    clientBuilderIStoreApi
+        .AddPolicyHandler(
+            HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .WaitAndRetryAsync(
+                    Backoff.DecorrelatedJitterBackoffV2(
+                        TimeSpan.FromSeconds(0.5),
+                        3)));
+
+    builder?.Invoke(clientBuilderIStoreApi);
+
+    var clientBuilderIUserApi = services
+        .AddRefitClient<IUserApi>(settings)
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
+        .AddHttpMessageHandler<TelemetryDelegatingHandler>();
+
+    clientBuilderIUserApi
+        .AddPolicyHandler(
+            HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .WaitAndRetryAsync(
+                    Backoff.DecorrelatedJitterBackoffV2(
+                        TimeSpan.FromSeconds(0.5),
+                        3)));
+
+    builder?.Invoke(clientBuilderIUserApi);
+
+    return services;
+}
+```
+
+Personally, they I use Refitter is to generate an interface per endpoint, so when generating code for a large and complex API, I might have several interfaces.

--- a/test/MinimalApi/Program.cs
+++ b/test/MinimalApi/Program.cs
@@ -1,4 +1,5 @@
 using Petstore;
+using Refit;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddEndpointsApiExplorer();
@@ -6,7 +7,8 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddLogging(logging => logging.AddDebug());
 builder.Services.AddTransient<TelemetryDelegatingHandler>();
-builder.Services.ConfigureRefitClients();
+builder.Services.ConfigureRefitClients(
+    settings: new RefitSettings { });
 
 var app = builder.Build();
 app.MapGet(


### PR DESCRIPTION
This pull request includes updates to the MinimalApi example and adds a new section to the documentation that explains how to use Dependency Injection with Refit. The changes ensure the code is current and provide clear instructions for configuring Refit interfaces using the `IServiceCollection` extension method `ConfigureRefitClients()`. This method allows for convenient configuration of multiple interfaces and supports features such as base URL, HTTP message handlers, transient error handling, and retry policies. 