### PR TITLE
Do not add both [Multipart] and "Content-Type: multipart/form-data"

### DIFF
--- a/src/Refitter.Core/RefitInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitInterfaceGenerator.cs
@@ -74,7 +74,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
                 this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), hasDynamicQuerystringParameter, hasApizrRequestOptionsParameter, code);
                 GenerateObsoleteAttribute(operation, code);
                 GenerateForMultipartFormData(operationModel, code);
-                GenerateHeaders(operations, operation, code);
+                GenerateHeaders(operations, operation, operationModel, code);
 
                 code.AppendLine($"{Separator}{Separator}[{verb}(\"{kv.Key}\")]")
                     .AppendLine($"{Separator}{Separator}{returnType} {operationName}({parametersString});")
@@ -85,7 +85,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
                     this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), false, hasApizrRequestOptionsParameter, code);
                     GenerateObsoleteAttribute(operation, code);
                     GenerateForMultipartFormData(operationModel, code);
-                    GenerateHeaders(operations, operation, code);
+                    GenerateHeaders(operations, operation, operationModel, code);
 
                     parametersString = string.Join(", ", parameters.Where(parameter => !parameter.Contains("?")));
 
@@ -182,6 +182,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
     protected void GenerateHeaders(
         KeyValuePair<string, OpenApiOperation> operations,
         OpenApiOperation operation,
+        CSharpOperationModel operationModel,
         StringBuilder code)
     {
         var headers = new List<string>();
@@ -211,7 +212,7 @@ internal class RefitInterfaceGenerator : IRefitInterfaceGenerator
                 uniqueContentTypes.FirstOrDefault(c => c.Equals("application/json", StringComparison.OrdinalIgnoreCase)) ??
                 uniqueContentTypes.FirstOrDefault();
 
-            if (!string.IsNullOrWhiteSpace(contentType))
+            if (!string.IsNullOrWhiteSpace(contentType) && !operationModel.Consumes.Contains("multipart/form-data"))
             {
                 headers.Add($"\"Content-Type: {contentType}\"");
             }

--- a/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceByTagGenerator.cs
@@ -84,7 +84,7 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
                 this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), hasDynamicQuerystringParameter, hasApizrRequestOptionsParameter, sb);
                 GenerateObsoleteAttribute(operation, sb);
                 GenerateForMultipartFormData(operationModel, sb);
-                GenerateHeaders(operations, operation, sb);
+                GenerateHeaders(operations, operation, operationModel, sb);
 
                 sb.AppendLine($"{Separator}{Separator}[{verb}(\"{op.PathItem.Key}\")]")
                     .AppendLine($"{Separator}{Separator}{returnType} {operationName}({parametersString});")
@@ -95,7 +95,7 @@ internal class RefitMultipleInterfaceByTagGenerator : RefitInterfaceGenerator
                     this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), false, hasApizrRequestOptionsParameter, sb);
                     GenerateObsoleteAttribute(operation, sb);
                     GenerateForMultipartFormData(operationModel, sb);
-                    GenerateHeaders(operations, operation, sb);
+                    GenerateHeaders(operations, operation, operationModel, sb);
 
                     parametersString = string.Join(", ", parameters.Where(parameter => !parameter.Contains("?")));
 

--- a/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
@@ -58,7 +58,7 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
                 this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), hasDynamicQuerystringParameter, hasApizrRequestOptionsParameter, code);
                 GenerateObsoleteAttribute(operation, code);
                 GenerateForMultipartFormData(operationModel, code);
-                GenerateHeaders(operations, operation, code);
+                GenerateHeaders(operations, operation, operationModel, code);
 
                 code.AppendLine($"{Separator}{Separator}[{verb}(\"{kv.Key}\")]")
                     .AppendLine($"{Separator}{Separator}{returnType} {methodName}({parametersString});")
@@ -69,7 +69,7 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
                     this.docGenerator.AppendMethodDocumentation(operationModel, IsApiResponseType(returnType), false, hasApizrRequestOptionsParameter, code);
                     GenerateObsoleteAttribute(operation, code);
                     GenerateForMultipartFormData(operationModel, code);
-                    GenerateHeaders(operations, operation, code);
+                    GenerateHeaders(operations, operation, operationModel, code);
 
                     parametersString = string.Join(", ", parameters.Where(parameter => !parameter.Contains("?")));
 

--- a/src/Refitter.Tests/Examples/MultiPartFormDataTests.cs
+++ b/src/Refitter.Tests/Examples/MultiPartFormDataTests.cs
@@ -118,6 +118,7 @@ public class MultiPartFormDataTests
     {
         string generateCode = await GenerateCode();
         generateCode.Should().Contain("[Multipart]");
+        generateCode.Should().NotContain("Content-Type: multipart/form-data");
     }
 
     [Fact]


### PR DESCRIPTION
Bugfix for: https://github.com/christianhelle/refitter/issues/654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Prevented the "Content-Type" header from being added when generating code for operations that consume multipart form data.
- **Tests**
	- Enhanced tests to verify that generated code for multipart form data does not include an explicit "Content-Type: multipart/form-data" header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->