### PR TITLE
Fix missing namespace import

### DIFF
--- a/src/Refitter.Core/RefitInterfaceImports.cs
+++ b/src/Refitter.Core/RefitInterfaceImports.cs
@@ -44,7 +44,7 @@ internal static class RefitInterfaceImports
             namespaces = namespaces.Except(excludedNamespaces).ToList();
         }
 
-        if (settings.GenerateMultipleFiles && settings.ContractsNamespace is not null)
+        if (settings.ContractsNamespace is not null && settings.Namespace != settings.ContractsNamespace)
         {
             namespaces.Add(settings.ContractsNamespace);
         }

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -848,4 +848,22 @@ public class SwaggerPetstoreTests
         generateCode.Should().Contain("\"/pet\"");
         generateCode.Should().Contain("\"/pet/{petId}\"");
     }
+
+    [Theory]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+#if !DEBUG
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]
+    [InlineData(SampleOpenSpecifications.SwaggerPetstoreYamlV2, "SwaggerPetstore.yaml")]
+#endif
+    public async Task Can_Import_Contracts_Namespace(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings { ContractsNamespace = "Contracts" };
+        var generateCode = await GenerateCode(version, filename, settings);
+        generateCode.Should().Contain("using Contracts;");
+        BuildHelper
+            .BuildCSharp(generateCode)
+            .Should()
+            .BeTrue();
+    }
 }


### PR DESCRIPTION
Fixes #715

This pull request includes changes to improve namespace handling in code generation and adds a new test to verify the functionality of importing a contracts namespace. The most important changes focus on refining conditional logic for namespace inclusion and enhancing test coverage.

### Namespace Handling Improvements:
* [`src/Refitter.Core/RefitInterfaceImports.cs`](diffhunk://#diff-9244c6e8c9866aa50f535d779f583c1fec218d6f14490e1bc6c09158d6381139L47-R47): Updated the conditional logic in `GetImportedNamespaces` to ensure the `ContractsNamespace` is only added when it differs from the main `Namespace`. This prevents redundant or conflicting namespace imports.

### Test Coverage Enhancements:
* [`src/Refitter.Tests/SwaggerPetstoreTests.cs`](diffhunk://#diff-2d291dd329e9b9ae6026f8304d46c61250754e60d8ea6827fd103b081649a202R851-R868): Added a new test method `Can_Import_Contracts_Namespace` to verify that the `ContractsNamespace` is correctly imported and that the generated code builds successfully. Includes multiple test cases for different specifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logic for including the contracts namespace in generated imports, ensuring it is added when appropriate.

* **Tests**
  * Added a new test to verify that the contracts namespace is correctly imported and that generated code compiles successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->