### PR TITLE
Response type handling to only use 2XX range

### DIFF
--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -115,18 +115,10 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
             .Select(code => GetTypeName(code, operation))
             .FirstOrDefault();
 
-        // If no explicit success codes found, check for range responses in precedence order
-        string[] ranges = { "1XX", "2XX", "3XX", "4XX", "5XX" };
-        if (returnTypeParameter == null)
+        // If no explicit success codes found, check for 2XX range
+        if (returnTypeParameter == null && operation.Responses.ContainsKey("2XX"))
         {
-            foreach (var rangeCode in ranges)
-            {
-                if (operation.Responses.ContainsKey(rangeCode))
-                {
-                    returnTypeParameter = GetTypeName(rangeCode, operation);
-                    break;
-                }
-            }
+            returnTypeParameter = GetTypeName("2XX", operation);
         }
 
         // If no success codes or ranges found, check for default response


### PR DESCRIPTION
This address the issue pointed out by @pfeigl

This pull request simplifies the logic for determining the return type in the `GetTypeName` method of the `RefitInterfaceGenerator` class. The most important change focuses on narrowing the range of response codes considered when no explicit success codes are found.

### Simplification of response code handling:

* [`src/Refitter.Core/RefitInterfaceGenerator.cs`](diffhunk://#diff-95f8543dcf9e641fc59aef59be1a4b37089babe99947ddc943628852fdb0f6a8L118-R121): The logic for handling response codes was simplified by removing checks for multiple response code ranges (`1XX`, `3XX`, `4XX`, `5XX`) and focusing solely on the `2XX` range when no explicit success codes are found. This reduces unnecessary complexity in the code.…lution