### PR TITLE
Add debug logging for source generator when searching for .refitter files

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,14 @@ dotnet add package Refitter.SourceGenerator
 
 ### Usage
 
-This source generator generates code based on any `.refitter` file included to the project as `AdditionalFiles`.
+This source generator generates code based on any `.refitter` file included to the project as `AdditionalFiles`:
 
-The generator can automatically detect all `.refitter` files inside the project that referenced the `Refitter.SourceGenerator` package and there is no need to include them manually as `AdditionalFiles`
+```markdown
+<ItemGroup>
+    <AdditionalFiles Include="Petstore.refitter" />
+</ItemGroup>
+```
+
 
 ### .Refitter File format
 

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 using Refitter.Core;
 
 namespace Refitter.SourceGenerator;


### PR DESCRIPTION
I was pretty confused why nothing was happening. It was mostly user error, though the README has some (seemingly) contradictory instructions.

This pull requests adds clear, explicit logging for which `.refitter` files are found. I waffled back and forth on whether to only include the debug log if NONE are found, but it seems ultimately helpful to have a log in the build output for what is generated.

I tested adding explicit warnings for this using the `Diagnostics`, but I could not get it to appear anywhere in Visual Studio.

**No refitter files:**
<img width="2440" height="414" alt="image" src="https://github.com/user-attachments/assets/2af79e0f-71ee-4735-952f-edb60b7765bf" />

**One refitter file:**
<img width="2362" height="426" alt="image" src="https://github.com/user-attachments/assets/3a2015c7-70c8-45d8-9050-72f83e90bf23" />
