### PR TITLE
Add support for custom DateTimeFormat

### DIFF
--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using NJsonSchema;
 using NSwag;
 using NSwag.CodeGeneration.CSharp.Models;
 using NSwag.CodeGeneration.Models;
@@ -96,9 +97,20 @@ internal static class ParameterExtractor
     {
         return (parameter, settings) switch
         {
-            { parameter.IsArray: true } => "Query(CollectionFormat.Multi)",
-            { parameter.IsDate: true, settings.UseIsoDateFormat: true } => "Query(Format = \"yyyy-MM-dd\")",
-            { parameter.IsDate: true, settings.CodeGeneratorSettings.DateFormat: not null } => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateFormat}\")",
+            { parameter.IsArray: true }
+                => "Query(CollectionFormat.Multi)",
+            { parameter.IsDate: true, settings.UseIsoDateFormat: true }
+                => "Query(Format = \"yyyy-MM-dd\")",
+            { parameter.IsDate: true, settings.CodeGeneratorSettings.DateFormat: not null }
+                => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateFormat}\")",
+            {
+                    parameter.IsDateOrDateTime: true, parameter.Schema.Format: "date-time",
+                    settings.CodeGeneratorSettings.DateTimeFormat: not null
+                } => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateTimeFormat}\")",
+            {
+                    parameter.Schema.Type: JsonObjectType.String, parameter.Schema.Format: "time",
+                    settings.CodeGeneratorSettings.TimeFormat: not null
+                } => $"Query(Format = \"{settings.CodeGeneratorSettings?.TimeFormat}\")",
             _ => "Query",
         };
     }

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -107,10 +107,6 @@ internal static class ParameterExtractor
                     parameter.IsDateOrDateTime: true, parameter.Schema.Format: "date-time",
                     settings.CodeGeneratorSettings.DateTimeFormat: not null
                 } => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateTimeFormat}\")",
-            {
-                    parameter.Schema.Type: JsonObjectType.String, parameter.Schema.Format: "time",
-                    settings.CodeGeneratorSettings.TimeFormat: not null
-                } => $"Query(Format = \"{settings.CodeGeneratorSettings?.TimeFormat}\")",
             _ => "Query",
         };
     }

--- a/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
@@ -165,6 +165,16 @@ public class CodeGeneratorSettings
     public string? DateFormat { get; set; }
 
     /// <summary>
+    /// Gets or sets the time string format to use
+    /// </summary>
+    public string? TimeFormat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date-time string format to use
+    /// </summary>
+    public string? DateTimeFormat { get; set; }
+
+    /// <summary>
     /// Gets or sets a custom <see cref="IPropertyNameGenerator"/>.
     /// </summary>
     [JsonIgnore]

--- a/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
@@ -165,11 +165,6 @@ public class CodeGeneratorSettings
     public string? DateFormat { get; set; }
 
     /// <summary>
-    /// Gets or sets the time string format to use
-    /// </summary>
-    public string? TimeFormat { get; set; }
-
-    /// <summary>
     /// Gets or sets the date-time string format to use
     /// </summary>
     public string? DateTimeFormat { get; set; }

--- a/src/Refitter.Tests/Examples/UseIsoDateFormatTests.cs
+++ b/src/Refitter.Tests/Examples/UseIsoDateFormatTests.cs
@@ -100,11 +100,23 @@ paths:
     }
 
     [Theory, AutoData]
-    public async Task GeneratedCode_Contains_Date_Format_String_With_Settings(string format)
+    public async Task GeneratedCode_Contains_Date_Format_String_With_Settings(
+        string timeFormat,
+        string dateFormat,
+        string dateTimeFormat)
     {
-        string generateCode = await GenerateCode(new CodeGeneratorSettings { DateFormat = format });
-        generateCode.Should().Contain(@$"[Query(Format = ""{format}"")] System.DateTimeOffset valid_from");
-        generateCode.Should().Contain(@$"[Query(Format = ""{format}"")] System.DateTimeOffset valid_to");
+        var generateCode = await GenerateCode(
+            new CodeGeneratorSettings
+            {
+                TimeFormat = timeFormat,
+                DateFormat = dateFormat,
+                DateTimeFormat = dateTimeFormat
+            });
+
+        generateCode.Should().Contain(@$"[Query(Format = ""{dateFormat}"")] System.DateTimeOffset valid_from");
+        generateCode.Should().Contain(@$"[Query(Format = ""{dateFormat}"")] System.DateTimeOffset valid_to");
+        generateCode.Should().Contain(@$"[Query(Format = ""{dateTimeFormat}"")] System.DateTimeOffset test_datetime");
+        generateCode.Should().Contain(@$"[Query(Format = ""{timeFormat}"")] System.TimeSpan test_time");
     }
 
     [Theory, AutoData]

--- a/src/Refitter.Tests/Examples/UseIsoDateFormatTests.cs
+++ b/src/Refitter.Tests/Examples/UseIsoDateFormatTests.cs
@@ -101,14 +101,12 @@ paths:
 
     [Theory, AutoData]
     public async Task GeneratedCode_Contains_Date_Format_String_With_Settings(
-        string timeFormat,
         string dateFormat,
         string dateTimeFormat)
     {
         var generateCode = await GenerateCode(
             new CodeGeneratorSettings
             {
-                TimeFormat = timeFormat,
                 DateFormat = dateFormat,
                 DateTimeFormat = dateTimeFormat
             });
@@ -116,7 +114,7 @@ paths:
         generateCode.Should().Contain(@$"[Query(Format = ""{dateFormat}"")] System.DateTimeOffset valid_from");
         generateCode.Should().Contain(@$"[Query(Format = ""{dateFormat}"")] System.DateTimeOffset valid_to");
         generateCode.Should().Contain(@$"[Query(Format = ""{dateTimeFormat}"")] System.DateTimeOffset test_datetime");
-        generateCode.Should().Contain(@$"[Query(Format = ""{timeFormat}"")] System.TimeSpan test_time");
+        generateCode.Should().Contain(@$"[Query] System.TimeSpan test_time");
     }
 
     [Theory, AutoData]


### PR DESCRIPTION
This builds upon #603 and #599 

This pull request introduces several changes to enhance date and date-time formatting capabilities in the `Refitter.Core` project. The key updates include adding support for date-time string formats, modifying the `ParameterExtractor` to handle the new formats, and updating the related test cases to verify these changes.

Enhancements to date and date-time formatting:

* [`src/Refitter.Core/Settings/CodeGeneratorSettings.cs`](diffhunk://#diff-6ef4d463b40adb93fa8148a5aac284ac193b42d09a8c86af3e433d9a86cf405cR167-R171): Added a new property `DateTimeFormat` to the `CodeGeneratorSettings` class to allow specifying a custom date-time string format.
* [`src/Refitter.Core/ParameterExtractor.cs`](diffhunk://#diff-fbf2584535de6a59f14801ef402a25e5d27e497a7fbebd15c6d2052cb113b013L99-R109): Updated the `GetQueryAttribute` method to handle the new `DateTimeFormat` property and added support for `parameter.IsDateOrDateTime` with `parameter.Schema.Format` set to "date-time".

Test updates:

* [`src/Refitter.Tests/Examples/UseIsoDateFormatTests.cs`](diffhunk://#diff-cde063ce947d73f122ef27cf921af997d091fbec8906eff926d75cefb57408a7L103-R117): Modified the `GeneratedCode_Contains_Date_Format_String_With_Settings` test to include checks for the new `DateTimeFormat` property and ensure proper generation of query attributes for date-time formats.