### PR TITLE
Fix incorrect error message shown due to Spectre.Console parsing

### DIFF
--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -83,9 +83,8 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
 
             if (exception is not OpenApiValidationException)
             {
-                AnsiConsole.MarkupLine($"[red]Error: {exception.Message}[/]");
-                AnsiConsole.MarkupLine($"[red]Exception: {exception.GetType()}[/]");
-                AnsiConsole.MarkupLine($"[yellow]Stack Trace:{Crlf}{exception.StackTrace}[/]");
+                AnsiConsole.MarkupLine("[red]Exception:[/]");
+                AnsiConsole.WriteException(exception);
                 AnsiConsole.WriteLine();
             }
 


### PR DESCRIPTION
This relates to #583

This pull request includes a change to improve the error handling in the `ExecuteAsync` method of the `GenerateCommand` class. The main change involves simplifying the way exceptions are logged to the console.

Error handling improvement:

* [`src/Refitter/GenerateCommand.cs`](diffhunk://#diff-5a3744a20d6fb16b3196ad75a6cffd5df047271cf9c9b8ca898f93784eecce31L86-R87): Simplified the exception logging by using `AnsiConsole.WriteException` to print the exception details instead of manually formatting the message, exception type, and stack trace.