### PR TITLE
[Apizr] Deprecated Optional package removed from code & doc

### DIFF
--- a/src/Refitter.Core/ApizrRegistrationGenerator.cs
+++ b/src/Refitter.Core/ApizrRegistrationGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Text;
 using Refitter.Core.Settings;
 
@@ -235,20 +235,7 @@ internal static class ApizrRegistrationGenerator
                 """);
         }
 
-        if (settings.ApizrSettings.WithOptionalMediation && isDependencyInjectionExtension)
-        {
-            apizrPackages.Add(ApizrPackages.Apizr_Integrations_Optional);
-            usingsCodeBuilder.AppendLine(
-                $$"""
-                    using MediatR;
-                """);
-            optionsCodeBuilder.AppendLine();
-            optionsCodeBuilder.Append(
-                $$"""
-                                .WithOptionalMediation()
-                """);
-        }
-        else if (settings.ApizrSettings.WithMediation && isDependencyInjectionExtension)
+        if (settings.ApizrSettings.WithMediation && isDependencyInjectionExtension)
         {
             apizrPackages.Add(ApizrPackages.Apizr_Integrations_MediatR);
             usingsCodeBuilder.AppendLine(
@@ -266,16 +253,7 @@ internal static class ApizrRegistrationGenerator
         {
             if (isDependencyInjectionExtension)
             {
-                if (settings.ApizrSettings.WithOptionalMediation)
-                {
-                    apizrPackages.Add(ApizrPackages.Apizr_Integrations_FileTransfer_Optional);
-                    optionsCodeBuilder.AppendLine();
-                    optionsCodeBuilder.Append(
-                $$"""
-                                .WithFileTransferOptionalMediation()
-                """);
-                }
-                else if (settings.ApizrSettings.WithMediation)
+                if (settings.ApizrSettings.WithMediation)
                 {
                     apizrPackages.Add(ApizrPackages.Apizr_Integrations_FileTransfer_MediatR);
                     optionsCodeBuilder.AppendLine();
@@ -310,8 +288,7 @@ internal static class ApizrRegistrationGenerator
         var packages = apizrPackages.OrderByDescending(p => p).ToList();
         if (packages.Count > 0)
         {
-            if (!isDependencyInjectionExtension && (settings.ApizrSettings.WithOptionalMediation ||
-                                                    settings.ApizrSettings.WithMediation ||
+            if (!isDependencyInjectionExtension && (settings.ApizrSettings.WithMediation ||
                                                     settings.ApizrSettings.WithCacheProvider == CacheProviderType.InMemory ||
                                                     settings.ApizrSettings.WithCacheProvider == CacheProviderType.DistributedAsString ||
                                                     settings.ApizrSettings.WithCacheProvider == CacheProviderType.DistributedAsByteArray))

--- a/src/Refitter.Core/Settings/ApizrPackages.cs
+++ b/src/Refitter.Core/Settings/ApizrPackages.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace Refitter.Core.Settings
 {
@@ -38,12 +38,6 @@ namespace Refitter.Core.Settings
         Apizr_Integrations_MediatR = 1024 | Apizr_Extensions_Microsoft_DependencyInjection,
 
         [Description("dotnet add package Apizr.Integrations.FileTransfer.MediatR, then register MediatR")]
-        Apizr_Integrations_FileTransfer_MediatR = 2048 | Apizr_Integrations_MediatR | Apizr_Extensions_Microsoft_FileTransfer,
-
-        [Description("dotnet add package Apizr.Integrations.Optional, then register MediatR")]
-        Apizr_Integrations_Optional = 4096 | Apizr_Integrations_MediatR,
-
-        [Description("dotnet add package Apizr.Integrations.FileTransfer.Optional, then register MediatR")]
-        Apizr_Integrations_FileTransfer_Optional = 8192 | Apizr_Integrations_Optional | Apizr_Integrations_FileTransfer_MediatR,
+        Apizr_Integrations_FileTransfer_MediatR = 2048 | Apizr_Integrations_MediatR | Apizr_Extensions_Microsoft_FileTransfer
     }
 }

--- a/src/Refitter.Core/Settings/ApizrSettings.cs
+++ b/src/Refitter.Core/Settings/ApizrSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Refitter.Core
 {
@@ -51,11 +51,6 @@ namespace Refitter.Core
         /// Set it to true to handle request with MediatR (default: false)
         /// </summary>
         public bool WithMediation { get; set; } = false;
-
-        /// <summary>
-        /// Set it to true to handle request with MediatR and Optional result (default: false)
-        /// </summary>
-        public bool WithOptionalMediation { get; set; } = false;
 
         /// <summary>
         /// Set it to true to manage file transfers (default: false)

--- a/src/Refitter.SourceGenerator/README.md
+++ b/src/Refitter.SourceGenerator/README.md
@@ -83,7 +83,6 @@ The following is an example `.refitter` file
     "withCacheProvider": "InMemory", // Optional. Values=None|Akavache|MonkeyCache|InMemory|DistributedAsString|DistributedAsByteArray. Default=None
     "withPriority": true, // Optional. Default=false
     "withMediation": true, // Optional. Default=false
-    "withOptionalMediation": true, // Optional. Default=false
     "withMappingProvider": "AutoMapper", // Optional. Values=None|AutoMapper|Mapster. Default=None
     "withFileTransfer": true // Optional. Default=false
   },
@@ -160,7 +159,6 @@ The following is an example `.refitter` file
   - `withCacheProvider` - Set the cache provider to be used
   - `withPriority` - Tells if Apizr should handle request priority
   - `withMediation` - Tells if Apizr should handle request mediation (extended only)
-  - `withOptionalMediation` - Tells if Apizr should handle optional request mediation (extended only)
   - `withMappingProvider` - Set the mapping provider to be used
   - `withFileTransfer` - Tells if Apizr should handle file transfer
 - `codeGeneratorSettings` - Setting this allows customization of the NSwag generated types and contracts

--- a/src/Refitter.Tests/ApizrGeneratorWithMicrosoftHttpResilienceTests.cs
+++ b/src/Refitter.Tests/ApizrGeneratorWithMicrosoftHttpResilienceTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Refitter.Core;
 using Xunit;
 
@@ -25,7 +25,6 @@ public class ApizrGeneratorWithMicrosoftHttpResilienceTests
             WithCacheProvider = CacheProviderType.InMemory,
             WithPriority = true,
             WithMediation = true,
-            WithOptionalMediation = true,
             WithMappingProvider = MappingProviderType.AutoMapper,
             WithFileTransfer = true
         }
@@ -41,7 +40,6 @@ public class ApizrGeneratorWithMicrosoftHttpResilienceTests
             WithCacheProvider = CacheProviderType.InMemory,
             WithPriority = true,
             WithMediation = true,
-            WithOptionalMediation = true,
             WithMappingProvider = MappingProviderType.AutoMapper,
             WithFileTransfer = true
         }

--- a/src/Refitter.Tests/ApizrGeneratorWithPollyTests.cs
+++ b/src/Refitter.Tests/ApizrGeneratorWithPollyTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Refitter.Core;
 using Xunit;
 
@@ -27,7 +27,6 @@ public class ApizrGeneratorWithPollyTests
             WithCacheProvider = CacheProviderType.InMemory,
             WithPriority = true,
             WithMediation = true,
-            WithOptionalMediation = true,
             WithMappingProvider = MappingProviderType.AutoMapper,
             WithFileTransfer = true
         }

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -1,4 +1,4 @@
-﻿namespace Refitter.Tests.Build;
+namespace Refitter.Tests.Build;
 
 public static class ProjectFileContents
 {
@@ -8,22 +8,22 @@ public static class ProjectFileContents
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""System.Text.Json"" Version=""8.0.4"" />
+    <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.7"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.9.1"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.1"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.11"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.10.0"" />
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
-    <PackageReference Include=""Apizr.Integrations.FileTransfer.Optional"" Version=""6.1.0"" />
-    <PackageReference Include=""Apizr.Integrations.Mapster"" Version=""6.1.0"" />
-    <PackageReference Include=""Apizr.Integrations.AutoMapper"" Version=""6.1.0"" />
-    <PackageReference Include=""Apizr.Integrations.Akavache"" Version=""6.1.0"" />
-    <PackageReference Include=""Apizr.Integrations.MonkeyCache"" Version=""6.1.0"" />
-    <PackageReference Include=""Apizr.Extensions.Microsoft.Caching"" Version=""6.1.0"" />
-    <PackageReference Include=""Apizr.Integrations.Fusillade"" Version=""6.1.0"" />
+    <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Mapster"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.AutoMapper"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Akavache"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.MonkeyCache"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Extensions.Microsoft.Caching"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Fusillade"" Version=""6.4.0"" />
   </ItemGroup>
 </Project>";
 }

--- a/src/Refitter.Tests/SwaggerPetstoreApizrTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreApizrTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Refitter.Core;
 using Refitter.Tests.Build;
 using Refitter.Tests.Resources;
@@ -24,7 +24,6 @@ public class SwaggerPetstoreApizrTests
                 WithCacheProvider = CacheProviderType.InMemory,
                 WithPriority = true,
                 WithMediation = true,
-                WithOptionalMediation = true,
                 WithMappingProvider = MappingProviderType.AutoMapper,
                 WithFileTransfer = true
             };

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Refitter.Core;
 using Refitter.Tests.Build;
 using Refitter.Tests.Resources;
@@ -372,7 +372,6 @@ public class SwaggerPetstoreTests
                 WithCacheProvider = CacheProviderType.InMemory,
                 WithPriority = true,
                 WithMediation = true,
-                WithOptionalMediation = true,
                 WithMappingProvider = MappingProviderType.AutoMapper,
                 WithFileTransfer = true
             }
@@ -402,7 +401,6 @@ public class SwaggerPetstoreTests
                 WithCacheProvider = CacheProviderType.InMemory,
                 WithPriority = true,
                 WithMediation = true,
-                WithOptionalMediation = true,
                 WithMappingProvider = MappingProviderType.AutoMapper,
                 WithFileTransfer = true
             }
@@ -432,7 +430,6 @@ public class SwaggerPetstoreTests
                 WithCacheProvider = CacheProviderType.InMemory,
                 WithPriority = true,
                 WithMediation = true,
-                WithOptionalMediation = true,
                 WithMappingProvider = MappingProviderType.AutoMapper,
                 WithFileTransfer = true
             }

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -174,7 +174,6 @@ The following is an example `.refitter` file
     "withCacheProvider": "InMemory", // Optional. Values=None|Akavache|MonkeyCache|InMemory|DistributedAsString|DistributedAsByteArray. Default=None
     "withPriority": true, // Optional. Default=false
     "withMediation": true, // Optional. Default=false
-    "withOptionalMediation": true, // Optional. Default=false
     "withMappingProvider": "AutoMapper", // Optional. Values=None|AutoMapper|Mapster. Default=None
     "withFileTransfer": true // Optional. Default=false
   },
@@ -258,7 +257,6 @@ The following is an example `.refitter` file
   - `withCacheProvider` - Set the cache provider to be used
   - `withPriority` - Tells if Apizr should handle request priority
   - `withMediation` - Tells if Apizr should handle request mediation (extended only)
-  - `withOptionalMediation` - Tells if Apizr should handle optional request mediation (extended only)
   - `withMappingProvider` - Set the mapping provider to be used
   - `withFileTransfer` - Tells if Apizr should handle file transfer
 - `codeGeneratorSettings` - Setting this allows customization of the NSwag generated types and contracts
@@ -1832,7 +1830,6 @@ This is what the `.refitter` settings file may look like, depending on you confi
     "withCacheProvider": "InMemory", // Optional, default is None
     "withPriority": true, // Optional, default is false
     "withMediation": true, // Optional, default is false
-    "withOptionalMediation": true, // Optional, default is false
     "withMappingProvider": "AutoMapper", // Optional, default is None
     "withFileTransfer": true // Optional, default is false
   }
@@ -1863,8 +1860,7 @@ public static IServiceCollection ConfigurePetstoreApiApizrManager(
         .WithInMemoryCacheHandler()
         .WithAutoMapperMappingHandler()
         .WithPriority()
-        .WithOptionalMediation()
-        .WithFileTransferOptionalMediation();
+        .WithFileTransferMediation();
                  
     return services.AddApizrManagerFor<IPetstoreApi>(optionsBuilder);
 }
@@ -1895,7 +1891,6 @@ This comes in handy especially when generating multiple interfaces, by tag or en
     "withCacheProvider": "InMemory", // Optional, default is None
     "withPriority": true, // Optional, default is false
     "withMediation": true, // Optional, default is false
-    "withOptionalMediation": true, // Optional, default is false
     "withMappingProvider": "AutoMapper", // Optional, default is None
     "withFileTransfer": true // Optional, default is false
   }
@@ -1926,8 +1921,7 @@ public static IServiceCollection ConfigurePetstoreApizrManagers(
         .WithInMemoryCacheHandler()
         .WithAutoMapperMappingHandler()
         .WithPriority()
-        .WithOptionalMediation()
-        .WithFileTransferOptionalMediation();
+        .WithFileTransferMediation();
             
     return services.AddApizr(
         registry => registry
@@ -1971,7 +1965,8 @@ public static IApizrManager<ISwaggerPetstoreOpenAPI30> BuildPetstore30ApizrManag
     optionsBuilder += options => options
         .WithAkavacheCacheHandler()
         .WithAutoMapperMappingHandler(new MapperConfiguration(config => { /* YOUR_MAPPINGS_HERE */ }))
-        .WithPriority();
+        .WithPriority()
+        .WithFileTransfer();
             
     return ApizrBuilder.Current.CreateManagerFor<ISwaggerPetstoreOpenAPI30>(optionsBuilder);  
 }
@@ -2002,7 +1997,6 @@ This comes in handy especially when generating multiple interfaces, by tag or en
     "withCacheProvider": "InMemory", // Optional, default is None
     "withPriority": true, // Optional, default is false
     "withMediation": true, // Optional, default is false
-    "withOptionalMediation": true, // Optional, default is false
     "withMappingProvider": "AutoMapper", // Optional, default is None
     "withFileTransfer": true // Optional, default is false
   }
@@ -2018,7 +2012,8 @@ public static IApizrRegistry BuildPetstoreApizrManagers(Action<IApizrCommonOptio
     optionsBuilder += options => options
         .WithAkavacheCacheHandler()
         .WithAutoMapperMappingHandler(new MapperConfiguration(config => { /* YOUR_MAPPINGS_HERE */ }))
-        .WithPriority();
+        .WithPriority()
+        .WithFileTransferMediation();
             
     return ApizrBuilder.Current.CreateRegistry(
         registry => registry


### PR DESCRIPTION
I just removed the now deprecated Apizr.Integrations.Optional package from generating code and documentation. Optional monad pattern wasn't used that much, complicated to understand and refreneced Optional.Async package was no longer maintained for years now.

I's a breaking change for those who are using Refitter with "WithOptionalMediation" but they still can reference the deprecated integration package manually. Like I said, I bet almost no body use it actually.

I updated the doc of course and the tests.
I upgraded build test referenced packages too.