### PR TITLE
Remove dependency on System.Text.Json

### DIFF
--- a/src/Refitter.Core/Refitter.Core.csproj
+++ b/src/Refitter.Core/Refitter.Core.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="14.2.0" />
     <PackageReference Include="NSwag.Core.Yaml" Version="14.2.0" />
     <PackageReference Include="OasReader" Version="1.6.16.16" />
-    <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request includes a small change to the `src/Refitter.Core/Refitter.Core.csproj` file. The change removes the `System.Text.Json` package reference.

* [`src/Refitter.Core/Refitter.Core.csproj`](diffhunk://#diff-444c79f78399cbb25d189742011c22f15d51330d014b91a714aabc678c422aa2L18): Removed the `System.Text.Json` package reference.