### PR TITLE
Fix invalid characters in generated XML docs

### DIFF
--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -25,6 +25,7 @@ public class RefitGeneratorSettings
 
     /// <summary>
     /// Gets or sets the namespace for the generated contracts. (default: GeneratedCode);
+    /// </summary>
     public string? ContractsNamespace { get; set; }
 
     /// <summary>

--- a/src/Refitter.Core/XmlDocumentationGenerator.cs
+++ b/src/Refitter.Core/XmlDocumentationGenerator.cs
@@ -235,10 +235,7 @@ public class XmlDocumentationGenerator
     private string EscapeSymbols(string input)
     {
         return input
-            .Replace("&", "&amp;")
             .Replace("<", "&lt;")
-            .Replace(">", "&gt;")
-            .Replace("\"", "&quot;")
-            .Replace("'", "&apos;");
+            .Replace(">", "&gt;");
     }
 }

--- a/src/Refitter.Core/XmlDocumentationGenerator.cs
+++ b/src/Refitter.Core/XmlDocumentationGenerator.cs
@@ -55,10 +55,10 @@ public class XmlDocumentationGenerator
             return;
 
         if (!string.IsNullOrWhiteSpace(method.Summary))
-            this.AppendXmlCommentBlock("summary", method.Summary, code);
+            this.AppendXmlCommentBlock("summary", EscapeSymbols(method.Summary), code);
 
         if (!string.IsNullOrWhiteSpace(method.Description))
-            this.AppendXmlCommentBlock("remarks", method.Description, code);
+            this.AppendXmlCommentBlock("remarks", EscapeSymbols(method.Description), code);
 
         foreach (var parameter in method.Parameters)
         {
@@ -230,5 +230,15 @@ public class XmlDocumentationGenerator
             .Append("</list>");
 
         return description.ToString();
+    }
+
+    private string EscapeSymbols(string input)
+    {
+        return input
+            .Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("\"", "&quot;")
+            .Replace("'", "&apos;");
     }
 }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/Refitter.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/Refitter.g.cs
@@ -221,7 +221,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         Task<Order> PlaceOrder([Body] Order body);
 
         /// <summary>Find purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">
@@ -246,7 +246,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         Task<Order> GetOrderById(long orderId);
 
         /// <summary>Delete purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
@@ -266,7 +266,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     public partial interface IGetOrderByIdEndpoint
     {
         /// <summary>Find purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">
@@ -295,7 +295,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
     public partial interface IDeleteOrderEndpoint
     {
         /// <summary>Delete purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfacesByTag.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfacesByTag.g.cs
@@ -221,7 +221,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         Task<Order> PlaceOrder([Body] Order body);
 
         /// <summary>Find purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">
@@ -245,7 +245,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         Task<Order> GetOrderById(long orderId);
 
         /// <summary>Delete purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreOptionalParameters.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreOptionalParameters.g.cs
@@ -221,7 +221,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         Task<Order> PlaceOrder([Body] Order? body = default);
 
         /// <summary>Find purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">
@@ -246,7 +246,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         Task<Order> GetOrderById(long orderId);
 
         /// <summary>Delete purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
@@ -221,7 +221,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         Task<Order> PlaceOrder([Body] Order body);
 
         /// <summary>Find purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">
@@ -246,7 +246,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         Task<Order> GetOrderById(long orderId);
 
         /// <summary>Delete purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
@@ -221,7 +221,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         Task<Order> PlaceOrder([Body] Order body);
 
         /// <summary>Find purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">
@@ -246,7 +246,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         Task<Order> GetOrderById(long orderId);
 
         /// <summary>Delete purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">

--- a/src/Refitter.SourceGenerator.Tests/CustomGenerated/CustomGenerated.cs
+++ b/src/Refitter.SourceGenerator.Tests/CustomGenerated/CustomGenerated.cs
@@ -223,7 +223,7 @@ namespace Refitter.Tests.CustomGenerated
         Task<Order> PlaceOrder([Body] Order body);
 
         /// <summary>Find purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions</remarks>
         /// <param name="orderId">ID of order that needs to be fetched</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">
@@ -248,7 +248,7 @@ namespace Refitter.Tests.CustomGenerated
         Task<Order> GetOrderById(long orderId);
 
         /// <summary>Delete purchase order by ID</summary>
-        /// <remarks>For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
+        /// <remarks>For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors</remarks>
         /// <param name="orderId">ID of the order that needs to be deleted</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">

--- a/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
+++ b/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
@@ -11,6 +11,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -6,6 +6,7 @@ public static class ProjectFileContents
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />

--- a/src/Refitter.Tests/Examples/SymbolsInDescriptionTests.cs
+++ b/src/Refitter.Tests/Examples/SymbolsInDescriptionTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class SymbolsInDescriptionTests
+{
+    private const string OpenApiSpec = @"
+openapi: 3.0.0
+info:
+  title: Reference parameters
+  version: v0.0.1
+paths:
+  '/symbols':
+    get:
+      description: >-
+        Something something <test> >> << </test>
+      responses:
+        '204':
+          description: No Content.
+        default:
+          description: Default response
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Error:
+    type: object
+    properties:
+      message:
+          type: string
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        var generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Symbols_In_Description_Are_Escaped()
+    {
+        var generateCode = await GenerateCode();
+        generateCode.Should().Contain("&lt;test&gt; &gt;&gt; &lt;&lt; &lt;/test&gt;");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        var generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/test/ConsoleApp/Directory.Build.props
+++ b/test/ConsoleApp/Directory.Build.props
@@ -4,6 +4,7 @@
         <LangVersion>latest</LangVersion>
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="..\Program.cs">

--- a/test/ConsoleApp/Directory.Build.props
+++ b/test/ConsoleApp/Directory.Build.props
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="..\Program.cs">


### PR DESCRIPTION
This resolves #605 

This pull request introduces several changes aimed at improving XML documentation generation and ensuring that symbols in descriptions are properly escaped. Additionally, it includes updates to the project files to generate documentation files and adds new tests to verify these changes.

Improvements to XML documentation generation:

* [`src/Refitter.Core/XmlDocumentationGenerator.cs`](diffhunk://#diff-1cee808dcdf73b5cd2a273cb85f48e831c6d1bebfba1827469a394469113e5d3L58-R61): Added a new private method `EscapeSymbols` to properly escape `<` and `>` symbols in method summaries and remarks. Updated `AppendMethodDocumentation` to use `EscapeSymbols` for method summaries and remarks. [[1]](diffhunk://#diff-1cee808dcdf73b5cd2a273cb85f48e831c6d1bebfba1827469a394469113e5d3L58-R61) [[2]](diffhunk://#diff-1cee808dcdf73b5cd2a273cb85f48e831c6d1bebfba1827469a394469113e5d3R234-R240)

Updates to project files:

* [`src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj`](diffhunk://#diff-5b2acedb4728d48e37b4880faeead1411f2dfa6a715902ea008c9db2ad1b6171R14): Enabled the generation of documentation files by setting `<GenerateDocumentationFile>true</GenerateDocumentationFile>`.
* [`src/Refitter.Tests/Build/ProjectFileContents.cs`](diffhunk://#diff-b50eea9ef8bc22e552467f370a0388c3036d02b4d024b5b854a6cd0dff53db01R9): Enabled the generation of documentation files by setting `<GenerateDocumentationFile>true</GenerateDocumentationFile>`.

New tests to verify changes:

* [`src/Refitter.Tests/Examples/SymbolsInDescriptionTests.cs`](diffhunk://#diff-fce33f9f40ceaf2d4c1c65855de36a32cb115482b334c9477256d90519f21316R1-R79): Added a new test class `SymbolsInDescriptionTests` with tests to ensure that symbols in descriptions are properly escaped and that the generated code can be built successfully.

Additional minor changes:

* [`src/Refitter.Core/Settings/RefitGeneratorSettings.cs`](diffhunk://#diff-09c3f09073c55f1efe14257ada0398aa412484724cd037564f9be336dcb3e048R28): Added a missing closing tag in the XML documentation for the `ContractsNamespace` property.
* [`src/Refitter.SourceGenerator.Tests/CustomGenerated/CustomGenerated.cs`](diffhunk://#diff-e6fa4f6d1eadbd53a5a65e76016e1219c7cc32e520cd39d6d97db50baee296d2L226-R226): Updated XML documentation remarks to use escaped symbols for `<` and `>`. [[1]](diffhunk://#diff-e6fa4f6d1eadbd53a5a65e76016e1219c7cc32e520cd39d6d97db50baee296d2L226-R226) [[2]](diffhunk://#diff-e6fa4f6d1eadbd53a5a65e76016e1219c7cc32e520cd39d6d97db50baee296d2L251-R251)