### PR TITLE
Temporary fix for Source Generator when running in Visual Studio

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       continue-on-error: true
       run: |
         rm -rf src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated
-        dotnet build src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
+        dotnet msbuild src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
     - name: 🛠️ Build
       run: dotnet build -c Release src/Refitter.sln -p:UseSourceLink=true -p:PackageVersion="${{ env.VERSION }}" -p:Version="${{ env.VERSION }}"
     - name: 🧪 Test

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,3 +16,7 @@ test:
 # Clean target
 clean:
 	dotnet clean Refitter.sln
+	rm -rf ./Refitter/bin
+	rm -rf ./Refitter/obj
+	rm -rf ./Refitter.Core/bin
+	rm -rf ./Refitter.Core/obj

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -181,7 +181,7 @@ public class RefitterSourceGenerator : IIncrementalGenerator
                         "Error",
                         $"Unable to deserialize .refitter file: {e}",
                         "Refitter",
-                        DiagnosticSeverity.Error,
+                        DiagnosticSeverity.Info,
                         true
                     ),
                     Location.None


### PR DESCRIPTION
This should resolve #627

The problem that the source generator occasionally fails to deserialize the `.refitter` file. When this happens, the problem is reported to Visual Studio as an `Error`, which causes Visual Studio to fail to build. The solution, which I hope is temporary, is to report the deserialization error with the severity level of `Info` so Visual Studio doesn't panic. Even though the source generator occasionally fails, it seems to work eventually. I haven't figured out exactly what I wrong yet and I wanted to go in the direction of just handling the deserialization myself, but that probably won't help since Refitter depends on NSwag, which also needs to deserialize the OpenAPI document. Maybe one day I'll nail this, but for now, this is blocking some users, and this "fix" needs to be released

This pull request includes changes to the build process, the test cleanup process, and the logging severity for deserialization errors. The most important changes are:

### Build Process:
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L39-R39): Changed the build command from `dotnet build` to `dotnet msbuild` for the `Refitter.SourceGenerator.Tests.csproj` project.

### Test Cleanup:
* [`src/Makefile`](diffhunk://#diff-3e2513390df543315686d7c85bd901ca9256268970032298815d2f893a9f0685R19-R22): Added commands to remove `bin` and `obj` directories for `Refitter` and `Refitter.Core` during the clean process.

### Logging Severity:
* [`src/Refitter.SourceGenerator/RefitterSourceGenerator.cs`](diffhunk://#diff-90a29fe1932e165fb8390fa7a09adab7593510586be65b64abcdbfe46777758fL184-R184): Changed the logging severity of deserialization errors from `DiagnosticSeverity.Error` to `DiagnosticSeverity.Info`.