### PR TITLE
- #557 - discard unused union types/inheritance types via config

### DIFF
--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -20,7 +20,7 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
 
         ProcessTagFilters(openApiDocument, settings.IncludeTags);
         ProcessPathFilters(openApiDocument, settings.IncludePathMatches);
-        ProcessContractFilter(openApiDocument, settings.TrimUnusedSchema, settings.KeepSchemaPatterns);
+        ProcessContractFilter(openApiDocument, settings.TrimUnusedSchema, settings.KeepSchemaPatterns, settings.IncludeInheritanceHierarchy);
 
         return new RefitGenerator(settings, openApiDocument);
     }
@@ -55,13 +55,17 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
         return openApiDocument;
     }
 
-    private static void ProcessContractFilter(OpenApiDocument openApiDocument, bool removeUnusedSchema, string[] includeSchemaMatches)
+    private static void ProcessContractFilter(OpenApiDocument openApiDocument, bool removeUnusedSchema, string[] includeSchemaMatches,
+        bool includeInheritanceHierarchy)
     {
         if (!removeUnusedSchema)
         {
             return;
         }
-        var cleaner = new SchemaCleaner(openApiDocument, includeSchemaMatches);
+        var cleaner = new SchemaCleaner(openApiDocument, includeSchemaMatches)
+        {
+            IncludeInheritanceHierarchy = includeInheritanceHierarchy
+        };
         cleaner.RemoveUnreferencedSchema();
     }
 

--- a/src/Refitter.Core/SchemaCleaner.cs
+++ b/src/Refitter.Core/SchemaCleaner.cs
@@ -37,8 +37,7 @@ public class SchemaCleaner
                 {
                     var mappings = schema.DiscriminatorObject.Mapping;
                     var keepMappings = mappings.Where(x =>
-                            usage.Contains(x.Value.ActualSchema.Id ?? x.Value.Id ?? "_________SOME NON EXISTING VALUE")
-                            )
+                            (x.Value.ActualSchema.Id ?? x.Value.Id) is { } id && usage.Contains(id))
                         .ToArray();
 
                     schema.DiscriminatorObject.Mapping.Clear();

--- a/src/Refitter.Core/SchemaCleaner.cs
+++ b/src/Refitter.Core/SchemaCleaner.cs
@@ -9,6 +9,8 @@ public class SchemaCleaner
     private readonly OpenApiDocument document;
     private readonly string[] keepSchemaPatterns;
 
+    public bool IncludeInheritanceHierarchy { get; set; }
+
     public SchemaCleaner(OpenApiDocument document, string[] keepSchemaPatterns)
     {
         this.document = document;
@@ -17,8 +19,7 @@ public class SchemaCleaner
 
     public void RemoveUnreferencedSchema()
     {
-        var usage = FindUsedSchema(document);
-
+        var (usedJsonSchema, usage) = FindUsedJsonSchema(document);
         var unused = document.Components.Schemas.Where(s => !usage.Contains(s.Key))
             .ToArray();
 
@@ -26,9 +27,31 @@ public class SchemaCleaner
         {
             document.Components.Schemas.Remove(unusedSchema);
         }
+
+        if (!IncludeInheritanceHierarchy)
+        {
+            foreach (var schema in usedJsonSchema)
+            {
+                // Fix any "abstract/sum" types so that the unused-types get removed
+                if (schema.DiscriminatorObject != null)
+                {
+                    var mappings = schema.DiscriminatorObject.Mapping;
+                    var keepMappings = mappings.Where(x =>
+                            usage.Contains(x.Value.ActualSchema.Id ?? x.Value.Id ?? "_________SOME NON EXISTING VALUE")
+                            )
+                        .ToArray();
+
+                    schema.DiscriminatorObject.Mapping.Clear();
+                    foreach (var kvp in keepMappings)
+                    {
+                        schema.DiscriminatorObject.Mapping[kvp.Key] = kvp.Value;
+                    }
+                }
+            }
+        }
     }
 
-    private HashSet<string> FindUsedSchema(OpenApiDocument doc)
+    private (IReadOnlyCollection<JsonSchema>, HashSet<string>) FindUsedJsonSchema(OpenApiDocument doc)
     {
         var toProcess = new Stack<JsonSchema>();
         var schemaIdLookup = document.Components.Schemas
@@ -82,7 +105,7 @@ public class SchemaCleaner
             }
         }
 
-        return seenIds;
+        return (seen, seenIds);
     }
 
     private IEnumerable<JsonSchema?> GetSchemaForPath(OpenApiPathItem pathItem)
@@ -144,10 +167,10 @@ public class SchemaCleaner
             .Where(x => x != null)
             .Select(x => x!);
 
-        static IEnumerable<JsonSchema?> EnumerateInternal(JsonSchema schema)
+        IEnumerable<JsonSchema?> EnumerateInternal(JsonSchema schema)
         {
             schema = schema.ActualSchema;
-            
+
             yield return schema.AdditionalItemsSchema;
             yield return schema.AdditionalPropertiesSchema;
             if (schema.AllInheritedSchemas != null)
@@ -157,12 +180,12 @@ public class SchemaCleaner
                     yield return s;
                 }
             }
-            
+
             if (schema.Item != null)
             {
                 yield return schema.Item;
             }
-            
+
             if (schema.Items != null)
             {
                 foreach (JsonSchema s in schema.Items)
@@ -177,6 +200,16 @@ public class SchemaCleaner
             foreach (var subSchema in schema.AllOf)
             {
                 yield return subSchema;
+            }
+
+            if (schema.DiscriminatorObject != null && IncludeInheritanceHierarchy)
+            {
+                // abstract type
+                // if we let these out, we get a bunch of "AnonymousN"-classes
+                foreach (var subSchema in schema.DiscriminatorObject.Mapping)
+                {
+                    yield return subSchema.Value;
+                }
             }
 
             foreach (var subSchema in schema.AnyOf)

--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -138,7 +138,7 @@ public class RefitGeneratorSettings
     public bool GenerateDeprecatedOperations { get; set; } = true;
 
     /// <summary>
-    /// Generate operation names using pattern. 
+    /// Generate operation names using pattern.
     /// When using <see cref="MultipleInterfaces"/> <see cref="Core.MultipleInterfaces.ByEndpoint"/>, this is name of the Execute() method in the interface.
     /// </summary>
     public string? OperationNameTemplate { get; set; }
@@ -186,6 +186,13 @@ public class RefitGeneratorSettings
     /// This works in conjunction with <see cref="TrimUnusedSchema"/>.
     /// </summary>
     public string[] KeepSchemaPatterns { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Set to <c>true</c> to keep all possible type-instances of inheritance/union types.
+    /// If this is <c>false</c> only directly referenced types will be kept.
+    /// This works in conjunction with <see cref="TrimUnusedSchema"/>.
+    /// </summary>
+    public bool IncludeInheritanceHierarchy { get; set; }
 
     /// <summary>
     /// The NSwag IOperationNameGenerator implementation to use

--- a/src/Refitter.Tests/Examples/IncludeInheritanceHierarchyTests.cs
+++ b/src/Refitter.Tests/Examples/IncludeInheritanceHierarchyTests.cs
@@ -1,0 +1,127 @@
+﻿using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests.Examples
+{
+    public class IncludeInheritanceHierarchyTests
+    {
+        private const string OpenApiSpec = @"
+openapi: 3.0.1
+paths:
+  /v1/A:
+    post:
+      tags:
+        - A
+      operationId: CreateA
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/A'
+components:
+  schemas:
+    ABaseType:
+      required:
+        - $type
+      type: object
+      properties:
+        $type:
+          type: string
+      discriminator:
+        propertyName: $type
+        mapping:
+          A: '#/components/schemas/A'
+          B: '#/components/schemas/B'
+      additionalProperties: false
+    A:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ABaseType'
+      properties:
+        propertyOfA:
+          type: integer
+          format: int64
+      additionalProperties: false
+    B:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ABaseType'
+      properties:
+        propertyOfB:
+          type: integer
+          format: int64
+      additionalProperties: false
+";
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Can_Generate_Code(bool includeHierarchy)
+    {
+        string generateCode = await GenerateCode(includeHierarchy);
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Removes_Unreferenced_Schema()
+    {
+        string generateCode = await GenerateCode(includeHierarchy: false);
+        generateCode.Should().NotContain("Anonymous");
+
+        generateCode.Should().NotContain("class B");
+        generateCode.Should().Contain("class A");
+    }
+
+    [Fact]
+    public async Task Keeps_All_Union_Cases_Schema()
+    {
+        string generateCode = await GenerateCode(includeHierarchy: true);
+        generateCode.Should().NotContain("Anonymous");
+
+        generateCode.Should().Contain("class B");
+        generateCode.Should().Contain("class A");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Can_Build_Generated_Code(bool includeHierarchy)
+    {
+        string generateCode = await GenerateCode(includeHierarchy);
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode(bool includeHierarchy)
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = swaggerFile,
+            TrimUnusedSchema = true,
+            IncludeInheritanceHierarchy = includeHierarchy,
+            UsePolymorphicSerialization = true, // use System.Text.Json attributes
+        };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}
+}

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -134,6 +134,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             OptionalParameters = settings.OptionalNullableParameters,
             TrimUnusedSchema = settings.TrimUnusedSchema,
             KeepSchemaPatterns = settings.KeepSchemaPatterns ?? Array.Empty<string>(),
+            IncludeInheritanceHierarchy = settings.IncludeInheritanceHierarchy,
             OperationNameGenerator = settings.OperationNameGenerator,
             GenerateDefaultAdditionalProperties = !settings.SkipDefaultAdditionalProperties,
             ImmutableRecords = settings.ImmutableRecords,

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -158,6 +158,11 @@ public sealed class Settings : CommandSettings
     [DefaultValue(new string[0])]
     public string[]? KeepSchemaPatterns { get; set; }
 
+    [Description("Keep all possible inherited types/union types even if they are not directly used.")]
+    [CommandOption("--include-inheritance-hierarchy")]
+    [DefaultValue(false)]
+    public bool IncludeInheritanceHierarchy { get; set; }
+
     [Description("Don't show donation banner")]
     [CommandOption("--no-banner")]
     [DefaultValue(false)]


### PR DESCRIPTION
This PR solves #557 by providing a flag to either keep all possible union types/the whole inheritance chain of an abstract type, or trimming the schema to remove any "Anonymous" types