### PR TITLE
Use Azure App Insights for telemetry

### DIFF
--- a/src/Refitter/Refitter.csproj
+++ b/src/Refitter/Refitter.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Exceptionless" Version="6.0.4" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.22.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Refitter/SupportKeyInitializer.cs
+++ b/src/Refitter/SupportKeyInitializer.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Refitter;
+
+public sealed class SupportKeyInitializer : ITelemetryInitializer
+{
+    public void Initialize(ITelemetry telemetry)
+    {
+        if (telemetry is ISupportProperties supportProperties)
+            supportProperties.Properties["support-key"] = SupportInformation.GetSupportKey();
+    }
+}


### PR DESCRIPTION
This pull request adds telemetry logging to both Exceptionless and App Insights. 

It includes a new package reference to Microsoft.ApplicationInsights.WindowsServer and modifies the Analytics class to configure and log telemetry using the TelemetryClient. The LogFeatureUsage method has been updated to log feature usage to both Exceptionless and App Insights.

Additionally, a new SupportKeyInitializer class has been added to initialize the support key property in telemetry.