### PR TITLE
Update devcontainer.json to use the latest version of .NET image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "C# (.NET)",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-6.0",
+	"image": "mcr.microsoft.com/devcontainers/dotnet",
 	"features": {
 		"ghcr.io/devcontainers/features/powershell:1": {},
 		"ghcr.io/devcontainers/features/dotnet:2": {}


### PR DESCRIPTION
This pull request updates the `devcontainer.json` file to use the latest version of the .NET image (`mcr.microsoft.com/devcontainers/dotnet`). This ensures that the development container is using the most up-to-date version of .NET for building and running the application.