### PR TITLE
Enable nullable annotations and disable warnings

### DIFF
--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -227,7 +227,7 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
         }
 
         code.AppendLine("#nullable enable annotations");
-        code.AppendLine("#nullable disable warnings");
+        code.AppendLine();
 
         var refitInterfaces = interfaceGenerator.GenerateCode();
         code.AppendLine($$"""

--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -226,7 +226,8 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
             code.AppendLine();
         }
 
-        code.AppendLine("#nullable enable");
+        code.AppendLine("#nullable enable annotations");
+        code.AppendLine("#nullable disable warnings");
 
         var refitInterfaces = interfaceGenerator.GenerateCode();
         code.AppendLine($$"""


### PR DESCRIPTION
This pull request enables nullable annotations in the code and removes explicit disable warnings. The change is replacing `#nullable enable` with `#nullable enable annotations` to the generated code

This resolves #451 (discussed in #449)