### PR TITLE
MSBuild Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The following is an example `.refitter` file
 - `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL
   - `httpMessageHandlers` - A collection of `HttpMessageHandler` that is added to the HttpClient pipeline
-  - `usePolly` - (DEPRECATED) Set this to true to configure the HttpClient to use Polly using a retry policy with a jittered backoff
+  - `usePolly` - Set this to `true` to configure the HttpClient to use Polly using a retry policy with a jittered backoff.  This is **DEPRECATED**, use `transientErrorHandler` instead
   - `transientErrorHandler`: Set this to configure transient error handling with a retry policy that uses a jittered backoff. See https://refitter.github.io/api/Refitter.Core.TransientErrorHandler.html
   - `firstBackoffRetryInSeconds` - This is the duration of the initial retry backoff. Default is 1 second
 - `apizrSettings` - Setting this will format Refit interface to be managed by Apizr. See https://www.apizr.net for more information

--- a/README.md
+++ b/README.md
@@ -352,6 +352,76 @@ The following is an example `.refitter` file
   - `inlineNamedAny` - Default is false
   - `excludedTypeNames` - Default is empty
 
+## MSBuild
+
+A common scenario for generating code from OpenAPI specifications is to do it at build time. This can be achieved using MSBuild tasks. An example of such an approach would be to include a `.refitter` file in the projects directory and execute the Refitter CLI from pre-build events
+
+```xml
+<Target Name="Refitter" AfterTargets="PreBuildEvent">
+    <Exec WorkingDirectory="$(ProjectDir)" Command="refitter --settings-file .refitter --skip-validation" />
+</Target>
+```
+
+The snippet above requires that Refitter is installed on the machine as a globally available dotnet tool. This might not be the case if you're running on a build agent from a CI/CD environment. In this case you might want to install Refitter as a local tool using a manifest file, as described in [this tutorial](https://learn.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use?WT.mc_id=DT-MVP-5004822)
+
+```xml
+<Target Name="Refitter" AfterTargets="PreBuildEvent">
+    <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet tool restore" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="refitter --settings-file .refitter --skip-validation" />
+</Target>
+```
+
+The `dotnet build` process does will probably not have access to the package repository in which to download Refitter from, this is at least the case with Azure Pipelines and Azure Artifacts. To workaround this, you can provide a separate `nuget.config` that only uses `nuget.org` as a `<packageSource>`.
+
+Something like this:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+You might want to place the `nuget.config` file in another folder to avoid using it to build the .NET project, then you can specify this when executing `dotnet tool restore`
+
+```xml
+<Target Name="Refitter" AfterTargets="PreBuildEvent">
+    <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet tool restore --configfile refitter/nuget.config" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="refitter --settings-file .refitter --skip-validation" />
+</Target>
+```
+
+In the example above, the `nuget.config` file is placed under the `refitter` folder.
+
+### Refitter.MSBuild package
+
+Refitter ships with an MSBuild custom task that is distributed as a NuGet package and includes the Refitter CLI binary. This will simplify generating code from OpenAPI specifications at build time. 
+
+To use the package, install `Refitter.MSBuild`
+
+```xml
+<ItemGroup>
+    <PackageReference Include="Refitter.MSBuild" Version="1.5.0" />
+</ItemGroup>
+```
+
+The MSBuild package includes a custom `.target` file which executes the `RefitterGenerateTask` custom task and looks something like this:
+
+```xml
+<Target Name="Refitter" BeforeTargets="BeforeBuild">
+    <RefitterGenerateTask ProjectFileDirectory="$(MSBuildProjectDirectory)"
+                          DisableLogging="$(RefitterNoLogging)"/>
+    <ItemGroup>
+        <Compile Include="**/*.cs" />
+    </ItemGroup>
+  </Target>
+```
+
+The `RefitterGenerateTask` task will scan the project folder for `.refitter` files and executes them all. By default, telemetry collection is enabled, and to opt-out of it you must specify `<RefitterNoLogging>true</RefitterNoLogging>` in the `.csproj` `<PropertyGroup>`
+
 
 # Using the generated code
 

--- a/docs/docfx_project/articles/msbuild.md
+++ b/docs/docfx_project/articles/msbuild.md
@@ -1,0 +1,69 @@
+## MSBuild
+
+A common scenario for generating code from OpenAPI specifications is to do it at build time. This can be achieved using MSBuild tasks. An example of such an approach would be to include a `.refitter` file in the projects directory and execute the Refitter CLI from pre-build events
+
+```xml
+<Target Name="Refitter" AfterTargets="PreBuildEvent">
+    <Exec WorkingDirectory="$(ProjectDir)" Command="refitter --settings-file .refitter --skip-validation" />
+</Target>
+```
+
+The snippet above requires that Refitter is installed on the machine as a globally available dotnet tool. This might not be the case if you're running on a build agent from a CI/CD environment. In this case you might want to install Refitter as a local tool using a manifest file, as described in [this tutorial](https://learn.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use?WT.mc_id=DT-MVP-5004822)
+
+```xml
+<Target Name="Refitter" AfterTargets="PreBuildEvent">
+    <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet tool restore" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="refitter --settings-file .refitter --skip-validation" />
+</Target>
+```
+
+The `dotnet build` process does will probably not have access to the package repository in which to download Refitter from, this is at least the case with Azure Pipelines and Azure Artifacts. To workaround this, you can provide a separate `nuget.config` that only uses `nuget.org` as a `<packageSource>`.
+
+Something like this:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+You might want to place the `nuget.config` file in another folder to avoid using it to build the .NET project, then you can specify this when executing `dotnet tool restore`
+
+```xml
+<Target Name="Refitter" AfterTargets="PreBuildEvent">
+    <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet tool restore --configfile refitter/nuget.config" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="refitter --settings-file .refitter --skip-validation" />
+</Target>
+```
+
+In the example above, the `nuget.config` file is placed under the `refitter` folder.
+
+### Refitter.MSBuild package
+
+Refitter ships with an MSBuild custom task that is distributed as a NuGet package and includes the Refitter CLI binary. This will simplify generating code from OpenAPI specifications at build time. 
+
+To use the package, install `Refitter.MSBuild`
+
+```xml
+<ItemGroup>
+    <PackageReference Include="Refitter.MSBuild" Version="1.5.0" />
+</ItemGroup>
+```
+
+The MSBuild package includes a custom `.target` file which executes the `RefitterGenerateTask` custom task and looks something like this:
+
+```xml
+<Target Name="Refitter" BeforeTargets="BeforeBuild">
+    <RefitterGenerateTask ProjectFileDirectory="$(MSBuildProjectDirectory)"
+                          DisableLogging="$(RefitterNoLogging)"/>
+    <ItemGroup>
+        <Compile Include="**/*.cs" />
+    </ItemGroup>
+  </Target>
+```
+
+The `RefitterGenerateTask` task will scan the project folder for `.refitter` files and executes them all. By default, telemetry collection is enabled, and to opt-out of it you must specify `<RefitterNoLogging>true</RefitterNoLogging>` in the `.csproj` `<PropertyGroup>`

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -160,7 +160,7 @@ The following is an example `.refitter` file
 - `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL
   - `httpMessageHandlers` - A collection of `HttpMessageHandler` that is added to the HttpClient pipeline
-  - `usePolly` - (DEPRECATED) Set this to true to configure the HttpClient to use Polly using a retry policy with a jittered backoff
+  - `usePolly` - Set this to `true` to configure the HttpClient to use Polly using a retry policy with a jittered backoff.  This is **DEPRECATED**, use `transientErrorHandler` instead
   - `transientErrorHandler`: Set this to configure transient error handling with a retry policy that uses a jittered backoff. See https://refitter.github.io/api/Refitter.Core.TransientErrorHandler.html
   - `maxRetryCount` - This is the max retry count used in the Polly retry policy. Default is 6
   - `firstBackoffRetryInSeconds` - This is the duration of the initial retry backoff. Default is 1 second

--- a/docs/docfx_project/articles/toc.yml
+++ b/docs/docfx_project/articles/toc.yml
@@ -4,6 +4,9 @@
 - name: Source Generator
   href: source-generator.md
 
+- name: MSBuild
+  href: msbuild.md
+
 - name: .refitter file format
   href: refitter-file-format.md
 

--- a/src/Refitter.MSBuild/README.md
+++ b/src/Refitter.MSBuild/README.md
@@ -1,6 +1,20 @@
 ## MSBuild Tasks for Refitter
 
-Refitter is available as custom MSBuild tasks that uses the [Refitter.Core](https://github.com/christianhelle/refitter/tree/main/src/Refitter.Core) library for generating a REST API Client using the [Refit](https://github.com/reactiveui/refit) library. Refitter can generate the Refit interface from OpenAPI specifications. Refitter could format the generated Refit interface to be managed by [Apizr](https://www.apizr.net) (v6+) and generate some registration helpers too.
+Refitter is available as custom MSBuild tasks that includes the Refitter CLI executable for generating a REST API Client using the [Refit](https://github.com/reactiveui/refit) library. Refitter can generate the Refit interface from OpenAPI specifications. Refitter could format the generated Refit interface to be managed by [Apizr](https://www.apizr.net) (v6+) and generate some registration helpers too.
+
+The MSBuild package includes a custom `.target` file which executes the `RefitterGenerateTask` custom task and looks something like this:
+
+```xml
+<Target Name="Refitter" BeforeTargets="BeforeBuild">
+    <RefitterGenerateTask ProjectFileDirectory="$(MSBuildProjectDirectory)"
+                          DisableLogging="$(RefitterNoLogging)"/>
+    <ItemGroup>
+        <Compile Include="**/*.cs" />
+    </ItemGroup>
+  </Target>
+```
+
+The `RefitterGenerateTask` task will scan the project folder for `.refitter` files and executes them all. By default, telemetry collection is enabled, and to opt-out of it you must specify `<RefitterNoLogging>true</RefitterNoLogging>` in the `.csproj` `<PropertyGroup>`
 
 
 ### .Refitter File format


### PR DESCRIPTION
This pull request includes updates to the documentation and examples for using Refitter, including new sections on using MSBuild tasks and clarifications on deprecated settings.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L312-R312): Updated the description of the `usePolly` setting to indicate it is deprecated and to use `transientErrorHandler` instead.
* [`docs/docfx_project/articles/refitter-file-format.md`](diffhunk://#diff-5700d0e2a30b141a3d7feeb8e6259a6553e4a0d884d6bab9c7fe16bbfbc3bc54L163-R163): Clarified that the `usePolly` setting is deprecated and should be replaced with `transientErrorHandler`.
* [`docs/docfx_project/articles/toc.yml`](diffhunk://#diff-083886ab0c6564e4e426fc7662dd7ff70aea18db9d70c1f5801222c0bcc3d523R7-R9): Added a new entry for the MSBuild documentation.

MSBuild integration:

* `README.md` and `docs/docfx_project/articles/msbuild.md`: Added detailed instructions and examples for using MSBuild tasks to generate code from OpenAPI specifications at build time. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R355-R424) [[2]](diffhunk://#diff-ec43a386fd3b94f54ae3a7de8480885f34600cb4cfbefb5ebc22386e35ad6e25R1-R69)
* [`src/Refitter.MSBuild/README.md`](diffhunk://#diff-2c833e2b1e69eae42a34db44b500bb4eda59c9a053d71311842ae3d7d1b1e57bL3-R17): Provided an example of the `RefitterGenerateTask` custom task and explained how to disable telemetry collection.