### PR TITLE
Added simple logic to make most identifier strings valid

### DIFF
--- a/src/Refitter.Core/IdentifierUtils.cs
+++ b/src/Refitter.Core/IdentifierUtils.cs
@@ -40,6 +40,16 @@ internal static class IdentifierUtils
     public static string Sanitize(this string value)
     {
         const char dash = '-';
+
+        // @ can be used and still make valid methode names. but this should make most use cases safe
+        if (
+            (value.First() < 'A' || value.First() > 'Z') &&
+            (value.First() < 'a' || value.First() > 'z') &&
+            value.First() != '_'
+            )
+        {
+            value = "_" + value;
+        }
         return string.Join(string.Empty, value.Split(IllegalSymbols, StringSplitOptions.RemoveEmptyEntries))
                 .Trim(dash);
     }

--- a/src/Refitter.Tests/Examples/OperationIdWithInvalidFirstCharTests.cs
+++ b/src/Refitter.Tests/Examples/OperationIdWithInvalidFirstCharTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class OperationIdWithInvalidFirstCharTests
+{
+
+    private const string OpenApiSpec = @"
+openapi: '3.0.0'
+paths:
+  /jobs/{job-id}:
+    get:
+      tags:
+      - 'Jobs'
+      operationId: '2fa'
+      description: '2 factr auth'
+      parameters:
+        - in: 'path'
+          name: 'job-id'
+          description: 'Job ID'
+          required: true
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'successful operation'
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Adds_Underscore_At_Beginning_With_Ivalid_Methode_Name()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().Contain("_2fa");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = swaggerFile
+        };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}


### PR DESCRIPTION
---
name: Pull request
title: 'Added simple logic to make most identifier strings valid'
labels: bug fix
assignees: Fargekritt

---

## Description:

Adds an _ to operationIds that don´t have a valid first char to make safe identifier names
This approach is not perfect and have some flaws but will cover most normal cases. `operationId: "return"` should `@` instead of `_`but both works
[official Identifier-name naming rules](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names)

[Code Generator creates unsafe interface method names #360](https://github.com/christianhelle/refitter/issues/360)
