### PR TITLE
Use fully qualified type name in Class template

### DIFF
--- a/src/Refitter.Core/Templates/Class.liquid
+++ b/src/Refitter.Core/Templates/Class.liquid
@@ -6,7 +6,7 @@
 {%- if HasDiscriminator -%}
 {%- if UseSystemTextJson -%}
 {%- if UsePolymorphicSerialization -%}
-[System.Text.Json.Serialization.JsonPolymorphic(TypeDiscriminatorPropertyName = "{{ Discriminator }}", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType, IgnoreUnrecognizedTypeDiscriminators = true)]
+[System.Text.Json.Serialization.JsonPolymorphic(TypeDiscriminatorPropertyName = "{{ Discriminator }}", UnknownDerivedTypeHandling = System.Text.Json.Serialization.JsonUnknownDerivedTypeHandling.FallBackToBaseType, IgnoreUnrecognizedTypeDiscriminators = true)]
 {%- else -%}
 [JsonInheritanceConverter(typeof({{ ClassName }}), "{{ Discriminator }}")]
 {%- endif -%}


### PR DESCRIPTION
This fixes missing references to `JsonUnknownDerivedTypeHandling` when using polymorphic serialization and generating contracts only.

Closes #683