### PR TITLE
Fix -v|--version CLI tool argument

### DIFF
--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -17,6 +17,10 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         if (!settings.NoLogging)
             Analytics.Configure();
 
+        if (context.Arguments.Any(a => a.Equals("--version", StringComparison.OrdinalIgnoreCase)) ||
+            context.Arguments.Any(a => a.Equals("-v", StringComparison.OrdinalIgnoreCase)))
+            return ValidationResult.Success();
+
         return SettingsValidator.Validate(settings);
     }
 
@@ -34,6 +38,12 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                 settings.NoLogging
                     ? "[green]Support key: Unavailable when logging is disabled[/]"
                     : $"[green]Support key: {SupportInformation.GetSupportKey()}[/]");
+
+            if (context.Arguments.Any(a => a.Equals("--version", StringComparison.OrdinalIgnoreCase)) ||
+                context.Arguments.Any(a => a.Equals("-v", StringComparison.OrdinalIgnoreCase)))
+            {
+                return 0;
+            }
 
             if (!string.IsNullOrWhiteSpace(settings.SettingsFilePath))
             {

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -136,6 +136,16 @@ function RunTests {
         Start-Process "dotnet" -Args "publish ../src/Refitter/Refitter.csproj -p:PublishReadyToRun=true -o bin -f net8.0" -NoNewWindow -PassThru | Wait-Process
     }
 
+    Write-Host "refitter --version"
+    $process = Start-Process "./bin/refitter" `
+        -Args " --version" `
+        -NoNewWindow `
+        -PassThru
+    $process | Wait-Process
+    if ($process.ExitCode -ne 0) {
+        throw "Show version failed!"
+    }
+
     GenerateAndBuild -format " " -namespace " " -outputPath "SwaggerPetstoreDirect.generated.cs" -args "--settings-file ./petstore.refitter" -buildFromSource $buildFromSource
     GenerateAndBuild -format " " -namespace " " -args "--settings-file ./Apizr/petstore.apizr.refitter" -csproj "./Apizr/Sample.csproj" -buildFromSource $buildFromSource
     GenerateAndBuild -format " " -namespace " " -args "--settings-file ./MultipleFiles/petstore.refitter" -csproj "MultipleFiles/Client/Client.csproj" -buildFromSource $buildFromSource


### PR DESCRIPTION
This pull request includes changes to the `src/Refitter/GenerateCommand.cs` file to handle version flag arguments. The most important changes are:

* Added a check in the `Validate` method to return success if the version flag (`--version` or `-v`) is present in the command context arguments.
* Added a check in the `ExecuteAsync` method to return a status code of 0 if the version flag (`--version` or `-v`) is present in the command context arguments.

This resolves #560 