### PR TITLE
Add support for disabling telemetry from MSBuild task

### DIFF
--- a/src/Refitter.MSBuild/Refitter.MSBuild.targets
+++ b/src/Refitter.MSBuild/Refitter.MSBuild.targets
@@ -1,7 +1,8 @@
 <Project>
 
     <Target Name="Refitter" BeforeTargets="BeforeBuild">
-        <RefitterGenerateTask ProjectFileDirectory="$(MSBuildProjectDirectory)" />
+        <RefitterGenerateTask ProjectFileDirectory="$(MSBuildProjectDirectory)"
+                              DisableLogging="$(RefitterNoLogging)"/>
         <ItemGroup>
             <Compile Include="**/*.cs" />
         </ItemGroup>

--- a/src/Refitter.MSBuild/RefitterGenerateTask.cs
+++ b/src/Refitter.MSBuild/RefitterGenerateTask.cs
@@ -49,13 +49,14 @@ public class RefitterGenerateTask : MSBuildTask
         var packageFolder = Path.GetDirectoryName(assembly.Location);
         var seperator = Path.DirectorySeparatorChar;
         var refitterDll = $"{packageFolder}{seperator}..{seperator}refitter.dll";
-        TryLogCommandLine("Starting " + refitterDll);
 
         var args = $"{refitterDll} --settings-file {file}";
         if (DisableLogging)
         {
             args += " --no-logging";
         }
+
+        TryLogCommandLine($"Starting dotnet {args}");
 
         using var process = new Process
         {

--- a/src/Refitter.MSBuild/RefitterGenerateTask.cs
+++ b/src/Refitter.MSBuild/RefitterGenerateTask.cs
@@ -8,6 +8,8 @@ public class RefitterGenerateTask : MSBuildTask
 {
     public string ProjectFileDirectory { get; set; }
 
+    public bool DisableLogging { get; set; }
+
     public override bool Execute()
     {
         TryLogCommandLine($"Starting {nameof(RefitterGenerateTask)}");
@@ -49,12 +51,18 @@ public class RefitterGenerateTask : MSBuildTask
         var refitterDll = $"{packageFolder}{seperator}..{seperator}refitter.dll";
         TryLogCommandLine("Starting " + refitterDll);
 
+        var args = $"{refitterDll} --settings-file {file}";
+        if (DisableLogging)
+        {
+            args += " --no-logging";
+        }
+
         using var process = new Process
         {
             StartInfo = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"{refitterDll} --settings-file {file}",
+                Arguments = args,
                 WorkingDirectory = Path.GetDirectoryName(file)!,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,

--- a/test/MSBuild/Refitter.MSBuild.Tests.csproj
+++ b/test/MSBuild/Refitter.MSBuild.Tests.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <RefitterNoLogging>true</RefitterNoLogging>
     </PropertyGroup>
 
     <ItemGroup>
@@ -13,5 +14,5 @@
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.0" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>
-   
+
 </Project>


### PR DESCRIPTION
This pull request introduces a new feature to disable logging in the `RefitterGenerateTask` and updates the related MSBuild targets and tests accordingly. The most important changes include adding a new property to control logging, modifying the MSBuild targets to use this property, and updating the process execution logic to respect this setting.

### New feature to disable logging:

* [`src/Refitter.MSBuild/Refitter.MSBuild.targets`](diffhunk://#diff-d196700fc0243c6c2f10cef734033c77a5c72403b86c506f903bf3a3847be38fL4-R5): Added the `DisableLogging` attribute to the `RefitterGenerateTask` to allow disabling logging during the build process.
* [`src/Refitter.MSBuild/RefitterGenerateTask.cs`](diffhunk://#diff-25622107c893a8ef0e23ec6525c89d39133dd8741cc4480a898a77a1df53d488R11-R12): Introduced a new `DisableLogging` property in the `RefitterGenerateTask` class and updated the `StartProcess` method to include the `--no-logging` argument if logging is disabled. [[1]](diffhunk://#diff-25622107c893a8ef0e23ec6525c89d39133dd8741cc4480a898a77a1df53d488R11-R12) [[2]](diffhunk://#diff-25622107c893a8ef0e23ec6525c89d39133dd8741cc4480a898a77a1df53d488L50-R66)

### Test project configuration:

* [`test/MSBuild/Refitter.MSBuild.Tests.csproj`](diffhunk://#diff-773b3552d883590491553f82cedb5b099d6fd3cc65a980c59424a05c3027bb0cL1-R8): Set the `<RefitterNoLogging>` property to `true` in the test project configuration to test the new logging behavior.