### PR TITLE
added options for a custom Name Generators

### DIFF
--- a/src/Refitter.Core/CSharpClientGeneratorFactory.cs
+++ b/src/Refitter.Core/CSharpClientGeneratorFactory.cs
@@ -24,7 +24,7 @@ internal class CSharpClientGeneratorFactory(RefitGeneratorSettings settings, Ope
             GenerateDtoTypes = true,
             GenerateClientInterfaces = false,
             GenerateExceptionClasses = false,
-            CodeGeneratorSettings = { PropertyNameGenerator = new CustomCSharpPropertyNameGenerator(), },
+            CodeGeneratorSettings = { PropertyNameGenerator = settings.CodeGeneratorSettings?.PropertyNameGenerator ?? new CustomCSharpPropertyNameGenerator() },
             CSharpGeneratorSettings =
             {
                 Namespace = settings.ContractsNamespace ?? settings.Namespace,
@@ -40,6 +40,11 @@ internal class CSharpClientGeneratorFactory(RefitGeneratorSettings settings, Ope
                     settings.CodeGeneratorSettings?.GenerateNativeRecords is true,
             }
         };
+
+        if (settings.ParameterNameGenerator != default)
+        {
+            csharpClientGeneratorSettings.ParameterNameGenerator = settings.ParameterNameGenerator;
+        }
 
         csharpClientGeneratorSettings.CSharpGeneratorSettings.TemplateFactory = new CustomTemplateFactory(
             csharpClientGeneratorSettings.CSharpGeneratorSettings,

--- a/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
@@ -148,7 +148,7 @@ public class CodeGeneratorSettings
     /// Gets or sets a value indicating whether to generate default values for properties (when JSON Schema default is set, default: true).
     /// </summary>
     public bool GenerateDefaultValues { get; set; } = true;
-    
+
     /// <summary>
     /// Gets or sets a value indicating whether named/referenced any schemas should be inlined or generated as class.
     /// </summary>
@@ -163,5 +163,5 @@ public class CodeGeneratorSettings
     /// Gets or sets a custom <see cref="IPropertyNameGenerator"/>.
     /// </summary>
     [JsonIgnore]
-    public IPropertyNameGenerator? PropertyNameGenerator { get; set; }// = new CustomCSharpPropertyNameGenerator();
+    public IPropertyNameGenerator? PropertyNameGenerator { get; set; }
 }

--- a/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
@@ -1,4 +1,7 @@
-﻿namespace Refitter.Core;
+using System.Text.Json.Serialization;
+using NJsonSchema.CodeGeneration;
+
+namespace Refitter.Core;
 
 /// <summary>
 /// CSharp code generator settings
@@ -155,4 +158,10 @@ public class CodeGeneratorSettings
     /// Gets or sets the excluded type names (must be defined in an import or other namespace).
     /// </summary>
     public string[] ExcludedTypeNames { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets a custom <see cref="IPropertyNameGenerator"/>.
+    /// </summary>
+    [JsonIgnore]
+    public IPropertyNameGenerator? PropertyNameGenerator { get; set; }// = new CustomCSharpPropertyNameGenerator();
 }

--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
+using NSwag.CodeGeneration;
 
 namespace Refitter.Core;
 
@@ -226,4 +227,7 @@ public class RefitGeneratorSettings
     /// See https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism for more information
     /// </summary>
     public bool UsePolymorphicSerialization { get; set; }
+
+    [JsonIgnore]
+    public IParameterNameGenerator? ParameterNameGenerator { get; set; }
 }

--- a/src/Refitter.Tests/SerializerTests.cs
+++ b/src/Refitter.Tests/SerializerTests.cs
@@ -1,4 +1,5 @@
-﻿using Atc.Test;
+using System.Reflection;
+using Atc.Test;
 using FluentAssertions;
 using Refitter.Core;
 using Xunit;
@@ -18,14 +19,16 @@ public class SerializerTests
     }
 
     [Theory, AutoNSubstituteData]
-    public void Can_Deserialize_RefitGeneratorSettings(
+    public void Can_Deserialize_RefitGeneratorSettingsWithoutNameGenerators(
         RefitGeneratorSettings settings)
     {
         var json = Serializer.Serialize(settings);
         Serializer
             .Deserialize<RefitGeneratorSettings>(json)
             .Should()
-            .BeEquivalentTo(settings);
+            .BeEquivalentTo(settings, options => options
+                .Excluding(settings => settings.ParameterNameGenerator)
+                .Excluding(settings => settings.CodeGeneratorSettings.PropertyNameGenerator));
     }
 
     [Theory, AutoNSubstituteData]
@@ -44,6 +47,10 @@ public class SerializerTests
         Serializer
             .Deserialize<RefitGeneratorSettings>(json)
             .Should()
-            .BeEquivalentTo(settings);
+            .BeEquivalentTo(settings, options => options
+                .Excluding(settings => settings.ParameterNameGenerator)
+                .Excluding(settings => settings.CodeGeneratorSettings.PropertyNameGenerator));
     }
+
+
 }

--- a/src/Refitter.Tests/SerializerTests.cs
+++ b/src/Refitter.Tests/SerializerTests.cs
@@ -40,7 +40,7 @@ public class SerializerTests
         {
             var jsonProperty = "\"" + property.Name + "\"";
             json = json.Replace(
-                jsonProperty, 
+                jsonProperty,
                 jsonProperty.ToUpperInvariant());
         }
 
@@ -51,6 +51,4 @@ public class SerializerTests
                 .Excluding(settings => settings.ParameterNameGenerator)
                 .Excluding(settings => settings.CodeGeneratorSettings.PropertyNameGenerator));
     }
-
-
 }


### PR DESCRIPTION
This PR adds the option to add another PropertyNameGenerator or ParameterNameGenerator.
References https://github.com/christianhelle/refitter/issues/516

These generators will not be serialized into the `.Refitter` configuration file.

```
return new RefitGeneratorSettings
{
  CodeGeneratorSettings = new CodeGeneratorSettings
  {
    PropertyNameGenerator = new PascalCasePropertyNameGenerator()
  },
  ParameterNameGenerator = new CamelCaseParameterNameGenerator(),
```

//cc @christianerbsmehl