### PR TITLE
Add .NET 9.0 to Target Frameworks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,9 @@ jobs:
       uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0'
+        dotnet-version: |
+          8.0.x
+          9.0.x
     - name: 🛠️ Prepare
       continue-on-error: true
       run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -31,7 +31,13 @@ jobs:
     steps:
     
     - name: 🛒 Checkout repository
-      uses: actions/checkout@v4    
+      uses: actions/checkout@v4   
+
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          8.0.x
+          9.0.x 
     
     - name: 🧪 Test
       run: dotnet test src/Refitter.Tests/Refitter.Tests.csproj -c Release --collect "Code coverage" -p:UseSourceLink=true -p:PackageVersion="${{ env.VERSION }}"

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -26,6 +26,11 @@ jobs:
     steps:    
     - name: 🛒 Checkout repository
       uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          8.0.x
+          9.0.x
     - name: 🛠️ Prepare
       working-directory: test/MSBuild
       run: |

--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -22,6 +22,11 @@ jobs:
         uses: dotnet/nbgv@master
         with:
           setAllVars: true
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
       - name: Build
         run: |
           dotnet build -c Release src/Refitter.sln -p:UseSourceLink=true -p:PackageVersion="${{ inputs.version }}" -p:Version="${{ inputs.version }}"

--- a/src/Refitter/Refitter.csproj
+++ b/src/Refitter/Refitter.csproj
@@ -9,7 +9,7 @@
     <Product>Refit API Client Code Generator</Product>
     <Description>Refitter is a CLI tool for generating a C# REST API Client using the Refit library from OpenAPI specifications.</Description>
     <PackAsTool>true</PackAsTool>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request introduces updates to support multiple .NET versions across workflows and the `Refitter` project. The changes ensure compatibility with both .NET 8.0 and 9.0 by modifying build configurations and workflows.

### Workflow updates for .NET version compatibility:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L34-R36): Updated the `dotnet-version` configuration to support both `8.0.x` and `9.0.x` in the build workflow.
* [`.github/workflows/codecov.yml`](diffhunk://#diff-512f30627f95d7fcdc76dc362d896351e9a4539994b7ab00b41979e653a6d0a9R36-R41): Added `actions/setup-dotnet@v4` with support for `8.0.x` and `9.0.x` to the code coverage workflow.
* [`.github/workflows/msbuild.yml`](diffhunk://#diff-de2a9656c10aacac69a56ff6ccf9b769be45400ac419e321b2090af70d8657cdR29-R33): Included `actions/setup-dotnet@v4` for compatibility with both `8.0.x` and `9.0.x` in the MSBuild workflow.
* [`.github/workflows/release-template.yml`](diffhunk://#diff-5634e481e2c4e165ffcd1de5aab959de4f65f0ff6eff699d52e53c19bc2811faR25-R29): Integrated `actions/setup-dotnet@v4` with support for `8.0.x` and `9.0.x` in the release template workflow.

### Project configuration updates:

* [`src/Refitter/Refitter.csproj`](diffhunk://#diff-5f1859c5df9d282e1faa9d5005ddd5246121c7de1ea8cae2e100295ab72e95d8L12-R12): Changed the `<TargetFramework>` property to `<TargetFrameworks>` to enable building the project for both `net8.0` and `net9.0`.

Resolves #684 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for both .NET 8.0 and .NET 9.0 SDKs in build, test, and release workflows.
  - The CLI tool can now be built and run against both .NET 8.0 and .NET 9.0 frameworks.
- **Chores**
  - Updated continuous integration workflows to install and use multiple .NET SDK versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->