### PR TITLE
Update docs for --include-inheritance-hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ The following is an example `.refitter` file
     "^Model$",
     "^Person.+"
   ],
+  "includeInheritanceHierarchy": false, // Optional. Default=false. Set to true to keep all possible type-instances of inheritance/union types. This works in conjunction with trimUnusedSchema.
   "generateDefaultAdditionalProperties": true, // Optional. default=true
   "operationNameGenerator": "Default", // Optional. May be one of Default, MultipleClientsFromOperationId, MultipleClientsFromPathSegments, MultipleClientsFromFirstTagAndOperationId, MultipleClientsFromFirstTagAndOperationName, MultipleClientsFromFirstTagAndPathSegments, SingleClientFromOperationId, SingleClientFromPathSegments
   "immutableRecords": false,
@@ -304,6 +305,7 @@ The following is an example `.refitter` file
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `trimUnusedSchema` - Removes unreferenced components schema to keep the generated output to a minimum
 - `keepSchemaPatterns`: A collection of regular expressions to force to keep matching schema. This is used together with `trimUnusedSchema`
+- `includeInheritanceHierarchy`: Set to true to keep all possible type-instances of inheritance/union types. If this is false only directly referenced types will be kept. This works in conjunction with `trimUnusedSchema`
 - `generateDefaultAdditionalProperties`: Set to `false` to skip default additional properties. Default is `true`
 - `operationNameGenerator`: The NSwag `IOperationNameGenerator` implementation to use. See https://refitter.github.io/api/Refitter.Core.OperationNameGeneratorTypes.html
 - `immutableRecords`: Set to `true` to generate contracts as immutable records instead of classes. Default is `false`

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ OPTIONS:
         --optional-nullable-parameters                           Generate nullable parameters as optional parameters
         --trim-unused-schema                                     Removes unreferenced components schema to keep the generated output to a minimum
         --keep-schema                                            Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times
+        --include-inheritance-hierarchy                          Keep all possible inherited types/union types even if they are not directly used
         --no-banner                                              Don't show donation banner
         --skip-default-additional-properties                     Set to true to skip default additional properties
         --operation-name-generator              Default          The NSwag IOperationNameGenerator implementation to use.

--- a/docs/docfx_project/articles/cli-tool.md
+++ b/docs/docfx_project/articles/cli-tool.md
@@ -79,6 +79,7 @@ OPTIONS:
         --optional-nullable-parameters                           Generate nullable parameters as optional parameters                                                                                       
         --trim-unused-schema                                     Removes unreferenced components schema to keep the generated output to a minimum                                                          
         --keep-schema                                            Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times              
+        --include-inheritance-hierarchy                          Keep all possible inherited types/union types even if they are not directly used                                                          
         --no-banner                                              Don't show donation banner                                                                                                                
         --skip-default-additional-properties                     Set to true to skip default additional properties                                                                                         
         --operation-name-generator              Default          The NSwag IOperationNameGenerator implementation to use.                                                                                  

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -151,6 +151,7 @@ The following is an example `.refitter` file
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `trimUnusedSchema` - Removes unreferenced components schema to keep the generated output to a minimum
 - `keepSchemaPatterns`: A collection of regular expressions to force to keep matching schema. This is used together with `trimUnusedSchema`
+- `includeInheritanceHierarchy`: Set to true to keep all possible type-instances of inheritance/union types. If this is false only directly referenced types will be kept. This works in conjunction with `trimUnusedSchema`
 - `generateDefaultAdditionalProperties`: Set to `false` to skip default additional properties. Default is `true`
 - `operationNameGenerator`: The NSwag `IOperationNameGenerator` implementation to use. See https://refitter.github.io/api/Refitter.Core.OperationNameGeneratorTypes.html
 - `immutableRecords`: Set to `true` to generate contracts as immutable records instead of classes. Default is `false`

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -82,6 +82,7 @@ OPTIONS:
         --optional-nullable-parameters                           Generate nullable parameters as optional parameters
         --trim-unused-schema                                     Removes unreferenced components schema to keep the generated output to a minimum
         --keep-schema                                            Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times
+        --include-inheritance-hierarchy                          Keep all possible inherited types/union types even if they are not directly used
         --no-banner                                              Don't show donation banner
         --skip-default-additional-properties                     Set to true to skip default additional properties
         --operation-name-generator              Default          The NSwag IOperationNameGenerator implementation to use.


### PR DESCRIPTION
Adds missing documentation updates for changes introduced in #575

This pull request adds a new option to include inheritance hierarchy in various configuration files and documentation. The main changes involve updating the `README.md` and other documentation files to reflect this new option.

Updates to documentation and configuration:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R101): Added the `--include-inheritance-hierarchy` option to the `OPTIONS:` section and described its functionality in the example `.refitter` file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R101) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R215) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R308)
* [`docs/docfx_project/articles/cli-tool.md`](diffhunk://#diff-02d0bdff78b5bf0c440df6e5d1aeb793a8513bdcef49a5c5bf7757b3f52a5a03R82): Included the `--include-inheritance-hierarchy` option in the `OPTIONS:` section.
* [`docs/docfx_project/articles/refitter-file-format.md`](diffhunk://#diff-5700d0e2a30b141a3d7feeb8e6259a6553e4a0d884d6bab9c7fe16bbfbc3bc54R154): Added a description for the `includeInheritanceHierarchy` option in the example `.refitter` file section.
* [`src/Refitter/README.md`](diffhunk://#diff-0cc8bf2255699a9e34d6f7ab2dbbb93d145c5cf40b54cf164357ba80bb93daf7R85): Updated the `OPTIONS:` section to include the `--include-inheritance-hierarchy` option.