### PR TITLE
Revert Microsoft.CodeAnalysis.CSharp to v4.8.0 and update SourceGenerator smoke test project to use v1.1.1

### DIFF
--- a/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
+++ b/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="H.Generators.Extensions" Version="1.22.0" PrivateAssets="all" />
     <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="14.1.0" PrivateAssets="all" />
     <PackageReference Include="NSwag.Core.Yaml" Version="14.1.0" PrivateAssets="all" />

--- a/test/SourceGenerator/Directory.Build.props
+++ b/test/SourceGenerator/Directory.Build.props
@@ -12,7 +12,7 @@
         <Compile Include="../Generated/*.cs" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Refitter.SourceGenerator" Version="0.9.7" />
+        <PackageReference Include="Refitter.SourceGenerator" Version="1.1.1" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
         <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     </ItemGroup>


### PR DESCRIPTION
This pull request reverts the version of Microsoft.CodeAnalysis.CSharp back to v4.8.0 and updates the SourceGenerator smoke test project to use v1.1.1. The previous version of Microsoft.CodeAnalysis.CSharp was causing compatibility issues, so it was necessary to revert it. Additionally, the SourceGenerator smoke test project needed to be updated to ensure compatibility with the new version.