### PR TITLE
[Apizr] Generate Apizr formatted Refit interface without .refitter settings file

### DIFF
--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -52,7 +52,8 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             KeepSchemaPatterns = settings.KeepSchemaPatterns ?? Array.Empty<string>(),
             OperationNameGenerator = settings.OperationNameGenerator,
             GenerateDefaultAdditionalProperties = !settings.SkipDefaultAdditionalProperties,
-            ImmutableRecords = settings.ImmutableRecords
+            ImmutableRecords = settings.ImmutableRecords,
+            ApizrSettings = settings.UseApizr ? new ApizrSettings() : null
         };
 
         try

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -165,4 +165,14 @@ public sealed class Settings : CommandSettings
     [CommandOption("--immutable-records")]
     [DefaultValue(false)]
     public bool ImmutableRecords { get; set; }
+
+    [Description("""
+                 Set to true to use Apizr by:
+                 - Adding a final IApizrRequestOptions options parameter to all generated methods
+                 - Using method overloads with dynamic querystring parameters instead of multiple optional parameters
+                 See https://refitter.github.io for more information and https://www.apizr.net to get started with Apizr.
+                 """)]
+    [CommandOption("--use-apizr")]
+    [DefaultValue(false)]
+    public bool UseApizr { get; set; }
 }

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -169,6 +169,7 @@ public sealed class Settings : CommandSettings
     [Description("""
                  Set to true to use Apizr by:
                  - Adding a final IApizrRequestOptions options parameter to all generated methods
+                 - Providing cancellation tokens by Apizr request options instead of a dedicated parameter
                  - Using method overloads instead of optional parameters
                  See https://refitter.github.io for more information and https://www.apizr.net to get started with Apizr.
                  """)]

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -169,7 +169,7 @@ public sealed class Settings : CommandSettings
     [Description("""
                  Set to true to use Apizr by:
                  - Adding a final IApizrRequestOptions options parameter to all generated methods
-                 - Using method overloads with dynamic querystring parameters instead of multiple optional parameters
+                 - Using method overloads instead of optional parameters
                  See https://refitter.github.io for more information and https://www.apizr.net to get started with Apizr.
                  """)]
     [CommandOption("--use-apizr")]


### PR DESCRIPTION
That was the missing part of the #404 puzzle.
Previous #428 PR focused on generating things from a .refitter settings file. 

Now with that PR we can generate Apizr formatted Refit interfaces without settings file but with such a command line:
```shell
refitter https://petstore3.swagger.io/api/v3/openapi.yaml --use-apizr
```

It will generate the Refit interface, but formatted to Apizr by:
- Adding a final IApizrRequestOptions options parameter to all generated methods
- Providing cancellation tokens by Apizr request options instead of a dedicated parameter
- Using method overloads instead of optional parameters

So now we should get best of both CLI & SourceGenerator worlds 🥂 