### PR TITLE
Convert properties with underscores to PascalCase

### DIFF
--- a/src/Refitter.Core/CustomCSharpPropertyNameGenerator.cs
+++ b/src/Refitter.Core/CustomCSharpPropertyNameGenerator.cs
@@ -42,7 +42,9 @@ internal class CustomCSharpPropertyNameGenerator : IPropertyNameGenerator
                 .Replace("+", "plus");
         }
 
-        name = ConversionUtilities.ConvertToUpperCamelCase(name, true);
+        name = ConversionUtilities
+            .ConvertToUpperCamelCase(name, true)
+            .ConvertSnakeCaseToPascalCase();
 
         if (name.IndexOfAny(ReservedSecondPassChars) != -1)
         {

--- a/src/Refitter.Tests/Examples/PercentageCharacterTests.cs
+++ b/src/Refitter.Tests/Examples/PercentageCharacterTests.cs
@@ -56,7 +56,7 @@ components:
     public async Task Replaces_Percentage_With_PascalCase()
     {
         string generateCode = await GenerateCode();
-        generateCode.Should().Contain("string Percent_of_something");
+        generateCode.Should().Contain("string PercentOfSomething");
     }
 
     [Fact]

--- a/src/Refitter.Tests/Examples/UnderscoresToPascalCaseTests.cs
+++ b/src/Refitter.Tests/Examples/UnderscoresToPascalCaseTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class HandleUnderscoresTests
+{
+    private const string OpenApiSpec = @"
+openapi: '3.0.0'
+info:
+  version: 'v1'
+  title: 'Test API'
+servers:
+  - url: 'https://test.host.com/api/v1'
+paths:
+  /jobs/{jobId}:
+    get:
+      tags:
+      - 'Jobs'
+      summary: 'Get job details'
+      description: 'Get the details of the specified job.'
+      parameters:
+        - in: 'path'
+          name: 'jobId'
+          description: 'Job ID'
+          required: true
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobResponse'
+components:
+  schemas:
+    JobResponse:
+      type: 'object'
+      properties:
+        job:
+          type: 'object'
+          properties:
+            start_date:
+              type: 'string'
+              format: 'date-time'
+            details:
+              type: 'string'
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Replaces_Underscore_Properties_With_PascalCase()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().Contain("DateTimeOffset StartDate");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generateCode = sut.Generate();
+        return generateCode;
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.yml";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}


### PR DESCRIPTION
This resolves #641 

This pull request includes several changes to improve the handling of property names and add new tests for code generation. The most important changes include modifying the property name conversion method, updating an existing test to reflect the new naming convention, and adding a new test class to validate the handling of underscores in property names.

### Improvements to property name handling:

* [`src/Refitter.Core/CustomCSharpPropertyNameGenerator.cs`](diffhunk://#diff-3bc6e4e9dc096be77cc2b29bcaeac87b344b9452ac0adf4758567c1d3ef42676L45-R47): Modified the `ReplaceNameContainingReservedCharacters` method to include a new step that converts snake_case to PascalCase.

### Updates to existing tests:

* [`src/Refitter.Tests/Examples/PercentageCharacterTests.cs`](diffhunk://#diff-f47993865e8ded0a978a4970a639bf8d3fe9dc8ce620481bd225933ddb601182L59-R59): Updated the `Can_Generate_Code` test to check for PascalCase property names instead of snake_case.

### Addition of new tests:

* [`src/Refitter.Tests/Examples/UnderscoresToPascalCaseTests.cs`](diffhunk://#diff-c0e1a251195b23e76bde7a04901a35dbd3212383bd985ce4b75c821b8fd2c75eR1-R96): Added a new test class `HandleUnderscoresTests` to ensure that underscores in property names are correctly converted to PascalCase. This includes tests for code generation, property name replacement, and building the generated code.