### PR TITLE
Handle '%' in property names

### DIFF
--- a/src/Refitter.Core/CustomCSharpPropertyNameGenerator.cs
+++ b/src/Refitter.Core/CustomCSharpPropertyNameGenerator.cs
@@ -8,8 +8,8 @@ namespace Refitter.Core;
 internal class CustomCSharpPropertyNameGenerator : IPropertyNameGenerator
 {
     private static readonly char[] ReservedFirstPassChars = ['"', '\'', '@', '?', '!', '$', '[', ']', '(', ')', '.', '=', '+'];
-    private static readonly char[] ReservedSecondPassChars = ['*', ':', '-', '#', '&'];
-    
+    private static readonly char[] ReservedSecondPassChars = ['*', ':', '-', '#', '&', '%'];
+
     public string Generate(JsonSchemaProperty property) =>
         string.IsNullOrWhiteSpace(property.Name)
             ? "_"
@@ -18,7 +18,7 @@ internal class CustomCSharpPropertyNameGenerator : IPropertyNameGenerator
     /// <summary>
     /// This code is taken directly from NJsonSchema.CodeGeneration.CSharp.CSharpPropertyNameGenerator
     /// which since v14.0.0 is no longer extensible.
-    /// See https://github.com/RicoSuter/NJsonSchema/blob/3585d60e949e43284601e0bea16c33de4c6c21f5/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs#L12" 
+    /// See https://github.com/RicoSuter/NJsonSchema/blob/3585d60e949e43284601e0bea16c33de4c6c21f5/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs#L12"
     /// </summary>
     [ExcludeFromCodeCoverage]
     private static string ReplaceNameContainingReservedCharacters(JsonSchemaProperty property)
@@ -52,7 +52,8 @@ internal class CustomCSharpPropertyNameGenerator : IPropertyNameGenerator
                 .Replace(":", "_")
                 .Replace("-", "_")
                 .Replace("#", "_")
-                .Replace("&", "And");
+                .Replace("&", "And")
+                .Replace("%", "Percent");
         }
 
         return name;

--- a/src/Refitter.Tests/Examples/PercentageCharacterTests.cs
+++ b/src/Refitter.Tests/Examples/PercentageCharacterTests.cs
@@ -1,0 +1,91 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class PercentageCharacterTests
+{
+    private const string OpenApiSpec = @"
+openapi: '3.0.0'
+info:
+  version: 'v1'
+  title: 'Test API'
+servers:
+  - url: 'https://test.host.com/api/v1'
+paths:
+  /data:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: 'object'
+              properties:
+                '% of something':
+                  type: 'string'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SomeResponse'
+components:
+  schemas:
+    SomeResponse:
+      type: 'object'
+      properties:
+        data:
+          type: 'object'
+          properties:
+            id:
+              type: 'string'
+            details:
+              type: 'string'
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Replaces_Percentage_With_PascalCase()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().Contain("string Percent_of_something");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}


### PR DESCRIPTION
The CustomCSharpPropertyNameGenerator class was updated to replace the '%' character with 'Percent'. This fixes an issue where the generator was not correctly handling properties with '%' in their names.

This resolves #453