### PR TITLE
fix missing schema for dictionary keys

### DIFF
--- a/src/Refitter.Core/SchemaCleaner.cs
+++ b/src/Refitter.Core/SchemaCleaner.cs
@@ -194,6 +194,11 @@ public class SchemaCleaner
                 }
             }
 
+            if (schema.DictionaryKey != null)
+            {
+                yield return schema.DictionaryKey;
+            }
+
             if (schema.Item != null)
             {
                 yield return schema.Item;


### PR DESCRIPTION
Without this change, enum-key types, or others, that use the following in their schema produce "anonymous" classes
```json
{
    "x-dictionaryKey": {
        "$ref": "#/components/schemas/SomeEnum"
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of schemas by ensuring dictionary keys are properly included during schema enumeration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->