### PR TITLE
Update smoke tests to generate authentication headers

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -29,7 +29,7 @@ on:
       - "!.github/workflows/template.yml"
       - "!.github/workflows/template-url.yml"
       - "!.github/workflows/smoke-tests.yml"
-      - "!test/smoke-tests.ps1"
+      - "!test/**/*"
     branches:
       - "*"
 

--- a/test/OpenAPI/v3.0/petstore.json
+++ b/test/OpenAPI/v3.0/petstore.json
@@ -39,6 +39,11 @@
       }
     }
   ],
+  "security": [
+    {
+       "api_key": []
+    }
+  ],
   "paths": {
     "/pet": {
       "put": {

--- a/test/OpenAPI/v3.0/petstore.yaml
+++ b/test/OpenAPI/v3.0/petstore.yaml
@@ -33,6 +33,8 @@ tags:
     externalDocs:
       description: Find out more about our store
       url: 'http://swagger.io'
+security:
+  - api_key: []
 paths:
   /pet:
     put:

--- a/test/petstore.refitter
+++ b/test/petstore.refitter
@@ -22,5 +22,6 @@
     "arrayType": "System.Collections.Generic.IList"
   },
   "operationNameGenerator": "default",
-  "typeAccessibility": "public"
+  "typeAccessibility": "public",
+  "generateAuthenticationHeader": true
 }


### PR DESCRIPTION
This pull request introduces changes to enhance the security configuration and authentication handling in the OpenAPI Petstore examples. The most important changes include adding security definitions for API key authentication and enabling the generation of authentication headers in the refitter configuration.

### Security Enhancements:
* [`test/OpenAPI/v3.0/petstore.json`](diffhunk://#diff-c55f880408eb644118b22e26e9ed4a87ac24e3a2facb3d82d9a09edc2f00cee7R42-R46): Added a `security` section specifying `api_key` as a required security scheme.
* [`test/OpenAPI/v3.0/petstore.yaml`](diffhunk://#diff-f77afc5897e8444172cd6887a297dd5b026880d961970bb71a2b9acc1319abbbR36-R37): Added a `security` section under `tags:` to include `api_key` as a security requirement.

### Authentication Configuration:
* [`test/petstore.refitter`](diffhunk://#diff-db77db3edff676bd867bb8ca1e5fea2876ac939dfbf0a50dee204951ab5c2899L25-R26): Added the `generateAuthenticationHeader` option and set it to `true` to enable automatic generation of authentication headers.