### PR TITLE
Fix missing Content-Type [Headers]

### DIFF
--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -198,7 +198,10 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
                 uniqueContentTypes.FirstOrDefault(c => c.Equals("application/json", StringComparison.OrdinalIgnoreCase)) ??
                 uniqueContentTypes.FirstOrDefault();
 
-            headers.Add($"\"Content-Type: {contentType}\"");
+            if (!string.IsNullOrWhiteSpace(contentType))
+            {
+                headers.Add($"\"Content-Type: {contentType}\"");
+            }
         }
 
         if (headers.Any())

--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -74,7 +74,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
                 this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), hasDynamicQuerystringParameter, hasApizrRequestOptionsParameter, code);
                 GenerateObsoleteAttribute(operation, code);
                 GenerateForMultipartFormData(operationModel, code);
-                GenerateAcceptHeaders(operations, operation, code);
+                GenerateHeaders(operations, operation, code);
 
                 code.AppendLine($"{Separator}{Separator}[{verb}(\"{kv.Key}\")]")
                     .AppendLine($"{Separator}{Separator}{returnType} {operationName}({parametersString});")
@@ -85,7 +85,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
                     this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), false, hasApizrRequestOptionsParameter, code);
                     GenerateObsoleteAttribute(operation, code);
                     GenerateForMultipartFormData(operationModel, code);
-                    GenerateAcceptHeaders(operations, operation, code);
+                    GenerateHeaders(operations, operation, code);
 
                     parametersString = string.Join(", ", parameters.Where(parameter => !parameter.Contains("?")));
 
@@ -166,7 +166,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
         }
     }
 
-    protected void GenerateAcceptHeaders(
+    protected void GenerateHeaders(
         KeyValuePair<string, OpenApiOperation> operations,
         OpenApiOperation operation,
         StringBuilder code)

--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -171,6 +171,8 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
         OpenApiOperation operation,
         StringBuilder code)
     {
+        var headers = new List<string>();
+
         if (settings.AddAcceptHeaders && document.SchemaType is >= NJsonSchema.SchemaType.OpenApi3)
         {
             //Generate header "Accept"
@@ -185,8 +187,23 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
 
             if (uniqueContentTypes.Any())
             {
-                code.AppendLine($"{Separator}{Separator}[Headers(\"Accept: {string.Join(", ", uniqueContentTypes)}\")]");
+                headers.Add($"\"Accept: {string.Join(", ", uniqueContentTypes)}\"");
             }
+        }
+
+        if (settings.AddContentTypeHeaders && document.SchemaType is >= NJsonSchema.SchemaType.OpenApi3)
+        {
+            var uniqueContentTypes = operations.Value.RequestBody?.Content.Keys ?? Array.Empty<string>();
+            var contentType =
+                uniqueContentTypes.FirstOrDefault(c => c.Equals("application/json", StringComparison.OrdinalIgnoreCase)) ??
+                uniqueContentTypes.FirstOrDefault();
+
+            headers.Add($"\"Content-Type: {contentType}\"");
+        }
+
+        if (headers.Any())
+        {
+            code.AppendLine($"{Separator}{Separator}[Headers({string.Join(", ", headers)})]");
         }
     }
 

--- a/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
@@ -84,7 +84,7 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
                 this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), hasDynamicQuerystringParameter, hasApizrRequestOptionsParameter, sb);
                 GenerateObsoleteAttribute(operation, sb);
                 GenerateForMultipartFormData(operationModel, sb);
-                GenerateAcceptHeaders(operations, operation, sb);
+                GenerateHeaders(operations, operation, sb);
 
                 sb.AppendLine($"{Separator}{Separator}[{verb}(\"{op.PathItem.Key}\")]")
                     .AppendLine($"{Separator}{Separator}{returnType} {operationName}({parametersString});")
@@ -95,7 +95,7 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
                     this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), false, hasApizrRequestOptionsParameter, sb);
                     GenerateObsoleteAttribute(operation, sb);
                     GenerateForMultipartFormData(operationModel, sb);
-                    GenerateAcceptHeaders(operations, operation, sb);
+                    GenerateHeaders(operations, operation, sb);
 
                     parametersString = string.Join(", ", parameters.Where(parameter => !parameter.Contains("?")));
 

--- a/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
@@ -58,7 +58,7 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
                 this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), hasDynamicQuerystringParameter, hasApizrRequestOptionsParameter, code);
                 GenerateObsoleteAttribute(operation, code);
                 GenerateForMultipartFormData(operationModel, code);
-                GenerateAcceptHeaders(operations, operation, code);
+                GenerateHeaders(operations, operation, code);
 
                 code.AppendLine($"{Separator}{Separator}[{verb}(\"{kv.Key}\")]")
                     .AppendLine($"{Separator}{Separator}{returnType} {methodName}({parametersString});")
@@ -69,7 +69,7 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
                     this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), false, hasApizrRequestOptionsParameter, code);
                     GenerateObsoleteAttribute(operation, code);
                     GenerateForMultipartFormData(operationModel, code);
-                    GenerateAcceptHeaders(operations, operation, code);
+                    GenerateHeaders(operations, operation, code);
 
                     parametersString = string.Join(", ", parameters.Where(parameter => !parameter.Contains("?")));
 

--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -69,6 +69,11 @@ public class RefitGeneratorSettings
     public bool AddAcceptHeaders { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to add content-type headers [Headers("Content-Type: application/json")].
+    /// </summary>
+    public bool AddContentTypeHeaders { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether to return <c>IApiResponse</c> objects.
     /// </summary>
     public bool ReturnIApiResponse { get; set; }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/Refitter.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/Refitter.g.cs
@@ -40,7 +40,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Put("/pet")]
         Task<Pet> UpdatePet([Body] Pet body);
 
@@ -61,7 +61,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Post("/pet")]
         Task<Pet> AddPet([Body] Pet body);
 
@@ -82,7 +82,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
 
@@ -103,7 +103,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
 
@@ -128,7 +128,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: ")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -150,6 +150,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
@@ -169,6 +170,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -188,7 +190,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </returns>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/octet-stream")]
         [Post("/pet/{petId}/uploadImage")]
         Task<ApiResponse> UploadFile(long petId, [Query] string additionalMetadata, StreamPart body);
 
@@ -196,7 +198,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -216,7 +218,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/json")]
         [Post("/store/order")]
         Task<Order> PlaceOrder([Body] Order body);
 
@@ -241,7 +243,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -266,6 +268,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -274,7 +277,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json, application/xml")]
+        [Headers("Accept: application/json, application/xml", "Content-Type: application/json")]
         [Post("/user")]
         Task CreateUser([Body] User body);
 
@@ -282,7 +285,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Post("/user/createWithList")]
         Task<User> CreateUsersWithListInput([Body] IEnumerable<User> body);
 
@@ -303,13 +306,14 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -333,7 +337,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -343,6 +347,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: application/json")]
         [Put("/user/{username}")]
         Task UpdateUser(string username, [Body] User body);
 
@@ -367,6 +372,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/Refitter.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/Refitter.g.cs
@@ -82,7 +82,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
 
@@ -103,7 +103,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
 
@@ -128,7 +128,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json", "Content-Type: ")]
+        [Headers("Accept: application/xml, application/json")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -150,7 +150,6 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
@@ -170,7 +169,6 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -198,7 +196,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -243,7 +241,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -268,7 +266,6 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -306,14 +303,13 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -337,7 +333,7 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -372,7 +368,6 @@ namespace Refitter.Tests.AdditionalFiles.NoFilename
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
@@ -95,7 +95,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> Execute([Query] Status? status);
     }
@@ -121,7 +120,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> Execute([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
     }
@@ -151,7 +149,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/pet/{petId}")]
         Task<Pet> Execute(long petId);
     }
@@ -178,7 +175,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task Execute(long petId, [Query] string name, [Query] string status);
     }
@@ -203,7 +199,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task Execute(long petId, [Header("api_key")] string api_key);
     }
@@ -241,7 +236,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Content-Type: ")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> Execute();
     }
@@ -296,7 +290,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/store/order/{orderId}")]
         Task<Order> Execute(long orderId);
     }
@@ -326,7 +319,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task Execute(long orderId);
     }
@@ -379,7 +371,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/user/login")]
         Task<string> Execute([Query] string username, [Query] string password);
     }
@@ -391,7 +382,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task Execute();
     }
@@ -420,7 +410,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/user/{username}")]
         Task<User> Execute(string username);
     }
@@ -465,7 +454,6 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task Execute(string username);
     }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
@@ -43,6 +43,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: application/json")]
         [Put("/pet")]
         Task<Pet> Execute([Body] Pet body);
     }
@@ -68,6 +69,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: application/json")]
         [Post("/pet")]
         Task<Pet> Execute([Body] Pet body);
     }
@@ -93,6 +95,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> Execute([Query] Status? status);
     }
@@ -118,6 +121,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> Execute([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
     }
@@ -147,6 +151,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/pet/{petId}")]
         Task<Pet> Execute(long petId);
     }
@@ -173,6 +178,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task Execute(long petId, [Query] string name, [Query] string status);
     }
@@ -197,6 +203,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task Execute(long petId, [Header("api_key")] string api_key);
     }
@@ -221,6 +228,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </returns>
+        [Headers("Content-Type: application/octet-stream")]
         [Post("/pet/{petId}/uploadImage")]
         Task<ApiResponse> Execute(long petId, [Query] string additionalMetadata, StreamPart body);
     }
@@ -233,6 +241,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: ")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> Execute();
     }
@@ -257,6 +266,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: application/json")]
         [Post("/store/order")]
         Task<Order> Execute([Body] Order body);
     }
@@ -286,6 +296,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/store/order/{orderId}")]
         Task<Order> Execute(long orderId);
     }
@@ -315,6 +326,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task Execute(long orderId);
     }
@@ -328,6 +340,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: application/json")]
         [Post("/user")]
         Task Execute([Body] User body);
     }
@@ -340,6 +353,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: application/json")]
         [Post("/user/createWithList")]
         Task<User> Execute([Body] IEnumerable<User> body);
     }
@@ -365,6 +379,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/user/login")]
         Task<string> Execute([Query] string username, [Query] string password);
     }
@@ -376,6 +391,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task Execute();
     }
@@ -404,6 +420,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/user/{username}")]
         Task<User> Execute(string username);
     }
@@ -418,6 +435,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: application/json")]
         [Put("/user/{username}")]
         Task Execute(string username, [Body] User body);
     }
@@ -447,6 +465,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task Execute(string username);
     }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfacesByTag.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfacesByTag.g.cs
@@ -85,7 +85,6 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
 
@@ -106,7 +105,6 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
 
@@ -131,7 +129,6 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -153,7 +150,6 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
@@ -173,7 +169,6 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -206,7 +201,6 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Content-Type: ")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -251,7 +245,6 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -276,7 +269,6 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
     }
@@ -319,14 +311,12 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -350,7 +340,6 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -385,7 +374,6 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
     }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfacesByTag.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfacesByTag.g.cs
@@ -43,6 +43,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: application/json")]
         [Put("/pet")]
         Task<Pet> UpdatePet([Body] Pet body);
 
@@ -63,6 +64,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: application/json")]
         [Post("/pet")]
         Task<Pet> AddPet([Body] Pet body);
 
@@ -83,6 +85,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
 
@@ -103,6 +106,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
 
@@ -127,6 +131,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -148,6 +153,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
@@ -167,6 +173,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -186,6 +193,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </returns>
+        [Headers("Content-Type: application/octet-stream")]
         [Post("/pet/{petId}/uploadImage")]
         Task<ApiResponse> UploadFile(long petId, [Query] string additionalMetadata, StreamPart body);
     }
@@ -198,6 +206,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: ")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -217,6 +226,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: application/json")]
         [Post("/store/order")]
         Task<Order> PlaceOrder([Body] Order body);
 
@@ -241,6 +251,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -265,6 +276,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
     }
@@ -278,6 +290,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: application/json")]
         [Post("/user")]
         Task CreateUser([Body] User body);
 
@@ -285,6 +298,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: application/json")]
         [Post("/user/createWithList")]
         Task<User> CreateUsersWithListInput([Body] IEnumerable<User> body);
 
@@ -305,12 +319,14 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -334,6 +350,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -343,6 +360,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: application/json")]
         [Put("/user/{username}")]
         Task UpdateUser(string username, [Body] User body);
 
@@ -367,6 +385,7 @@ namespace Refitter.Tests.AdditionalFiles.ByTag
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
     }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreOptionalParameters.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreOptionalParameters.g.cs
@@ -82,7 +82,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status = default);
 
@@ -103,7 +103,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string>? tags = default);
 
@@ -128,7 +128,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json", "Content-Type: ")]
+        [Headers("Accept: application/xml, application/json")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -150,7 +150,6 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string? name = default, [Query] string? status = default);
 
@@ -170,7 +169,6 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string? api_key = default);
 
@@ -198,7 +196,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -243,7 +241,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -268,7 +266,6 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -306,14 +303,13 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string? username = default, [Query] string? password = default);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -337,7 +333,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -372,7 +368,6 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreOptionalParameters.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreOptionalParameters.g.cs
@@ -40,7 +40,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Put("/pet")]
         Task<Pet> UpdatePet([Body] Pet body);
 
@@ -61,7 +61,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Post("/pet")]
         Task<Pet> AddPet([Body] Pet body);
 
@@ -82,7 +82,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status = default);
 
@@ -103,7 +103,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string>? tags = default);
 
@@ -128,7 +128,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: ")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -150,6 +150,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string? name = default, [Query] string? status = default);
 
@@ -169,6 +170,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string? api_key = default);
 
@@ -188,7 +190,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </returns>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/octet-stream")]
         [Post("/pet/{petId}/uploadImage")]
         Task<ApiResponse> UploadFile(long petId, StreamPart body, [Query] string? additionalMetadata = default);
 
@@ -196,7 +198,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -216,7 +218,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/json")]
         [Post("/store/order")]
         Task<Order> PlaceOrder([Body] Order? body = default);
 
@@ -241,7 +243,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -266,6 +268,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -274,7 +277,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json, application/xml")]
+        [Headers("Accept: application/json, application/xml", "Content-Type: application/json")]
         [Post("/user")]
         Task CreateUser([Body] User? body = default);
 
@@ -282,7 +285,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Post("/user/createWithList")]
         Task<User> CreateUsersWithListInput([Body] IEnumerable<User>? body = default);
 
@@ -303,13 +306,14 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string? username = default, [Query] string? password = default);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -333,7 +337,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -343,6 +347,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: application/json")]
         [Put("/user/{username}")]
         Task UpdateUser(string username, [Body] User? body = default);
 
@@ -367,6 +372,7 @@ namespace Refitter.Tests.AdditionalFiles.OptionalParameters
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
@@ -82,7 +82,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
 
@@ -103,7 +103,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
 
@@ -128,7 +128,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json", "Content-Type: ")]
+        [Headers("Accept: application/xml, application/json")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -150,7 +150,6 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
@@ -170,7 +169,6 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -198,7 +196,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -243,7 +241,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -268,7 +266,6 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -306,14 +303,13 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -337,7 +333,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -372,7 +368,6 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
@@ -40,7 +40,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Put("/pet")]
         Task<Pet> UpdatePet([Body] Pet body);
 
@@ -61,7 +61,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Post("/pet")]
         Task<Pet> AddPet([Body] Pet body);
 
@@ -82,7 +82,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
 
@@ -103,7 +103,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
 
@@ -128,7 +128,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: ")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -150,6 +150,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
@@ -169,6 +170,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -188,7 +190,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </returns>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/octet-stream")]
         [Post("/pet/{petId}/uploadImage")]
         Task<ApiResponse> UploadFile(long petId, [Query] string additionalMetadata, StreamPart body);
 
@@ -196,7 +198,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -216,7 +218,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/json")]
         [Post("/store/order")]
         Task<Order> PlaceOrder([Body] Order body);
 
@@ -241,7 +243,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -266,6 +268,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -274,7 +277,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json, application/xml")]
+        [Headers("Accept: application/json, application/xml", "Content-Type: application/json")]
         [Post("/user")]
         Task CreateUser([Body] User body);
 
@@ -282,7 +285,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Post("/user/createWithList")]
         Task<User> CreateUsersWithListInput([Body] IEnumerable<User> body);
 
@@ -303,13 +306,14 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -333,7 +337,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -343,6 +347,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: application/json")]
         [Put("/user/{username}")]
         Task UpdateUser(string username, [Body] User body);
 
@@ -367,6 +372,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
@@ -82,7 +82,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
 
@@ -103,7 +103,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
 
@@ -128,7 +128,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json", "Content-Type: ")]
+        [Headers("Accept: application/xml, application/json")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -150,7 +150,6 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
@@ -170,7 +169,6 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -198,7 +196,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -243,7 +241,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -268,7 +266,6 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -306,14 +303,13 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -337,7 +333,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -372,7 +368,6 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
@@ -40,7 +40,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Put("/pet")]
         Task<Pet> UpdatePet([Body] Pet body);
 
@@ -61,7 +61,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Post("/pet")]
         Task<Pet> AddPet([Body] Pet body);
 
@@ -82,7 +82,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
 
@@ -103,7 +103,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
 
@@ -128,7 +128,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: ")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -150,6 +150,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
@@ -169,6 +170,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -188,7 +190,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </returns>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/octet-stream")]
         [Post("/pet/{petId}/uploadImage")]
         Task<ApiResponse> UploadFile(long petId, [Query] string additionalMetadata, StreamPart body);
 
@@ -196,7 +198,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -216,7 +218,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/json")]
         [Post("/store/order")]
         Task<Order> PlaceOrder([Body] Order body);
 
@@ -241,7 +243,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -266,6 +268,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -274,7 +277,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json, application/xml")]
+        [Headers("Accept: application/json, application/xml", "Content-Type: application/json")]
         [Post("/user")]
         Task CreateUser([Body] User body);
 
@@ -282,7 +285,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Post("/user/createWithList")]
         Task<User> CreateUsersWithListInput([Body] IEnumerable<User> body);
 
@@ -303,13 +306,14 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -333,7 +337,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -343,6 +347,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: application/json")]
         [Put("/user/{username}")]
         Task UpdateUser(string username, [Body] User body);
 
@@ -367,6 +372,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/UseJsonInheritanceConverter.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/UseJsonInheritanceConverter.g.cs
@@ -34,7 +34,7 @@ namespace Refitter.Tests.UseJsonInheritanceConverter
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/json")]
         [Post("/v1/Warehouses")]
         Task<ICollection<WarehouseResponse>> CreateWarehouse([Query] string token, [Body] Warehouse body);
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/UsePolymorphicSerialization.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/UsePolymorphicSerialization.g.cs
@@ -34,7 +34,7 @@ namespace Refitter.Tests.UsePolymorphicSerialization
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/json")]
         [Post("/v1/Warehouses")]
         Task<ICollection<WarehouseResponse>> CreateWarehouse([Query] string token, [Body] Warehouse body);
 

--- a/src/Refitter.SourceGenerator.Tests/CustomGenerated/CustomGenerated.cs
+++ b/src/Refitter.SourceGenerator.Tests/CustomGenerated/CustomGenerated.cs
@@ -84,7 +84,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
 
@@ -105,7 +105,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
 
@@ -130,7 +130,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json", "Content-Type: ")]
+        [Headers("Accept: application/xml, application/json")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -152,7 +152,6 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
@@ -172,7 +171,6 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -200,7 +198,7 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -245,7 +243,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -270,7 +268,6 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -308,14 +305,13 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -339,7 +335,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json", "Content-Type: ")]
+        [Headers("Accept: application/json")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -374,7 +370,6 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.SourceGenerator.Tests/CustomGenerated/CustomGenerated.cs
+++ b/src/Refitter.SourceGenerator.Tests/CustomGenerated/CustomGenerated.cs
@@ -42,7 +42,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Put("/pet")]
         Task<Pet> UpdatePet([Body] Pet body);
 
@@ -63,7 +63,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Post("/pet")]
         Task<Pet> AddPet([Body] Pet body);
 
@@ -84,7 +84,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/pet/findByStatus")]
         Task<ICollection<Pet>> FindPetsByStatus([Query] Status? status);
 
@@ -105,7 +105,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/pet/findByTags")]
         Task<ICollection<Pet>> FindPetsByTags([Query(CollectionFormat.Multi)] IEnumerable<string> tags);
 
@@ -130,7 +130,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: ")]
         [Get("/pet/{petId}")]
         Task<Pet> GetPetById(long petId);
 
@@ -152,6 +152,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Post("/pet/{petId}")]
         Task UpdatePetWithForm(long petId, [Query] string name, [Query] string status);
 
@@ -171,6 +172,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/pet/{petId}")]
         Task DeletePet(long petId, [Header("api_key")] string api_key);
 
@@ -190,7 +192,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </returns>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/octet-stream")]
         [Post("/pet/{petId}/uploadImage")]
         Task<ApiResponse> UploadFile(long petId, [Query] string additionalMetadata, StreamPart body);
 
@@ -198,7 +200,7 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/store/inventory")]
         Task<IDictionary<string, int>> GetInventory();
 
@@ -218,7 +220,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: application/json")]
         [Post("/store/order")]
         Task<Order> PlaceOrder([Body] Order body);
 
@@ -243,7 +245,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/store/order/{orderId}")]
         Task<Order> GetOrderById(long orderId);
 
@@ -268,6 +270,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/store/order/{orderId}")]
         Task DeleteOrder(long orderId);
 
@@ -276,7 +279,7 @@ namespace Refitter.Tests.CustomGenerated
         /// <param name="body">Created user object</param>
         /// <returns>successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/json, application/xml")]
+        [Headers("Accept: application/json, application/xml", "Content-Type: application/json")]
         [Post("/user")]
         Task CreateUser([Body] User body);
 
@@ -284,7 +287,7 @@ namespace Refitter.Tests.CustomGenerated
         /// <remarks>Creates list of users with given input array</remarks>
         /// <returns>Successful operation</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
-        [Headers("Accept: application/xml, application/json")]
+        [Headers("Accept: application/xml, application/json", "Content-Type: application/json")]
         [Post("/user/createWithList")]
         Task<User> CreateUsersWithListInput([Body] IEnumerable<User> body);
 
@@ -305,13 +308,14 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/user/login")]
         Task<string> LoginUser([Query] string username, [Query] string password);
 
         /// <summary>Logs out current logged in user session</summary>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: ")]
         [Get("/user/logout")]
         Task LogoutUser();
 
@@ -335,7 +339,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
-        [Headers("Accept: application/json")]
+        [Headers("Accept: application/json", "Content-Type: ")]
         [Get("/user/{username}")]
         Task<User> GetUserByName(string username);
 
@@ -345,6 +349,7 @@ namespace Refitter.Tests.CustomGenerated
         /// <param name="body">Update an existent user in the store</param>
         /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
         /// <exception cref="ApiException">Thrown when the request returns a non-success status code.</exception>
+        [Headers("Content-Type: application/json")]
         [Put("/user/{username}")]
         Task UpdateUser(string username, [Body] User body);
 
@@ -369,6 +374,7 @@ namespace Refitter.Tests.CustomGenerated
         /// </item>
         /// </list>
         /// </exception>
+        [Headers("Content-Type: ")]
         [Delete("/user/{username}")]
         Task DeleteUser(string username);
 

--- a/src/Refitter.Tests/Examples/RequestResponseHeadersTests.cs
+++ b/src/Refitter.Tests/Examples/RequestResponseHeadersTests.cs
@@ -18,18 +18,11 @@ paths:
           application/json:
             schema:
               type: string
-          application/xml:
-            schema:
-              type: string
         required: true
       responses:
         '200':
-          description: OK
           content:
             application/json:
-              schema:
-                type: string
-            application/xml:
               schema:
                 type: string
 ";
@@ -47,6 +40,14 @@ paths:
         var generateCode = await GenerateCode();
         using var scope = new AssertionScope();
         generateCode.Should().Contain("Content-Type: application/json");
+    }
+
+    [Fact]
+    public async Task Generates_Accept_Header_Attribute()
+    {
+        var generateCode = await GenerateCode();
+        using var scope = new AssertionScope();
+        generateCode.Should().Contain("Accept: application/json");
     }
 
     [Fact]

--- a/src/Refitter.Tests/Examples/RequestResponseHeadersTests.cs
+++ b/src/Refitter.Tests/Examples/RequestResponseHeadersTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class RequestResponseHeadersTests
+{
+    private const string OpenApiSpec = @"
+openapi: 3.0.1
+paths:
+  /foo:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          application/xml:
+            schema:
+              type: string
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+            application/xml:
+              schema:
+                type: string
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        var generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Generates_ContentType_Header_Attribute()
+    {
+        var generateCode = await GenerateCode();
+        using var scope = new AssertionScope();
+        generateCode.Should().Contain("Content-Type: application/json");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        var generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile, AddAcceptHeaders = true };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/src/Refitter.Tests/Examples/ResponseHeadersTests.cs
+++ b/src/Refitter.Tests/Examples/ResponseHeadersTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class ResponseHeadersTests
+{
+    private const string OpenApiSpec = @"
+openapi: 3.0.1
+paths:
+  /foo:
+    post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: string
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        var generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Should_Not_Generate_ContentType_Header_Attribute()
+    {
+        var generateCode = await GenerateCode();
+        using var scope = new AssertionScope();
+        generateCode.Should().NotContain("Content-Type: \")]");
+    }
+
+    [Fact]
+    public async Task Generates_Accept_Header_Attribute()
+    {
+        var generateCode = await GenerateCode();
+        using var scope = new AssertionScope();
+        generateCode.Should().Contain("Accept: application/json");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        var generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile, AddAcceptHeaders = true };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/src/Refitter.Tests/SwaggerPetstoreApizrTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreApizrTests.cs
@@ -268,9 +268,9 @@ public class SwaggerPetstoreApizrTests
         var settings = new ApizrGeneratorSettings();
         var generateCode = await GenerateCode(version, filename, settings);
         if (version is SampleOpenSpecifications.SwaggerPetstoreJsonV3 or SampleOpenSpecifications.SwaggerPetstoreYamlV3)
-            generateCode.Should().Contain("[Headers(\"Accept: application/json\")]");
+            generateCode.Should().Contain("[Headers(\"Accept: application/json\"");
         else if (version is SampleOpenSpecifications.SwaggerPetstoreJsonV2 or SampleOpenSpecifications.SwaggerPetstoreYamlV2)
-            generateCode.Should().NotContain("[Headers(\"Accept: application/json\")]");
+            generateCode.Should().NotContain("[Headers(\"Accept: application/json\"");
     }
 
     [Theory]

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -271,9 +271,9 @@ public class SwaggerPetstoreTests
         var settings = new RefitGeneratorSettings();
         var generateCode = await GenerateCode(version, filename, settings);
         if (version is SampleOpenSpecifications.SwaggerPetstoreJsonV3 or SampleOpenSpecifications.SwaggerPetstoreYamlV3)
-            generateCode.Should().Contain("[Headers(\"Accept: application/json\")]");
+            generateCode.Should().Contain("[Headers(\"Accept: application/json\"");
         else if (version is SampleOpenSpecifications.SwaggerPetstoreJsonV2 or SampleOpenSpecifications.SwaggerPetstoreYamlV2)
-            generateCode.Should().NotContain("[Headers(\"Accept: application/json\")]");
+            generateCode.Should().NotContain("[Headers(\"Accept: application/json\"");
     }
 
     [Theory]


### PR DESCRIPTION
This resolves #617

This pull request includes several changes to enhance the header generation functionality in the `Refitter.Core` project. The key changes involve renaming methods to reflect their purpose better, adding support for generating `Content-Type` headers, and updating tests to verify the new functionality.

With the changes in the pull request, the following OpenAPI document:

```yaml
openapi: 3.0.1
paths:
  /foo:
    post:
      requestBody:
        content:
          application/json:
            schema:
              type: string
        required: true
      responses:
        '200':
          content:
            application/json:
              schema:
                type: string
```

Generate the following Refit interface:

```csharp
public partial interface IApiClient
{
    [Headers("Accept: application/json", "Content-Type: application/json")]
    [Post("/foo")]
    Task<string> Foo([Body] string body);
}
```

### Header Generation Enhancements:

* Renamed the `GenerateAcceptHeaders` method to `GenerateHeaders` and added logic to generate `Content-Type` headers if specified in the settings. [[1]](diffhunk://#diff-95f8543dcf9e641fc59aef59be1a4b37089babe99947ddc943628852fdb0f6a8L77-R77) [[2]](diffhunk://#diff-95f8543dcf9e641fc59aef59be1a4b37089babe99947ddc943628852fdb0f6a8L88-R88) [[3]](diffhunk://#diff-95f8543dcf9e641fc59aef59be1a4b37089babe99947ddc943628852fdb0f6a8L169-R175) [[4]](diffhunk://#diff-95f8543dcf9e641fc59aef59be1a4b37089babe99947ddc943628852fdb0f6a8L188-R209) [[5]](diffhunk://#diff-287d64a2c95aee3476e19a720a49398c156e0680d6dcccac445b53f0ffb345c3L87-R87) [[6]](diffhunk://#diff-287d64a2c95aee3476e19a720a49398c156e0680d6dcccac445b53f0ffb345c3L98-R98) [[7]](diffhunk://#diff-3c28617568adeea92a02098a73e6a33e2dcf4a56e142afad07c2fb2ef89d77acL61-R61) [[8]](diffhunk://#diff-3c28617568adeea92a02098a73e6a33e2dcf4a56e142afad07c2fb2ef89d77acL72-R72)

* Added a new property `AddContentTypeHeaders` to the `RefitGeneratorSettings` class to control the generation of `Content-Type` headers.

### Test Updates:

* Updated existing tests in `src/Refitter.SourceGenerator.Tests/CustomGenerated/CustomGenerated.cs` to include `Content-Type` headers in the `Headers` attribute. [[1]](diffhunk://#diff-e6fa4f6d1eadbd53a5a65e76016e1219c7cc32e520cd39d6d97db50baee296d2L45-R45) [[2]](diffhunk://#diff-e6fa4f6d1eadbd53a5a65e76016e1219c7cc32e520cd39d6d97db50baee296d2L66-R66) [[3]](diffhunk://#diff-e6fa4f6d1eadbd53a5a65e76016e1219c7cc32e520cd39d6d97db50baee296d2L193-R193) [[4]](diffhunk://#diff-e6fa4f6d1eadbd53a5a65e76016e1219c7cc32e520cd39d6d97db50baee296d2L221-R221) [[5]](diffhunk://#diff-e6fa4f6d1eadbd53a5a65e76016e1219c7cc32e520cd39d6d97db50baee296d2L279-R287) [[6]](diffhunk://#diff-e6fa4f6d1eadbd53a5a65e76016e1219c7cc32e520cd39d6d97db50baee296d2R348)

* Added new test classes `RequestResponseHeadersTests` and `ResponseHeadersTests` to verify the generation of `Accept` and `Content-Type` headers. [[1]](diffhunk://#diff-19e5ba2e653d0a331c74f1aee40cde4432ca26a592e5acb0c4b5f493cdc92ce0R1-R82) [[2]](diffhunk://#diff-cd30b329f5a62f7bf82611cbaa2aa080e4352db889aae6767fea6d3c02deda5cR1-R76)

* Modified tests in `src/Refitter.Tests/SwaggerPetstoreApizrTests.cs` and `src/Refitter.Tests/SwaggerPetstoreTests.cs` to validate the presence or absence of `Accept` headers based on the OpenAPI specification version. [[1]](diffhunk://#diff-fc0677cd018403266031cba8acb3a4b1484e26c92499e4eaa216ab7838bbbfa0L271-R273) [[2]](diffhunk://#diff-2d291dd329e9b9ae6026f8304d46c61250754e60d8ea6827fd103b081649a202L274-R276)