### PR TITLE
Fix ISO date format handling when dateFormat is defined in settings file

### DIFF
--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -98,7 +98,7 @@ internal static class ParameterExtractor
         {
             { parameter.IsArray: true } => "Query(CollectionFormat.Multi)",
             { parameter.IsDate: true, settings.UseIsoDateFormat: true } => "Query(Format = \"yyyy-MM-dd\")",
-            { parameter.IsDateOrDateTime: true, settings.CodeGeneratorSettings: not null } => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateFormat}\")",
+            { parameter.IsDate: true, settings.CodeGeneratorSettings.DateFormat: not null } => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateFormat}\")",
             _ => "Query",
         };
     }

--- a/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
@@ -159,7 +159,10 @@ public class CodeGeneratorSettings
     /// </summary>
     public string[] ExcludedTypeNames { get; set; } = Array.Empty<string>();
 
-    public string DateFormat { get; set; } = "yyyy-MM-dd";
+    /// <summary>
+    /// Gets or sets the date string format to use
+    /// </summary>
+    public string? DateFormat { get; set; }
 
     /// <summary>
     /// Gets or sets a custom <see cref="IPropertyNameGenerator"/>.

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -91,6 +91,21 @@ public class RefitterSourceGenerator : IIncrementalGenerator
                     settings.OpenApiPath);
             }
 
+            if (settings.UseIsoDateFormat &&
+                settings.CodeGeneratorSettings?.DateFormat is not null)
+            {
+                diagnostics.Add(
+                    Diagnostic.Create(
+                        new DiagnosticDescriptor(
+                            "REFITTER002",
+                            "Warning",
+                            "'codeGeneratorSettings.dateFormat' will be ignored due to 'useIsoDateFormat' set to true",
+                            "Refitter",
+                            DiagnosticSeverity.Warning,
+                            true),
+                        Location.None));
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
             var generator = RefitGenerator.CreateAsync(settings).GetAwaiter().GetResult();
             var refit = generator.Generate();

--- a/src/Refitter.Tests/Examples/UseIsoDateFormatTests.cs
+++ b/src/Refitter.Tests/Examples/UseIsoDateFormatTests.cs
@@ -75,6 +75,52 @@ paths:
     }
 
     [Fact]
+    public async Task GeneratedCode_Contains_Date_Format_String_With_Empty_Settings()
+    {
+        string generateCode = await GenerateCode(new CodeGeneratorSettings());
+        generateCode.Should().Contain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset valid_from");
+        generateCode.Should().Contain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset valid_to");
+    }
+
+    [Fact]
+    public async Task GeneratedCode_NotContains_DateTime_Format_String_With_Empty_Settings()
+    {
+        string generateCode = await GenerateCode(new CodeGeneratorSettings());
+		generateCode.Should().Contain(@"[Query] System.DateTimeOffset test_datetime");
+        generateCode.Should().NotContain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset time_datetime");
+    }
+
+    [Fact]
+    public async Task GeneratedCode_Contains_TimeSpan_Parameter_With_Empty_Settings()
+    {
+        string generateCode = await GenerateCode(new CodeGeneratorSettings());
+        generateCode.Should().Contain("[Query] System.TimeSpan");
+    }
+
+    [Fact]
+    public async Task GeneratedCode_Contains_Date_Format_String_With_Settings()
+    {
+        string generateCode = await GenerateCode(new CodeGeneratorSettings { DateFormat = "yyyy-MM-dd" });
+        generateCode.Should().Contain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset valid_from");
+        generateCode.Should().Contain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset valid_to");
+    }
+
+    [Fact]
+    public async Task GeneratedCode_NotContains_DateTime_Format_String_With_Settings()
+    {
+        string generateCode = await GenerateCode(new CodeGeneratorSettings { DateFormat = "yyyy-MM-dd" });
+		generateCode.Should().Contain(@"[Query] System.DateTimeOffset test_datetime");
+        generateCode.Should().NotContain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset time_datetime");
+    }
+
+    [Fact]
+    public async Task GeneratedCode_Contains_TimeSpan_Parameter_With_Settings()
+    {
+        string generateCode = await GenerateCode(new CodeGeneratorSettings { DateFormat = "yyyy-MM-dd" });
+        generateCode.Should().Contain("[Query] System.TimeSpan");
+    }
+
+    [Fact]
     public async Task Can_Build_Generated_Code()
     {
         string generateCode = await GenerateCode();
@@ -84,10 +130,15 @@ paths:
             .BeTrue();
     }
 
-    private static async Task<string> GenerateCode()
+    private static async Task<string> GenerateCode(CodeGeneratorSettings? generatorSettings = null)
     {
         var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
-        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile, UseIsoDateFormat = true };
+        var settings = new RefitGeneratorSettings 
+		{ 
+			OpenApiPath = swaggerFile,
+			UseIsoDateFormat = true,
+			CodeGeneratorSettings = generatorSettings
+		};
 
         var sut = await RefitGenerator.CreateAsync(settings);
         var generateCode = sut.Generate();

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -77,7 +77,9 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             AnsiConsole.WriteLine();
             if (exception is OpenApiUnsupportedSpecVersionException unsupportedSpecVersionException)
             {
-                AnsiConsole.MarkupLine($"[red]Unsupported OpenAPI version: {unsupportedSpecVersionException.SpecificationVersion}[/]");
+                AnsiConsole.MarkupLine(
+                    $"[red]Unsupported OpenAPI version: {unsupportedSpecVersionException.SpecificationVersion}[/]"
+                );
                 AnsiConsole.WriteLine();
             }
 
@@ -212,7 +214,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         if (refitGeneratorSettings.UseIsoDateFormat &&
             refitGeneratorSettings.CodeGeneratorSettings?.DateFormat is not null)
         {
-            AnsiConsole.MarkupLine("[yellow]'codeGeneratorSettings.dateFormat' will be ignored due to 'useIsoDateFormat' set to true");
+            AnsiConsole.MarkupLine("[yellow]WARNING: 'codeGeneratorSettings.dateFormat' will be ignored due to 'useIsoDateFormat' set to true[/]");
             AnsiConsole.WriteLine();
         }
 

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -69,7 +69,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             if (!settings.NoBanner)
                 DonationBanner();
 
-            ShowDeprecationWarning(refitGeneratorSettings);
+            ShowWarnings(refitGeneratorSettings);
             return 0;
         }
         catch (Exception exception)
@@ -207,8 +207,15 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         }
     }
 
-    private static void ShowDeprecationWarning(RefitGeneratorSettings refitGeneratorSettings)
+    private static void ShowWarnings(RefitGeneratorSettings refitGeneratorSettings)
     {
+        if (refitGeneratorSettings.UseIsoDateFormat &&
+            refitGeneratorSettings.CodeGeneratorSettings?.DateFormat is not null)
+        {
+            AnsiConsole.MarkupLine("[yellow]'codeGeneratorSettings.dateFormat' will be ignored due to 'useIsoDateFormat' set to true");
+            AnsiConsole.WriteLine();
+        }
+
 #pragma warning disable CS0618 // Type or member is obsolete
         if (refitGeneratorSettings.DependencyInjectionSettings?.UsePolly is true)
 #pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
This should fix the #599 

This pull request includes several changes to improve the handling of date formats and enhance test coverage in the `Refitter` project. The most important changes include modifying the `CodeGeneratorSettings` class to support nullable date format strings, updating the `GetQueryAttribute` method to use the new date format property, and expanding the test suite to cover various scenarios related to date formats and settings.

Enhancements to date format handling:

* [`src/Refitter.Core/Settings/CodeGeneratorSettings.cs`](diffhunk://#diff-6ef4d463b40adb93fa8148a5aac284ac193b42d09a8c86af3e433d9a86cf405cL162-R165): Modified the `DateFormat` property to be nullable and added a summary comment.
* [`src/Refitter.Core/ParameterExtractor.cs`](diffhunk://#diff-fbf2584535de6a59f14801ef402a25e5d27e497a7fbebd15c6d2052cb113b013L101-R101): Updated the `GetQueryAttribute` method to use the new nullable `DateFormat` property in `CodeGeneratorSettings`.

Improvements to test coverage:

* [`src/Refitter.Tests/Examples/UseIsoDateFormatTests.cs`](diffhunk://#diff-cde063ce947d73f122ef27cf921af997d091fbec8906eff926d75cefb57408a7R79-R140): Added multiple test cases to verify the correct generation of code with different date format settings and scenarios.
* [`src/Refitter.Tests/Examples/UseIsoDateFormatTests.cs`](diffhunk://#diff-cde063ce947d73f122ef27cf921af997d091fbec8906eff926d75cefb57408a7L1-R2): Included `AutoFixture.Xunit2` for parameterized tests and adjusted the formatting of the `OpenApiSpec` constant. [[1]](diffhunk://#diff-cde063ce947d73f122ef27cf921af997d091fbec8906eff926d75cefb57408a7L1-R2) [[2]](diffhunk://#diff-cde063ce947d73f122ef27cf921af997d091fbec8906eff926d75cefb57408a7L10-R12)