### PR TITLE
[Apizr] Including an xml doc param for ApizrRequestOptions parameter

### DIFF
--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -62,7 +62,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
                 var parameters = ParameterExtractor.GetParameters(operationModel, operation, settings).ToList();
                 var parametersString = string.Join(", ", parameters);
 
-                this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), code);
+                this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), settings.ApizrSettings?.WithRequestOptions == true, code);
                 GenerateObsoleteAttribute(operation, code);
                 GenerateForMultipartFormData(operationModel, code);
                 GenerateAcceptHeaders(operations, operation, code);
@@ -84,7 +84,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
                         foreach (var operationParameterToRemove in operationParametersToRemove) 
                             operationModel.Parameters.Remove(operationParameterToRemove);
 
-                        this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), code);
+                        this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), true, code);
                         GenerateObsoleteAttribute(operation, code);
                         GenerateForMultipartFormData(operationModel, code);
                         GenerateAcceptHeaders(operations, operation, code);

--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -61,8 +61,9 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
                 var operationModel = generator.CreateOperationModel(operation);
                 var parameters = ParameterExtractor.GetParameters(operationModel, operation, settings).ToList();
                 var parametersString = string.Join(", ", parameters);
+                var hasApizrRequestOptionsParameter = settings.ApizrSettings?.WithRequestOptions == true;
 
-                this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), settings.ApizrSettings?.WithRequestOptions == true, code);
+                this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), hasApizrRequestOptionsParameter, code);
                 GenerateObsoleteAttribute(operation, code);
                 GenerateForMultipartFormData(operationModel, code);
                 GenerateAcceptHeaders(operations, operation, code);

--- a/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
@@ -63,8 +63,9 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
                 var operationModel = generator.CreateOperationModel(operation);
                 var parameters = ParameterExtractor.GetParameters(operationModel, operation, settings);
                 var parametersString = string.Join(", ", parameters);
+                var hasApizrRequestOptionsParameter = settings.ApizrSettings?.WithRequestOptions == true;
 
-                this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), sb);
+                this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), hasApizrRequestOptionsParameter, sb);
                 GenerateObsoleteAttribute(operation, sb);
                 GenerateForMultipartFormData(operationModel, sb);
                 GenerateAcceptHeaders(operations, operation, sb);

--- a/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
@@ -48,8 +48,9 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
                 var operationModel = generator.CreateOperationModel(operation);
                 var parameters = ParameterExtractor.GetParameters(operationModel, operation, settings);
                 var parametersString = string.Join(", ", parameters);
+                var hasApizrRequestOptionsParameter = settings.ApizrSettings?.WithRequestOptions == true;
 
-                this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), code);
+                this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), hasApizrRequestOptionsParameter, code);
                 GenerateObsoleteAttribute(operation, code);
                 GenerateForMultipartFormData(operationModel, code);
                 GenerateAcceptHeaders(operations, operation, code);

--- a/src/Refitter.Core/XmlDocumentationGenerator.cs
+++ b/src/Refitter.Core/XmlDocumentationGenerator.cs
@@ -47,8 +47,9 @@ public class XmlDocumentationGenerator
     /// </summary>
     /// <param name="method">The NSwag model of the method's OpenAPI definition.</param>
     /// <param name="hasApiResponse">Indicates whether the method returns an <c>ApiResponse</c>.</param>
+    /// <param name="hasApizrRequestOptionsParameter">Indicates whether the method get an IApizrRequestOptions options final parameter</param>
     /// <param name="code">The builder to append the documentation to.</param>
-    public void AppendMethodDocumentation(CSharpOperationModel method, bool hasApiResponse, StringBuilder code)
+    public void AppendMethodDocumentation(CSharpOperationModel method, bool hasApiResponse, bool hasApizrRequestOptionsParameter, StringBuilder code)
     {
         if (!_settings.GenerateXmlDocCodeComments)
             return;
@@ -66,6 +67,15 @@ public class XmlDocumentationGenerator
 
             this.AppendXmlCommentBlock("param", parameter.Description, code, new Dictionary<string, string>
                 { ["name"] = parameter.VariableName });
+        }
+
+        if(hasApizrRequestOptionsParameter)
+        {
+            this.AppendXmlCommentBlock(
+                "param",
+                "The <see cref=\"IApizrRequestOptions\"/> instance to pass through the request.",
+                code,
+                new Dictionary<string, string> { ["name"] = "options" });
         }
 
         if (hasApiResponse)

--- a/src/Refitter.Tests/XmlDocumentationGeneratorTests.cs
+++ b/src/Refitter.Tests/XmlDocumentationGeneratorTests.cs
@@ -54,7 +54,7 @@ namespace Refitter.Tests
         {
             var docs = new StringBuilder();
             var method = CreateOperationModel(new OpenApiOperation { Summary = "TestSummary", });
-            this._generator.AppendMethodDocumentation(method, false, docs);
+            this._generator.AppendMethodDocumentation(method, false, false, docs);
             docs.ToString().Trim().Should().StartWith("/// <summary>TestSummary</summary>");
         }
 
@@ -63,7 +63,7 @@ namespace Refitter.Tests
         {
             var docs = new StringBuilder();
             var method = CreateOperationModel(new OpenApiOperation { Description = "TestDescription", });
-            this._generator.AppendMethodDocumentation(method, false, docs);
+            this._generator.AppendMethodDocumentation(method, false, false, docs);
             docs.ToString().Should().Contain("/// <remarks>TestDescription</remarks>");
         }
 
@@ -74,8 +74,20 @@ namespace Refitter.Tests
             var method = CreateOperationModel(new OpenApiOperation {
                 Parameters = { new OpenApiParameter { OriginalName = "testParam", Description = "TestParameter" } },
             });
-            this._generator.AppendMethodDocumentation(method, false, docs);
+            this._generator.AppendMethodDocumentation(method, false, false, docs);
             docs.ToString().Should().Contain("/// <param name=\"testParam\">TestParameter</param>");
+        }
+
+        [Fact]
+        public void Can_Generate_ApizrRequestOptions_Param()
+        {
+            var docs = new StringBuilder();
+            var method = CreateOperationModel(new OpenApiOperation
+            {
+                Parameters = { new OpenApiParameter { OriginalName = "testParam", Description = "TestParameter" } },
+            });
+            this._generator.AppendMethodDocumentation(method, false, true, docs);
+            docs.ToString().Should().Contain("/// <param name=\"options\">The <see cref=\"IApizrRequestOptions\"/> instance to pass through the request.</param>");
         }
 
         [Fact]
@@ -93,7 +105,7 @@ namespace Refitter.Tests
                 },
                 Produces = ["application/json"],
             });
-            this._generator.AppendMethodDocumentation(method, false, docs);
+            this._generator.AppendMethodDocumentation(method, false, false, docs);
             docs.ToString().Should().Contain("/// <returns>TestResponse</returns>");
         }
 
@@ -108,7 +120,7 @@ namespace Refitter.Tests
                 },
                 Produces = ["application/json"],
             });
-            this._generator.AppendMethodDocumentation(method, false, docs);
+            this._generator.AppendMethodDocumentation(method, false, false, docs);
             docs.ToString().Should().Contain("/// <returns>")
                 .And.Contain("Task");
         }
@@ -118,7 +130,7 @@ namespace Refitter.Tests
         {
             var docs = new StringBuilder();
             var method = CreateOperationModel(new OpenApiOperation());
-            this._generator.AppendMethodDocumentation(method, false, docs);
+            this._generator.AppendMethodDocumentation(method, false, false, docs);
             docs.ToString().Should().Contain("/// <returns>")
                 .And.Contain("Task");
         }
@@ -128,7 +140,7 @@ namespace Refitter.Tests
         {
             var docs = new StringBuilder();
             var method = CreateOperationModel(new OpenApiOperation());
-            this._generator.AppendMethodDocumentation(method, false, docs);
+            this._generator.AppendMethodDocumentation(method, false, false, docs);
             docs.ToString().Should().Contain("/// <exception cref=\"ApiException\">");
         }
 
@@ -145,7 +157,7 @@ namespace Refitter.Tests
             {
                 Responses = { ["400"] = new OpenApiResponse { Description = "TestResponse" } },
             });
-            this._generator.AppendMethodDocumentation(method, false, docs);
+            this._generator.AppendMethodDocumentation(method, false, false, docs);
             docs.ToString().Should().Contain("/// <exception cref=\"ApiException\">")
                 .And.Contain("<term>400</term>");
         }
@@ -163,7 +175,7 @@ namespace Refitter.Tests
             {
                 Responses = { ["400"] = new OpenApiResponse { Description = "TestResponse" } },
             });
-            this._generator.AppendMethodDocumentation(method, false, docs);
+            this._generator.AppendMethodDocumentation(method, false, false, docs);
             docs.ToString().Should().Contain("/// <exception cref=\"ApiException\">")
                 .And.NotContain("<term>400</term>");
         }
@@ -181,7 +193,7 @@ namespace Refitter.Tests
             {
                 Responses = { ["400"] = new OpenApiResponse { Description = "TestResponse" } },
             });
-            this._generator.AppendMethodDocumentation(method, true, docs);
+            this._generator.AppendMethodDocumentation(method, true, false, docs);
             docs.ToString().Should().NotContain("/// <exception cref=\"ApiException\">")
                 .And.Contain("/// <returns>")
                 .And.Contain("<term>400</term>");


### PR DESCRIPTION
I just added the missing xml doc param over interface methods when needed:
```xml
/// <param name="options">The <see cref=\"IApizrRequestOptions\"/> instance to pass through the request.</param>
```
Added a test to cover it to.