### PR TITLE
Improve telemetry for --settings-file usage

### DIFF
--- a/src/Refitter/Analytics.cs
+++ b/src/Refitter/Analytics.cs
@@ -21,8 +21,11 @@ public static class Analytics
         ExceptionlessClient.Default.Configuration.SetVersion(typeof(GenerateCommand).Assembly.GetName().Version!);
         ExceptionlessClient.Default.Startup("pRql7vmgecZ0Iph6MU5TJE5XsZeesdTe0yx7TN4f");
     }
-    
-    public static Task LogFeatureUsage(Settings settings)
+
+    public static Task LogFeatureUsage(
+        Settings settings,
+        RefitGeneratorSettings refitGeneratorSettings
+    )
     {
         if (settings.NoLogging)
             return Task.CompletedTask;
@@ -47,6 +50,14 @@ public static class Analytics
                         ExceptionlessClient.Default
                             .CreateFeatureUsage(attribute.LongNames.FirstOrDefault() ?? property.Name)
                             .Submit());
+        }
+
+        if (settings.SettingsFilePath is not null)
+        {
+            ExceptionlessClient
+                .Default.CreateFeatureUsage("settings-file")
+                .AddObject(refitGeneratorSettings, ignoreSerializationErrors: true)
+                .Submit();
         }
 
         return ExceptionlessClient.Default.ProcessQueueAsync();

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -86,7 +86,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                 Directory.CreateDirectory(directory);
 
             await File.WriteAllTextAsync(outputPath, code);
-            await Analytics.LogFeatureUsage(settings);
+            await Analytics.LogFeatureUsage(settings, refitGeneratorSettings);
 
             AnsiConsole.MarkupLine($"[green]Duration: {stopwatch.Elapsed}{Crlf}[/]");
 


### PR DESCRIPTION
This pull request improves the telemetry for the usage of the `--settings-file` option. Previously, only the `settings-file` object was logged, but now the `RefitGeneratorSettings` object is also logged when the `SettingsFilePath` is not null. This provides more detailed information for analysis.