### PR TITLE
Update Apizr Dependencies to v6.1.0

### DIFF
--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -16,13 +16,13 @@ public static class ProjectFileContents
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
-    <PackageReference Include=""Apizr.Integrations.FileTransfer.Optional"" Version=""6.0.0-preview.7"" />
-    <PackageReference Include=""Apizr.Integrations.Mapster"" Version=""6.0.0-preview.7"" />
-    <PackageReference Include=""Apizr.Integrations.AutoMapper"" Version=""6.0.0-preview.7"" />
-    <PackageReference Include=""Apizr.Integrations.Akavache"" Version=""6.0.0-preview.7"" />
-    <PackageReference Include=""Apizr.Integrations.MonkeyCache"" Version=""6.0.0-preview.7"" />
-    <PackageReference Include=""Apizr.Extensions.Microsoft.Caching"" Version=""6.0.0-preview.7"" />
-    <PackageReference Include=""Apizr.Integrations.Fusillade"" Version=""6.0.0-preview.7"" />
+    <PackageReference Include=""Apizr.Integrations.FileTransfer.Optional"" Version=""6.1.0"" />
+    <PackageReference Include=""Apizr.Integrations.Mapster"" Version=""6.1.0"" />
+    <PackageReference Include=""Apizr.Integrations.AutoMapper"" Version=""6.1.0"" />
+    <PackageReference Include=""Apizr.Integrations.Akavache"" Version=""6.1.0"" />
+    <PackageReference Include=""Apizr.Integrations.MonkeyCache"" Version=""6.1.0"" />
+    <PackageReference Include=""Apizr.Extensions.Microsoft.Caching"" Version=""6.1.0"" />
+    <PackageReference Include=""Apizr.Integrations.Fusillade"" Version=""6.1.0"" />
   </ItemGroup>
 </Project>";
 }

--- a/test/Apizr/Sample.csproj
+++ b/test/Apizr/Sample.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apizr.Extensions.Microsoft.Caching" Version="6.0.0" />
-    <PackageReference Include="Apizr.Integrations.AutoMapper" Version="6.0.0" />
-    <PackageReference Include="Apizr.Integrations.FileTransfer.Optional" Version="6.0.0" />
-    <PackageReference Include="Apizr.Integrations.Fusillade" Version="6.0.0" />
+    <PackageReference Include="Apizr.Extensions.Microsoft.Caching" Version="6.1.0" />
+    <PackageReference Include="Apizr.Integrations.AutoMapper" Version="6.1.0" />
+    <PackageReference Include="Apizr.Integrations.FileTransfer.Optional" Version="6.1.0" />
+    <PackageReference Include="Apizr.Integrations.Fusillade" Version="6.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.9.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>


### PR DESCRIPTION
This pull request updates several package references in two project files to newer versions. The changes ensure that the projects use the latest stable versions of the Apizr integrations and extensions.

Package reference updates:

* [`src/Refitter.Tests/Build/ProjectFileContents.cs`](diffhunk://#diff-b50eea9ef8bc22e552467f370a0388c3036d02b4d024b5b854a6cd0dff53db01L19-R25): Updated multiple `Apizr` package references from version `6.0.0-preview.7` to `6.1.0`.
* [`test/Apizr/Sample.csproj`](diffhunk://#diff-fbb979c250529437fcdc9df15da6acf7b63a92ecf800d0daac71981fc28f0821L11-R14): Updated multiple `Apizr` package references from version `6.0.0` to `6.1.0`.