### PR TITLE
Add collection format option to CLI tool documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ OPTIONS:
         --include-inheritance-hierarchy                          Keep all possible inherited types/union types even if they are not directly used
         --no-banner                                              Don't show donation banner
         --skip-default-additional-properties                     Set to true to skip default additional properties
+        --collection-format                      Multi           Determines the format of collection parameters. May be one of Multi, Csv, Ssv, Tsv, Pipes
         --operation-name-generator              Default          The NSwag IOperationNameGenerator implementation to use.
                                                                  May be one of:
                                                                  - Default

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ EXAMPLES:
     refitter ./openapi.json --operation-name-template '{operationName}Async'
     refitter ./openapi.json --optional-nullable-parameters
     refitter ./openapi.json --use-polymorphic-serialization
+    refitter ./openapi.json --collection-format Csv
 
 ARGUMENTS:
     [URL or input file]    URL or file path to OpenAPI Specification file

--- a/docs/docfx_project/articles/cli-tool.md
+++ b/docs/docfx_project/articles/cli-tool.md
@@ -39,6 +39,7 @@ EXAMPLES:
     refitter ./openapi.json --operation-name-template '{operationName}Async'
     refitter ./openapi.json --optional-nullable-parameters
     refitter ./openapi.json --use-polymorphic-serialization
+    refitter ./openapi.json --collection-format Csv
 
 ARGUMENTS:
     [URL or input file]    URL or file path to OpenAPI Specification file

--- a/docs/docfx_project/articles/cli-tool.md
+++ b/docs/docfx_project/articles/cli-tool.md
@@ -83,6 +83,12 @@ OPTIONS:
         --include-inheritance-hierarchy                          Keep all possible inherited types/union types even if they are not directly used                                                          
         --no-banner                                              Don't show donation banner                                                                                                                
         --skip-default-additional-properties                     Set to true to skip default additional properties                                                                                         
+        --collection-format                      Multi           Determines the format of collection parameters. May be one of:
+                                                                 - Multi (separate parameter instances for each array item)
+                                                                 - Csv (comma separated values)
+                                                                 - Ssv (space separated values)
+                                                                 - Tsv (tab separated values)
+                                                                 - Pipes (pipe separated values)
         --operation-name-generator              Default          The NSwag IOperationNameGenerator implementation to use.                                                                                  
                                                                  May be one of:                                                                                                                            
                                                                  - Default                                                                                                                                 

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -63,6 +63,7 @@ The following is an example `.refitter` file
   "useDynamicQuerystringParameters": false, // Optional. Default=false
   "usePolymorphicSerialization": true, // Optional. Default=false
   "generateDisposableClients": true, // Optional. Default=false
+  "collectionFormat": "Multi", // Optional. Determines the format of collection parameters. Values=Multi|Csv|Ssv|Tsv|Pipes. Default=Multi
   "dependencyInjectionSettings": { // Optional
     "baseUrl": "https://petstore3.swagger.io/api/v3", // Optional. Leave this blank to set the base address manually
     "httpMessageHandlers": [ // Optional
@@ -421,7 +422,7 @@ The following is an example `.refitter` file
             "properties": {
                 "withRequestOptions": {
                     "type": "boolean",
-                    "description": "Tells if the Refit interface methods should have a final IApizrRequestOptions options parameter."
+                    "description": "Tells if the Refit interface methods should have a final IApizrRequestOptions options parameter"
                 },
                 "withRegistrationHelper": {
                     "type": "boolean",

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -117,7 +117,7 @@ internal static class ParameterExtractor
         return (parameter, settings) switch
         {
             { parameter.IsArray: true }
-                => "Query(CollectionFormat.Multi)",
+                => $"Query(CollectionFormat.{settings.CollectionFormat})",
             { parameter.IsDate: true, settings.UseIsoDateFormat: true }
                 => "Query(Format = \"yyyy-MM-dd\")",
             { parameter.IsDate: true, settings.CodeGeneratorSettings.DateFormat: not null }

--- a/src/Refitter.Core/Settings/CollectionFormat.cs
+++ b/src/Refitter.Core/Settings/CollectionFormat.cs
@@ -1,14 +1,14 @@
 namespace Refitter.Core;
 
 /// <summary>
-/// Collection format defined in https://swagger.io/docs/specification/2-0/describing-parameters/
+/// Collection format defined in https://swagger.io/docs/specification/v2_0/describing-parameters/#array-and-multi-value-parameters
 /// </summary>
 public enum CollectionFormat
 {
     /// <summary>
-    /// Values formatted with UrlParameterFormatter or FormUrlEncodedParameterFormatter
+    /// Multiple parameter instances
     /// </summary>
-    RefitParameterFormatter,
+    Multi,
 
     /// <summary>
     /// Comma-separated values
@@ -28,10 +28,5 @@ public enum CollectionFormat
     /// <summary>
     /// Pipe-separated values
     /// </summary>
-    Pipes,
-
-    /// <summary>
-    /// Multiple parameter instances
-    /// </summary>
-    Multi
+    Pipes
 }

--- a/src/Refitter.Core/Settings/CollectionFormat.cs
+++ b/src/Refitter.Core/Settings/CollectionFormat.cs
@@ -1,0 +1,37 @@
+namespace Refitter.Core;
+
+/// <summary>
+/// Collection format defined in https://swagger.io/docs/specification/2-0/describing-parameters/
+/// </summary>
+public enum CollectionFormat
+{
+    /// <summary>
+    /// Values formatted with UrlParameterFormatter or FormUrlEncodedParameterFormatter
+    /// </summary>
+    RefitParameterFormatter,
+
+    /// <summary>
+    /// Comma-separated values
+    /// </summary>
+    Csv,
+
+    /// <summary>
+    /// Space-separated values
+    /// </summary>
+    Ssv,
+
+    /// <summary>
+    /// Tab-separated values
+    /// </summary>
+    Tsv,
+
+    /// <summary>
+    /// Pipe-separated values
+    /// </summary>
+    Pipes,
+
+    /// <summary>
+    /// Multiple parameter instances
+    /// </summary>
+    Multi
+}

--- a/src/Refitter.Core/Settings/CollectionFormat.cs
+++ b/src/Refitter.Core/Settings/CollectionFormat.cs
@@ -6,27 +6,33 @@ namespace Refitter.Core;
 public enum CollectionFormat
 {
     /// <summary>
-    /// Multiple parameter instances
+    /// Multiple parameter instances rather than multiple values. 
+    /// Only supported for the in: query and in: formData parameters. 
+    /// Example: ?param=value1&param=value2&param=value3
     /// </summary>
     Multi,
 
     /// <summary>
     /// Comma-separated values
+    /// Example: param=value1,value2,value3
     /// </summary>
     Csv,
 
     /// <summary>
     /// Space-separated values
+    /// Example: param=value1 value2 value3
     /// </summary>
     Ssv,
 
     /// <summary>
     /// Tab-separated values
+    /// Example: param=value1\tvalue2\tvalue3
     /// </summary>
     Tsv,
 
     /// <summary>
     /// Pipe-separated values
+    /// Example: param=value1|value2|value3
     /// </summary>
     Pipes
 }

--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -362,4 +362,12 @@ public class RefitGeneratorSettings
     /// </summary>
     [Description("Generate Security Schema Authentication headers")]
     public bool GenerateAuthenticationHeader { get; set; }
+
+    /// <summary>
+    /// Gets or sets the collection format to use for array query parameters.
+    /// Default is CollectionFormat.Multi.
+    /// </summary>
+    [Description("The collection format to use for array query parameters. Default is CollectionFormat.Multi.")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.Multi;
 }

--- a/src/Refitter.Tests/Examples/CollectionFormatTests.cs
+++ b/src/Refitter.Tests/Examples/CollectionFormatTests.cs
@@ -1,0 +1,136 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class CollectionFormatTests
+{
+    private const string OpenApiSpec = @"
+{
+  ""swagger"": ""2.0"",
+  ""info"": {
+    ""title"": ""Collection Format API"",
+    ""version"": ""1.0.0""
+  },
+  ""host"": ""example.com"",
+  ""basePath"": ""/"",
+  ""schemes"": [
+    ""https""
+  ],
+  ""paths"": {
+    ""/api/test"": {
+      ""get"": {
+        ""summary"": ""Test endpoint with array parameters"",
+        ""description"": ""Endpoint to test different collection formats"",
+        ""operationId"": ""getWithArrayParameter"",
+        ""parameters"": [
+          {
+            ""name"": ""ids"",
+            ""in"": ""query"",
+            ""description"": ""Array of IDs"",
+            ""required"": true,
+            ""type"": ""array"",
+            ""items"": {
+              ""type"": ""integer"",
+              ""format"": ""int32""
+            }
+          },
+          {
+            ""name"": ""tags"",
+            ""in"": ""query"",
+            ""description"": ""Array of tags"",
+            ""required"": false,
+            ""type"": ""array"",
+            ""items"": {
+              ""type"": ""string""
+            }
+          }
+        ],
+        ""responses"": {
+          ""200"": {
+            ""description"": ""Success response""
+          }
+        }
+      }
+    }
+  }
+}
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generateCode = await GenerateCode();
+        generateCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generateCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Theory]
+    [InlineData(CollectionFormat.Multi, "Query(CollectionFormat.Multi)")]
+    [InlineData(CollectionFormat.Csv, "Query(CollectionFormat.Csv)")]
+    [InlineData(CollectionFormat.Ssv, "Query(CollectionFormat.Ssv)")]
+    [InlineData(CollectionFormat.Tsv, "Query(CollectionFormat.Tsv)")]
+    [InlineData(CollectionFormat.Pipes, "Query(CollectionFormat.Pipes)")]
+    public async Task Generated_Code_Contains_Expected_Collection_Format(CollectionFormat format, string expectedAttribute)
+    {
+        string generateCode = await GenerateCode(format);
+        
+        using (new AssertionScope())
+        {
+            generateCode.Should().Contain(expectedAttribute);
+            // Check both array parameters use the same format
+            generateCode.Should().Contain($"[{expectedAttribute}] IEnumerable<int> ids");
+            generateCode.Should().Contain($"[{expectedAttribute}] IEnumerable<string> tags");
+        }
+    }
+
+    private static async Task<string> GenerateCode(CollectionFormat format = CollectionFormat.Multi)
+    {
+        string swaggerFile = await CreateSwaggerFile(OpenApiSpec);
+        try
+        {
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = swaggerFile,
+                CollectionFormat = format
+            };
+            var generator = await RefitGenerator.CreateAsync(settings);
+            return generator.Generate();
+        }
+        finally
+        {
+            if (File.Exists(swaggerFile))
+            {
+                File.Delete(swaggerFile);
+            }
+
+            var directory = Path.GetDirectoryName(swaggerFile);
+            if (directory != null && Directory.Exists(directory))
+            {
+                Directory.Delete(directory, true);
+            }
+        }
+    }
+
+    private static async Task<string> CreateSwaggerFile(string contents)
+    {
+        var filename = $"{Guid.NewGuid()}.json";
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+        var swaggerFile = Path.Combine(folder, filename);
+        await File.WriteAllTextAsync(swaggerFile, contents);
+        return swaggerFile;
+    }
+}

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -146,6 +146,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             ContractsNamespace = settings.ContractsNamespace,
             UsePolymorphicSerialization = settings.UsePolymorphicSerialization,
             GenerateDisposableClients = settings.GenerateDisposableClients,
+            CollectionFormat = settings.CollectionFormat
         };
     }
 

--- a/src/Refitter/Program.cs
+++ b/src/Refitter/Program.cs
@@ -155,6 +155,12 @@ internal static class Program
                     .AddExample(
                         "./openapi.json",
                         "--use-polymorphic-serialization");
+
+                configuration
+                    .AddExample(
+                        "./openapi.json",
+                        "--collection-format",
+                        "Csv");
             });
 
         return app.Run(args);

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -230,7 +230,16 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool GenerateDisposableClients { get; set; }
 
-    [Description("The collection format to use for query parameters. Default is Multi")]
+    [Description("""
+                 The collection format to use for query parameters. Default is Multi.
+                 May be one of:
+                 - Multi: Multiple parameter instances rather than multiple values. Only supported for the in: query and in: formData parameters. (?param=value1&param=value2)
+                 - Csv: Comma-separated values. (?param=value1,value2)
+                 - Ssv: Space-separated values. (?param=value1 value2)
+                 - Tsv: Tab-separated values. (?param=value1\tvalue2)
+                 - Pipes: Pipe-separated values. (?param=value1|value2)    
+                 See https://swagger.io/docs/specification/v2_0/describing-parameters/#array-and-multi-value-parameters for more information.
+                 """)]
     [CommandOption("--collection-format")]
     [DefaultValue(CollectionFormat.Multi)]
     public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.Multi;

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -229,4 +229,9 @@ public sealed class Settings : CommandSettings
     [CommandOption("--disposable")]
     [DefaultValue(false)]
     public bool GenerateDisposableClients { get; set; }
+
+    [Description("The collection format to use for query parameters. Default is Multi")]
+    [CommandOption("--collection-format")]
+    [DefaultValue(CollectionFormat.Multi)]
+    public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.Multi;
 }

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -179,6 +179,7 @@ function RunTests {
                     GenerateAndBuild -format $format -namespace "$namespace.ContractOnly" -outputPath "ContractOnly$outputPath" -args "--contract-only" -buildFromSource $buildFromSource
                     GenerateAndBuild -format $format -namespace "$namespace.ImmutableRecords" -outputPath "ImmutableRecords$outputPath" -args "--immutable-records" -buildFromSource $buildFromSource -netCore
                     GenerateAndBuild -format $format -namespace "$namespace.PolymorphicSerialization" -outputPath "PolymorphicSerialization$outputPath" -args "--use-polymorphic-serialization" -buildFromSource $buildFromSource -netCore
+                    GenerateAndBuild -format $format -namespace "$namespace.CollectionFormatCsv" -outputPath "CollectionFormatCsv$outputPath" -args "--collection-format csv" -buildFromSource $buildFromSource -netCore
                 }
             }
         }


### PR DESCRIPTION
This pull request introduces support for configurable collection formats for array query parameters in the Refitter tool. The changes include the addition of a new `CollectionFormat` enumeration, updates to the CLI and `.refitter` file format to accept this option, and corresponding updates to the documentation and tests.

### Feature: Configurable Collection Format for Array Query Parameters

* **Added `CollectionFormat` enumeration**: Introduced a new `CollectionFormat` enum in `src/Refitter.Core/Settings/CollectionFormat.cs` to define supported formats such as `Multi`, `Csv`, `Ssv`, `Tsv`, and `Pipes`.
* **Updated `RefitGeneratorSettings`**: Added a `CollectionFormat` property in `src/Refitter.Core/Settings/RefitGeneratorSettings.cs` to allow configuration of the collection format for array query parameters, defaulting to `Multi`.
* **Modified query attribute generation**: Updated `src/Refitter.Core/ParameterExtractor.cs` to use the configured `CollectionFormat` when generating query attributes.

### CLI and `.refitter` File Enhancements

* **CLI support for `--collection-format`**: Added a new `--collection-format` option to the CLI in `src/Refitter/Settings.cs` and updated examples in `src/Refitter/Program.cs` and `README.md`. [[1]](diffhunk://#diff-e121665c8ca375ca2b7920a849a47661f7e58387e2d1bad96979ce367fe2fad0R232-R245) [[2]](diffhunk://#diff-0318fbc39ac65e269845316c294126e89d735be8e5b9ad0eac813224cef2e6e6R158-R163) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R63) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107)
* **`.refitter` file support**: Extended the `.refitter` file format to include a `collectionFormat` property, with corresponding documentation updates in `docs/docfx_project/articles/refitter-file-format.md`. [[1]](diffhunk://#diff-5700d0e2a30b141a3d7feeb8e6259a6553e4a0d884d6bab9c7fe16bbfbc3bc54R66) [[2]](diffhunk://#diff-5700d0e2a30b141a3d7feeb8e6259a6553e4a0d884d6bab9c7fe16bbfbc3bc54L424-R425)

### Documentation Updates

* **Documentation for CLI and `.refitter` updates**: Updated `docs/docfx_project/articles/cli-tool.md` to document the new `--collection-format` option and its possible values. [[1]](diffhunk://#diff-02d0bdff78b5bf0c440df6e5d1aeb793a8513bdcef49a5c5bf7757b3f52a5a03R42) [[2]](diffhunk://#diff-02d0bdff78b5bf0c440df6e5d1aeb793a8513bdcef49a5c5bf7757b3f52a5a03R86-R91)

### Testing Enhancements

* **New unit tests**: Added comprehensive tests in `src/Refitter.Tests/Examples/CollectionFormatTests.cs` to validate the correct generation of code for different collection formats.
* **Smoke tests**: Updated `test/smoke-tests.ps1` to include a test case for the `--collection-format` option with `Csv` as an example.

These changes ensure that users can flexibly configure how array query parameters are serialized, improving compatibility with different API specifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the format of collection (array) query parameters in the CLI tool and `.refitter` file, with options including Multi, Csv, Ssv, Tsv, and Pipes.
  - Introduced a new command-line option and configuration property to select the desired collection format for generated code.

- **Documentation**
  - Updated user guides and examples to document the new `--collection-format` option and its usage.
  - Enhanced `.refitter` file format documentation to include the new `collectionFormat` property.

- **Tests**
  - Added tests to verify correct code generation and compilation for each supported collection format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->