### PR TITLE
Limit Exceptionless telemetry

### DIFF
--- a/src/Refitter/Analytics.cs
+++ b/src/Refitter/Analytics.cs
@@ -78,11 +78,6 @@ public static class Analytics
     {
         var featureName = attribute.LongNames.FirstOrDefault() ?? property.Name;
 
-        ExceptionlessClient
-            .Default
-            .CreateFeatureUsage(featureName)
-            .Submit();
-
         telemetryClient.TrackEvent(featureName);
         telemetryClient.Flush();
     }

--- a/src/Refitter/Analytics.cs
+++ b/src/Refitter/Analytics.cs
@@ -64,11 +64,6 @@ public static class Analytics
 
         if (settings.SettingsFilePath is not null)
         {
-            ExceptionlessClient
-                .Default.CreateFeatureUsage("settings-file")
-                .AddObject(refitGeneratorSettings, ignoreSerializationErrors: true)
-                .Submit();
-
             telemetryClient.TrackEvent(
                 "settings-file",
                 new Dictionary<string, string>

--- a/src/Refitter/Analytics.cs
+++ b/src/Refitter/Analytics.cs
@@ -37,12 +37,12 @@ public static class Analytics
         telemetryClient.TelemetryConfiguration.TelemetryInitializers.Add(new SupportKeyInitializer());
     }
 
-    public static Task LogFeatureUsage(
+    public static void LogFeatureUsage(
         Settings settings,
         RefitGeneratorSettings refitGeneratorSettings)
     {
         if (settings.NoLogging)
-            return Task.CompletedTask;
+            return;
 
         foreach (var property in typeof(Settings).GetProperties())
         {
@@ -72,8 +72,6 @@ public static class Analytics
                 });
             telemetryClient.Flush();
         }
-
-        return ExceptionlessClient.Default.ProcessQueueAsync();
     }
 
     private static void LogFeatureUsage(CommandOptionAttribute attribute, PropertyInfo property)

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -63,7 +63,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
                 ? WriteMultipleFiles(generator, settings, refitGeneratorSettings)
                 : WriteSingleFile(generator, settings, refitGeneratorSettings));
 
-            await Analytics.LogFeatureUsage(settings, refitGeneratorSettings);
+            Analytics.LogFeatureUsage(settings, refitGeneratorSettings);
             AnsiConsole.MarkupLine($"[green]Duration: {stopwatch.Elapsed}{Crlf}[/]");
 
             if (!settings.NoBanner)


### PR DESCRIPTION
Due to the popularity of Refitter, I reach my monthly cap on Exceptionless after just a few days into the month. Exceptionless was kind enough to sponsor me with 15k events a month, which was fine when Refitter was initially released but now, Refitter has 150k weekly usages which is way above the 15k monthly cap.

This pull request includes changes to the `src/Refitter/Analytics.cs` and `src/Refitter/GenerateCommand.cs` files to improve the logging mechanism by removing asynchronous calls and simplifying the code. The most important changes are summarized below:

### Improvements to logging mechanism:

* Changed the `LogFeatureUsage` method from `Task` to `void` and removed the asynchronous call to `ExceptionlessClient.Default.ProcessQueueAsync` in `src/Refitter/Analytics.cs`. [[1]](diffhunk://#diff-9ac67f866d3b35737956b059cd99736872df99c9a619085bf3505729c2b76472L40-R45) [[2]](diffhunk://#diff-9ac67f866d3b35737956b059cd99736872df99c9a619085bf3505729c2b76472L80-L92)
* Removed the call to `ExceptionlessClient.Default.CreateFeatureUsage` and its related code in `LogFeatureUsage` method, opting to use `telemetryClient.TrackEvent` instead in `src/Refitter/Analytics.cs`. [[1]](diffhunk://#diff-9ac67f866d3b35737956b059cd99736872df99c9a619085bf3505729c2b76472L67-L71) [[2]](diffhunk://#diff-9ac67f866d3b35737956b059cd99736872df99c9a619085bf3505729c2b76472L80-L92)

### Code simplification:

* Updated the `ExecuteAsync` method in `src/Refitter/GenerateCommand.cs` to call the now synchronous `LogFeatureUsage` method.