### PR TITLE
Return null when object subtype is not found

### DIFF
--- a/src/Refitter.Core/Templates/JsonInheritanceConverter.liquid
+++ b/src/Refitter.Core/Templates/JsonInheritanceConverter.liquid
@@ -222,7 +222,7 @@ public class JsonInheritanceConverter : Newtonsoft.Json.JsonConverter
                 return attribute.Type;
         }
 
-        return objectType;
+        return null;
     }
 
     private string GetSubtypeDiscriminator(System.Type objectType)


### PR DESCRIPTION
Fixes `StackOverflowException` which is thrown when subtype discriminator value is unknown.

The same issue was reported in [NJsonSchema](https://github.com/RicoSuter/NJsonSchema/issues/1728) with a corresponding [fix](https://github.com/RicoSuter/NJsonSchema/pull/1729).