### PR TITLE
Show Deserializaton Errors from Source Generator

### DIFF
--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Refitter.Core;
@@ -76,7 +76,7 @@ public class RefitterSourceGenerator : IIncrementalGenerator
                         true),
                     Location.None));
 
-            var settings = TryDeserialize(json);
+            var settings = TryDeserialize(json, diagnostics);
             if (settings is null)
             {
                 return diagnostics;
@@ -151,14 +151,28 @@ public class RefitterSourceGenerator : IIncrementalGenerator
         }
     }
 
-    private static RefitGeneratorSettings? TryDeserialize(string json)
+    private static RefitGeneratorSettings? TryDeserialize(string json, List<Diagnostic> diagnostics)
     {
         try
         {
             return Serializer.Deserialize<RefitGeneratorSettings>(json);
         }
-        catch
+        catch (Exception e)
         {
+            diagnostics.Add(
+                Diagnostic.Create(
+                    new DiagnosticDescriptor(
+                        "REFITTER000",
+                        "Error",
+                        $"Unable to deserialize .refitter file: {e}",
+                        "Refitter",
+                        DiagnosticSeverity.Error,
+                        true
+                    ),
+                    Location.None
+                )
+            );
+
             return null;
         }
     }


### PR DESCRIPTION
This resolves #568 which relates to #534

This pull request includes several changes to the `RefitterSourceGenerator.cs` file to improve error handling and diagnostics during the code generation process. The most important changes include adding a diagnostics parameter to the `TryDeserialize` method and enhancing the error handling mechanism.

Improvements to error handling and diagnostics:

* [`src/Refitter.SourceGenerator/RefitterSourceGenerator.cs`](diffhunk://#diff-90a29fe1932e165fb8390fa7a09adab7593510586be65b64abcdbfe46777758fL79-R79): Added a `diagnostics` parameter to the `TryDeserialize` method to collect diagnostics information. [[1]](diffhunk://#diff-90a29fe1932e165fb8390fa7a09adab7593510586be65b64abcdbfe46777758fL79-R79) [[2]](diffhunk://#diff-90a29fe1932e165fb8390fa7a09adab7593510586be65b64abcdbfe46777758fL154-R175)
* [`src/Refitter.SourceGenerator/RefitterSourceGenerator.cs`](diffhunk://#diff-90a29fe1932e165fb8390fa7a09adab7593510586be65b64abcdbfe46777758fL154-R175): Enhanced the `catch` block in the `TryDeserialize` method to add a diagnostic message when deserialization fails.

Using the source generator with a .refitter file containing invalid JSON will result in an error message like this:

```
CSC : error REFITTER000: 
Unable to deserialize .refitter file: System.Text.Json.JsonException
The JSON object contains a trailing comma at the end which is not supported in this mode. 
Change the reader options. Path: $ | LineNumber: 8 | BytePositionInLine: 0.

Build failed with 1 error(s) in 2.3s
```