### PR TITLE
IdentifierUtils.Counted() now removes the NSwag appended numbers if p…

### DIFF
--- a/src/Refitter.Core/IdentifierUtils.cs
+++ b/src/Refitter.Core/IdentifierUtils.cs
@@ -1,4 +1,7 @@
-﻿namespace Refitter.Core;
+﻿using System.Text.RegularExpressions;
+using Parlot.Fluent;
+
+namespace Refitter.Core;
 
 internal static class IdentifierUtils
 {
@@ -8,13 +11,20 @@ internal static class IdentifierUtils
     /// </summary>
     public static string Counted(ISet<string> knownIdentifiers, string name, string suffix = "", string parent = "")
     {
+        var hasParent = !string.IsNullOrEmpty(parent);
+
+        if (hasParent)
+        {
+            name = Regex.Replace(name, @"\d+$", string.Empty);
+        }
+
         if (!knownIdentifiers.Contains(string.IsNullOrEmpty(parent) ? $"{name}{suffix}" : $"{parent}.{name}{suffix}"))
         {
             return $"{name}{suffix}";
         }
 
         var counter = 2;
-        while (knownIdentifiers.Contains(string.IsNullOrEmpty(parent)
+        while (knownIdentifiers.Contains(!hasParent
                    ? $"{name}{counter}{suffix}"
                    : $"{parent}.{name}{counter}{suffix}"))
             counter++;

--- a/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
@@ -32,6 +32,8 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
 
         foreach (var kv in byGroup)
         {
+            string interfaceName = null!;
+            
             foreach (var op in kv.Combined)
             {
                 var operations = op.Operation;
@@ -45,7 +47,6 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
                 var returnType = GetTypeName(operation);
                 var verb = operations.Key.CapitalizeFirstCharacter();
 
-                string interfaceName = null!;
                 if (!interfacesByGroup.TryGetValue(kv.Key, out var sb))
                 {
                     interfacesByGroup[kv.Key] = sb = new StringBuilder();
@@ -61,7 +62,7 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
                 }
 
                 var operationName = GetOperationName(interfaceName, op.PathItem.Key, operations.Key, operation);
-                var dynamicQuerystringParameterType = operationName + "QueryParams";
+                var dynamicQuerystringParameterType = kv.Key.CapitalizeFirstCharacter() + operationName + "QueryParams";
                 var operationModel = generator.CreateOperationModel(operation);
                 var parameters = ParameterExtractor
                     .GetParameters(

--- a/src/Refitter.Tests/Examples/MultipleInterfacesByTagsTests.cs
+++ b/src/Refitter.Tests/Examples/MultipleInterfacesByTagsTests.cs
@@ -14,7 +14,7 @@ paths:
     get:
       tags:
       - 'Foo'
-      operationId: 'Get foo details'
+      operationId: 'Get details'
       description: 'Get the details of the specified foo'
       parameters:
         - in: 'path'
@@ -47,7 +47,7 @@ paths:
     get:
       tags:
       - 'Foo'
-      operationId: 'Get all foos'
+      operationId: 'Get all'
       description: 'Get all foos'  
       parameters:
         - in: 'query'
@@ -74,7 +74,7 @@ paths:
     get:
       tags:
       - 'Bar'
-      operationId: 'Get all bars'
+      operationId: 'Get all'
       description: 'Get all bars'      
       responses:
         '200':
@@ -83,7 +83,7 @@ paths:
     get:
       tags:
       - 'Bar'
-      operationId: 'Get bar details'
+      operationId: 'Get details'
       description: 'Get the details of the specified bar'   
       parameters:
         - in: 'path'
@@ -139,9 +139,18 @@ paths:
     public async Task Generates_Dynamic_Querystring_Parameters()
     {
         string generateCode = await GenerateCode(true);
-        generateCode.Should().Contain("GetFooDetailsQueryParams");
-        generateCode.Should().Contain("GetAllFoosQueryParams");
-        generateCode.Should().Contain("GetBarDetailsQueryParams");
+        generateCode.Should().Contain("FooGetDetailsQueryParams");
+        generateCode.Should().Contain("FooGetAllQueryParams");
+        generateCode.Should().Contain("BarGetDetailsQueryParams");
+    }
+
+    [Fact]
+    public async Task Can_Generate_Scoped_Interfaces()
+    {
+        string generateCode = await GenerateCode(true);
+        generateCode.Should().NotContain("GetAll2");
+        generateCode.Should().NotContain("GetDetails2");
+        generateCode.Should().NotContain("GetDetails2QueryParams");
     }
 
     [Fact]


### PR DESCRIPTION
For #672

---

`IdentifierUtils.Counted()` now removes the NSwag appended numbers if parent is not null.
`RefitMultipleInterfaceByTagGenerator.GenerateCode()` now has the` interfaceName` outside of the op loop scope, after the first in a group, all subsequent op loops it would reset to null, meaning no parent was supplied to `IdentifierUtils.Counted()`.
`dynamicQuerystringParameterType` has the `interfaceName` at the start to prevent clashes.
Updated `MultipleInterfacesByTagsTests`' spec to be able to test these changes.

At the moment not all tests pass due to the changes I made to the `dynamicQuerystringParameterType` specifically, and I would like to put in some tests to ensure that `IdentifierUtils.Counted()` does still count correctly when both multiple interfaces by tag generations and for single interface generations.

The test that currently fails is `ApizrTests.Generates_Dynamic_Querystring_Parameters_ByTag`.

---

Before continuing I was hoping for some feedback to see if this was a suitable method.

From testing and debugging, the numbers are initially appended by NSwag, before the `IdentifierUtils.Counted()` method is even reached (hence the stripping of numbers at the end of the `operationId` in my changes). I was hoping to maybe find a way to stop that from happening at that end, but I couldn't figure out exactly where I could do it and saw that there was already a fallback with the `IdentifierUtils.Counted()` so decided it was suitable to workaround it the way I have done.

Since the records for the query params are not within each given interface, a clash can still occur due to the changes I made with `IdentifierUtils.Counted()`. I went with prepending them with the Tag used for the interface since the point of my changes was to try and remove the numbers appended to method names, and felt this ideology would then clash with allowing these to still have numbers on the end. But let me know your opinions on whether or not this was the right move or not.

If this is the way to go then I would have to change the spec in `ApizrTests.Generates_Dynamic_Querystring_Parameters_ByTag` too and add in a few more tests like I want to do with `MultipleInterfacesByTagsTests` as well.

---

However I'm wondering if this behaviour should be hard coded as I have implemented it so far or be another option in the config.