### PR TITLE
Clients implementing IDisposable interface

### DIFF
--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -250,10 +250,15 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
             : settings.Naming.InterfaceName;
 
         interfaceName = $"I{title.CapitalizeFirstCharacter()}";
+
+        var inheritance = settings.GenerateDisposableClients
+            ? ": IDisposable"
+            : null;
+        
         var modifier = settings.TypeAccessibility.ToString().ToLowerInvariant();
         return $"""
                 {Separator}{GetGeneratedCodeAttribute()}
-                {Separator}{modifier} partial interface I{title.CapitalizeFirstCharacter()}
+                {Separator}{modifier} partial interface {interfaceName} {inheritance}
                 """;
     }
 

--- a/src/Refitter.Core/RefitInterfaceImports.cs
+++ b/src/Refitter.Core/RefitInterfaceImports.cs
@@ -14,6 +14,12 @@ internal static class RefitInterfaceImports
     public static string[] GetImportedNamespaces(RefitGeneratorSettings settings)
     {
         var namespaces = new List<string>(defaultNamespases);
+
+        if(settings.GenerateDisposableClients)
+        {
+            namespaces.Add("System");
+        }
+
         if (settings.ApizrSettings?.WithRequestOptions == true)
         {
             namespaces.Add("Apizr.Configuring.Request");

--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -43,6 +43,11 @@ public class RefitGeneratorSettings
     public bool GenerateClients { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether clients should implement IDisposable.
+    /// </summary>
+    public bool GenerateDisposableClients { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether XML doc comments should be generated.
     /// </summary>
     public bool GenerateXmlDocCodeComments { get; set; } = true;


### PR DESCRIPTION
This PR adds the option to add inheritance from IDisposable by client interfaces.

Inheritance from IDisposable support add in Refit v8.0.0 https://github.com/reactiveui/refit/blob/8.0.0/InterfaceStubGenerator.Shared/Emitter.cs#L239
