### PR TITLE
Less strict OpenAPI Validation rules

### DIFF
--- a/test/OpenAPI/v3.0/weather.json
+++ b/test/OpenAPI/v3.0/weather.json
@@ -1,0 +1,103 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "WebApplication",
+      "version": "1.0"
+    },
+    "paths": {
+      "/weatherforecast/{id}": {
+        "get": {
+          "tags": [
+            "WebApplication"
+          ],
+          "operationId": "GetWeatherForecastById",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/WeatherForecast"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/weatherforecast/{code}": {
+        "get": {
+          "tags": [
+            "WebApplication3"
+          ],
+          "operationId": "GetWeatherForecastByCode",
+          "parameters": [
+            {
+              "name": "code",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/WeatherForecast"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "WeatherForecast": {
+          "type": "object",
+          "properties": {
+            "date": {
+              "type": "string",
+              "format": "date"
+            },
+            "temperatureC": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "summary": {
+              "type": "string",
+              "nullable": true
+            },
+            "temperatureF": {
+              "type": "integer",
+              "format": "int32",
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  }

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -114,7 +114,8 @@ function RunTests {
         $BuildFromSource = $true
     )
 
-    $filenames = @(
+    $filenames = @(        
+        "weather",
         "bot.paths",
         "petstore",
         "petstore-expanded",


### PR DESCRIPTION
The actual change is from #556 which was implemented in [this pull request](https://github.com/christianhelle/oasreader/pull/71). The changes here just update the tests to include the example OpenAPI specification provided in #551 

This resolves #551 