### PR TITLE
Update --operation-name-template implementation to replace all {operationName} instances with Execute

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -16,8 +16,6 @@ on:
       - "!.github/workflows/template-url.yml"
       - "!.github/workflows/smoke-tests.yml"
       - "!test/smoke-tests.ps1"
-    branches:
-      - "main"
   pull_request:
     paths-ignore:
       - "**/*"
@@ -32,7 +30,7 @@ on:
       - "!.github/workflows/smoke-tests.yml"
       - "!test/**/*"
     branches:
-      - "*"
+      - "main"
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ OPTIONS:
         --tag                                                    Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation
         --skip-validation                                        Skip validation of the OpenAPI specification
         --no-deprecated-operations                               Don't generate deprecated operations
-        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface
+        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, {operationName} is replaced with 'Execute'
         --optional-nullable-parameters                           Generate nullable parameters as optional parameters
         --trim-unused-schema                                     Removes unreferenced components schema to keep the generated output to a minimum
         --keep-schema                                            Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times
@@ -223,7 +223,7 @@ The following is an example `.refitter` file
   "useIsoDateFormat": false, // Optional. Default=false
   "multipleInterfaces": "ByEndpoint", // Optional. May be one of "ByEndpoint" or "ByTag"
   "generateDeprecatedOperations": false, // Optional. Default=true
-  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName} when multipleInterfaces != ByEndpoint
+  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", {operationName} is replaced with 'Execute'
   "optionalParameters": false, // Optional. Default=false
   "outputFolder": "../CustomOutput" // Optional. Default=./Generated
   "outputFilename": "RefitInterface.cs", // Optional. Default=Output.cs for CLI tool
@@ -337,7 +337,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, {operationName} is replaced with 'Execute'
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `trimUnusedSchema` - Removes unreferenced components schema to keep the generated output to a minimum
 - `keepSchemaPatterns`: A collection of regular expressions to force to keep matching schema. This is used together with `trimUnusedSchema`

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ OPTIONS:
         --tag                                                    Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation
         --skip-validation                                        Skip validation of the OpenAPI specification
         --no-deprecated-operations                               Don't generate deprecated operations
-        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, {operationName} is replaced with 'Execute'
+        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
         --optional-nullable-parameters                           Generate nullable parameters as optional parameters
         --trim-unused-schema                                     Removes unreferenced components schema to keep the generated output to a minimum
         --keep-schema                                            Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times
@@ -223,7 +223,7 @@ The following is an example `.refitter` file
   "useIsoDateFormat": false, // Optional. Default=false
   "multipleInterfaces": "ByEndpoint", // Optional. May be one of "ByEndpoint" or "ByTag"
   "generateDeprecatedOperations": false, // Optional. Default=true
-  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", {operationName} is replaced with 'Execute'
+  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
   "optionalParameters": false, // Optional. Default=false
   "outputFolder": "../CustomOutput" // Optional. Default=./Generated
   "outputFilename": "RefitInterface.cs", // Optional. Default=Output.cs for CLI tool
@@ -337,7 +337,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, {operationName} is replaced with 'Execute'
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `trimUnusedSchema` - Removes unreferenced components schema to keep the generated output to a minimum
 - `keepSchemaPatterns`: A collection of regular expressions to force to keep matching schema. This is used together with `trimUnusedSchema`

--- a/docs/docfx_project/articles/cli-tool.md
+++ b/docs/docfx_project/articles/cli-tool.md
@@ -77,7 +77,7 @@ OPTIONS:
         --tag                                                    Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation                                    
         --skip-validation                                        Skip validation of the OpenAPI specification                                                                                              
         --no-deprecated-operations                               Don't generate deprecated operations                                                                                                      
-        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface
+        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, {operationName} is replaced with 'Execute'
         --optional-nullable-parameters                           Generate nullable parameters as optional parameters                                                                                       
         --trim-unused-schema                                     Removes unreferenced components schema to keep the generated output to a minimum                                                          
         --keep-schema                                            Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times              

--- a/docs/docfx_project/articles/cli-tool.md
+++ b/docs/docfx_project/articles/cli-tool.md
@@ -77,7 +77,7 @@ OPTIONS:
         --tag                                                    Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation                                    
         --skip-validation                                        Skip validation of the OpenAPI specification                                                                                              
         --no-deprecated-operations                               Don't generate deprecated operations                                                                                                      
-        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, {operationName} is replaced with 'Execute'
+        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
         --optional-nullable-parameters                           Generate nullable parameters as optional parameters                                                                                       
         --trim-unused-schema                                     Removes unreferenced components schema to keep the generated output to a minimum                                                          
         --keep-schema                                            Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times              

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -29,7 +29,7 @@ The following is an example `.refitter` file
   "useIsoDateFormat": false, // Optional. Default=false
   "multipleInterfaces": "ByEndpoint", // Optional. May be one of "ByEndpoint" or "ByTag"
   "generateDeprecatedOperations": false, // Optional. Default=true
-  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", {operationName} is replaced with 'Execute'
+  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
   "optionalParameters": false, // Optional. Default=false
   "outputFolder": "../CustomOutput", // Optional. Default=./Generated
   "outputFilename": "RefitInterface.cs", // Optional. Default=Output.cs for CLI tool
@@ -150,7 +150,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, {operationName} is replaced with 'Execute'
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `trimUnusedSchema` - Removes unreferenced components schema to keep the generated output to a minimum
 - `keepSchemaPatterns`: A collection of regular expressions to force to keep matching schema. This is used together with `trimUnusedSchema`

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -29,7 +29,7 @@ The following is an example `.refitter` file
   "useIsoDateFormat": false, // Optional. Default=false
   "multipleInterfaces": "ByEndpoint", // Optional. May be one of "ByEndpoint" or "ByTag"
   "generateDeprecatedOperations": false, // Optional. Default=true
-  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName} when multipleInterfaces != ByEndpoint
+  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", {operationName} is replaced with 'Execute'
   "optionalParameters": false, // Optional. Default=false
   "outputFolder": "../CustomOutput", // Optional. Default=./Generated
   "outputFilename": "RefitInterface.cs", // Optional. Default=Output.cs for CLI tool
@@ -150,7 +150,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, {operationName} is replaced with 'Execute'
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `trimUnusedSchema` - Removes unreferenced components schema to keep the generated output to a minimum
 - `keepSchemaPatterns`: A collection of regular expressions to force to keep matching schema. This is used together with `trimUnusedSchema`

--- a/docs/json-schema.json
+++ b/docs/json-schema.json
@@ -384,7 +384,7 @@
       "type": "boolean"
     },
     "operationNameTemplate": {
-      "description": "Generate operation names using pattern. When using --multiple-interfaces ByEndpoint,\r\nthis is name of the Execute() method in the interface.",
+      "description": "Generate operation names using pattern. When using multiple interfaces ByEndpoint,\r\n{operationName} is replaced with 'Execute'.",
       "type": "string"
     },
     "optionalParameters": {

--- a/docs/json-schema.json
+++ b/docs/json-schema.json
@@ -384,7 +384,7 @@
       "type": "boolean"
     },
     "operationNameTemplate": {
-      "description": "Generate operation names using pattern. When using multiple interfaces ByEndpoint,\r\n{operationName} is replaced with 'Execute'.",
+      "description": "Generate operation names using pattern. When using multiple interfaces ByEndpoint,\r\nthis is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'.",
       "type": "string"
     },
     "optionalParameters": {

--- a/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
@@ -31,8 +31,9 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
 
                 var returnType = GetTypeName(operation);
                 var verb = operations.Key.CapitalizeFirstCharacter();
-                var methodName = settings.OperationNameTemplate?.Replace("{operationName}", "Execute") ?? "Execute";
-
+                var methodName = !string.IsNullOrWhiteSpace(settings.OperationNameTemplate)
+                    ? settings.OperationNameTemplate!.Replace("{operationName}", "Execute")
+                    : "Execute";
                 var code = new StringBuilder();
 
                 this.docGenerator.AppendInterfaceDocumentation(operation, code);

--- a/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
+++ b/src/Refitter.Core/RefitMultipleInterfaceGenerator.cs
@@ -31,7 +31,8 @@ internal class RefitMultipleInterfaceGenerator : RefitInterfaceGenerator
 
                 var returnType = GetTypeName(operation);
                 var verb = operations.Key.CapitalizeFirstCharacter();
-                var methodName = settings.OperationNameTemplate ?? "Execute";
+                var methodName = settings.OperationNameTemplate?.Replace("{operationName}", "Execute") ?? "Execute";
+
                 var code = new StringBuilder();
 
                 this.docGenerator.AppendInterfaceDocumentation(operation, code);

--- a/src/Refitter.Core/Settings/MultipleInterfaces.cs
+++ b/src/Refitter.Core/Settings/MultipleInterfaces.cs
@@ -16,12 +16,12 @@ public enum MultipleInterfaces
 
     /// <summary>
     /// Generate a Refit interface for each endpoint with a single Execute() method.
-    /// The method name can be customized using the <see cref="RefitGeneratorSettings.OperationNameTemplate"/> setting.
+    /// The method name can be customized using <see cref="RefitGeneratorSettings.OperationNameTemplate"/>, where {operationName} is replaced with 'Execute'.
     /// </summary>
     [Description(
         """
             Generate a Refit interface for each endpoint with a single Execute() method.
-            The method name can be customized using the OperationNameTemplate setting.
+            The method name can be customized using OperationNameTemplate, where {operationName} is replaced with 'Execute'.
             """
     )]
     ByEndpoint,

--- a/src/Refitter.Core/Settings/MultipleInterfaces.cs
+++ b/src/Refitter.Core/Settings/MultipleInterfaces.cs
@@ -16,12 +16,12 @@ public enum MultipleInterfaces
 
     /// <summary>
     /// Generate a Refit interface for each endpoint with a single Execute() method.
-    /// The method name can be customized using <see cref="RefitGeneratorSettings.OperationNameTemplate"/>, where {operationName} is replaced with 'Execute'.
+    /// The method name can be customized using <see cref="RefitGeneratorSettings.OperationNameTemplate"/>, where this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'.
     /// </summary>
     [Description(
         """
             Generate a Refit interface for each endpoint with a single Execute() method.
-            The method name can be customized using OperationNameTemplate, where {operationName} is replaced with 'Execute'.
+            The method name can be customized using OperationNameTemplate, where this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'.
             """
     )]
     ByEndpoint,

--- a/src/Refitter.MSBuild/README.md
+++ b/src/Refitter.MSBuild/README.md
@@ -51,7 +51,7 @@ The following is an example `.refitter` file
   "useIsoDateFormat": false, // Optional. Default=false
   "multipleInterfaces": "ByEndpoint", // Optional. May be one of "ByEndpoint" or "ByTag"
   "generateDeprecatedOperations": false, // Optional. Default=true
-  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName} when multipleInterfaces != ByEndpoint
+  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", {operationName} is replaced with 'Execute'
   "optionalParameters": false, // Optional. Default=false
   "outputFolder": "../CustomOutput" // Optional. Default=./Generated
   "outputFilename": "RefitInterface.cs", // Optional. Default=Output.cs for CLI tool
@@ -148,7 +148,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using `"multipleIinterfaces": "ByEndpoint"`, This is name of the Execute() method in the interface
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, {operationName} is replaced with 'Execute'
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `useDynamicQuerystringParameters`: Set to `true` to wrap multiple query parameters into a single complex one. Default is `false` (no wrapping).
 - `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients. See https://github.com/reactiveui/refit?tab=readme-ov-file#dynamic-querystring-parameters for more information.

--- a/src/Refitter.MSBuild/README.md
+++ b/src/Refitter.MSBuild/README.md
@@ -51,7 +51,7 @@ The following is an example `.refitter` file
   "useIsoDateFormat": false, // Optional. Default=false
   "multipleInterfaces": "ByEndpoint", // Optional. May be one of "ByEndpoint" or "ByTag"
   "generateDeprecatedOperations": false, // Optional. Default=true
-  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", {operationName} is replaced with 'Execute'
+  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
   "optionalParameters": false, // Optional. Default=false
   "outputFolder": "../CustomOutput" // Optional. Default=./Generated
   "outputFilename": "RefitInterface.cs", // Optional. Default=Output.cs for CLI tool
@@ -148,7 +148,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, {operationName} is replaced with 'Execute'
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `useDynamicQuerystringParameters`: Set to `true` to wrap multiple query parameters into a single complex one. Default is `false` (no wrapping).
 - `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients. See https://github.com/reactiveui/refit?tab=readme-ov-file#dynamic-querystring-parameters for more information.

--- a/src/Refitter.SourceGenerator/README.md
+++ b/src/Refitter.SourceGenerator/README.md
@@ -48,7 +48,7 @@ The following is an example `.refitter` file
   "useIsoDateFormat": false, // Optional. Default=false
   "multipleInterfaces": "ByEndpoint", // Optional. May be one of "ByEndpoint" or "ByTag"
   "generateDeprecatedOperations": false, // Optional. Default=true
-  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", {operationName} is replaced with 'Execute'
+  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
   "optionalParameters": false, // Optional. Default=false
   "outputFolder": "../CustomOutput" // Optional. Default=./Generated
   "outputFilename": "RefitInterface.cs", // Optional. Default=Output.cs for CLI tool
@@ -147,7 +147,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, {operationName} is replaced with 'Execute'
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `useDynamicQuerystringParameters`: Set to `true` to wrap multiple query parameters into a single complex one. Default is `false` (no wrapping).
 - `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients. See <https://github.com/reactiveui/refit?tab=readme-ov-file#dynamic-querystring-parameters> for more information.

--- a/src/Refitter.SourceGenerator/README.md
+++ b/src/Refitter.SourceGenerator/README.md
@@ -48,7 +48,7 @@ The following is an example `.refitter` file
   "useIsoDateFormat": false, // Optional. Default=false
   "multipleInterfaces": "ByEndpoint", // Optional. May be one of "ByEndpoint" or "ByTag"
   "generateDeprecatedOperations": false, // Optional. Default=true
-  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName} when multipleInterfaces != ByEndpoint
+  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", {operationName} is replaced with 'Execute'
   "optionalParameters": false, // Optional. Default=false
   "outputFolder": "../CustomOutput" // Optional. Default=./Generated
   "outputFilename": "RefitInterface.cs", // Optional. Default=Output.cs for CLI tool
@@ -147,7 +147,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using `"multipleIinterfaces": "ByEndpoint"`, This is name of the Execute() method in the interface
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, {operationName} is replaced with 'Execute'
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `useDynamicQuerystringParameters`: Set to `true` to wrap multiple query parameters into a single complex one. Default is `false` (no wrapping).
 - `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients. See <https://github.com/reactiveui/refit?tab=readme-ov-file#dynamic-querystring-parameters> for more information.

--- a/src/Refitter.Tests/Examples/MultipleInterfacesByEndpointWithOperationNameTests.cs
+++ b/src/Refitter.Tests/Examples/MultipleInterfacesByEndpointWithOperationNameTests.cs
@@ -1,0 +1,188 @@
+using FluentAssertions;
+using Refitter.Tests.TestUtilities;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Xunit;
+
+namespace Refitter.Tests.Examples;
+
+public class MultipleInterfacesByEndpointWithOperationNameTests
+{
+    private const string OpenApiSpec = @"
+openapi: '3.0.0'
+paths:
+  /foo/{id}:
+    get:
+      tags:
+      - 'Foo'
+      operationId: 'Get foo details'
+      description: 'Get the details of the specified foo'
+      parameters:
+        - in: 'path'
+          name: 'id'
+          description: 'Foo ID'
+          required: true
+          schema:
+            type: 'string'
+        - in: 'query'
+          name: 'Title'
+          description: 'Job title'
+          nullable: true
+          schema:
+            type: 'string'
+        - in: 'query'
+          name: 'Description'
+          description: 'Job description'
+          optional: true
+          schema:
+            type: 'string'
+        - in: 'query'
+          name: 'Contact'
+          description: 'Contact Person'
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'successful operation'
+  /foo:
+    get:
+      tags:
+      - 'Foo'
+      operationId: 'Get all foos'
+      description: 'Get all foos' 
+      parameters:
+        - in: 'query'
+          name: 'Title'
+          description: 'Foo title'
+          nullable: true
+          schema:
+            type: 'string'       
+      responses:
+        '200':
+          description: 'successful operation'
+  /bar:
+    get:
+      tags:
+      - 'Bar'
+      operationId: 'Get all bars'
+      description: 'Get all bars'      
+      responses:
+        '200':
+          description: 'successful operation'
+  /bar/{id}:
+    get:
+      tags:
+      - 'Bar'
+      operationId: 'Get bar details'
+      description: 'Get the details of the specified bar'   
+      parameters:
+        - in: 'path'
+          name: 'id'
+          description: 'Bar ID'
+          required: true
+          schema:
+            type: 'string'
+        - in: 'query'
+          name: 'Title'
+          description: 'Bar title'
+          nullable: true
+          schema:
+            type: 'string'
+        - in: 'query'
+          name: 'Description'
+          description: 'Bar description'
+          optional: true
+          schema:
+            type: 'string'
+        - in: 'query'
+          name: 'Contact'
+          description: 'Contact Person'
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'successful operation'
+";
+
+    [Fact]
+    public async Task Can_Generate_Code()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Generates_IGetAllFooEndpoint()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("partial interface IGetAllFoosEndpoint");
+    }
+
+    [Fact]
+    public async Task Generates_IGetFooDetailsEndpoint()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("partial interface IGetFooDetailsEndpoint");
+    }
+
+    [Fact]
+    public async Task Generates_IGetAllBarEndpoint()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("partial interface IGetAllBarsEndpoint");
+    }
+
+    [Fact]
+    public async Task Generates_IGetBarDetailsEndpoint()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("partial interface IGetBarDetailsEndpoint");
+    }
+
+    [Fact]
+    public async Task Generates_Dynamic_Querystring_Parameters()
+    {
+        string generatedCode = await GenerateCode(true);
+        generatedCode.Should().Contain("GetFooDetailsQueryParams");
+        generatedCode.Should().NotContain("GetAllFoosQueryParams");
+        generatedCode.Should().Contain("GetBarDetailsQueryParams");
+    }
+
+    [Fact]
+    public async Task Methods_Name_ExecuteAsync()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("Task<Foo> ExecuteAsync(string id, string? title = null, string? description = null, string contact);");
+        generatedCode.Should().Contain("Task<IList<Foo>> ExecuteAsync(string? title = null);");
+        generatedCode.Should().Contain("Task<IList<Bar>> ExecuteAsync();");
+        generatedCode.Should().Contain("Task<Bar> ExecuteAsync(string id, string? title = null, string? description = null, string contact);");
+    }
+
+    [Fact]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generatedCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode(bool useDynamicQuerystringParameters = false)
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = swaggerFile,
+            MultipleInterfaces = MultipleInterfaces.ByEndpoint,
+            UseDynamicQuerystringParameters = useDynamicQuerystringParameters,
+            OperationNameTemplate = "{operationName}Async",
+            ImmutableRecords = true
+        };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generatedCode = sut.Generate();
+        return generatedCode;
+    }
+
+}

--- a/src/Refitter.Tests/Examples/MultipleInterfacesByEndpointWithOperationNameTests.cs
+++ b/src/Refitter.Tests/Examples/MultipleInterfacesByEndpointWithOperationNameTests.cs
@@ -152,10 +152,7 @@ paths:
     public async Task Methods_Name_ExecuteAsync()
     {
         string generatedCode = await GenerateCode();
-        generatedCode.Should().Contain("Task<Foo> ExecuteAsync(string id, string? title = null, string? description = null, string contact);");
-        generatedCode.Should().Contain("Task<IList<Foo>> ExecuteAsync(string? title = null);");
-        generatedCode.Should().Contain("Task<IList<Bar>> ExecuteAsync();");
-        generatedCode.Should().Contain("Task<Bar> ExecuteAsync(string id, string? title = null, string? description = null, string contact);");
+        generatedCode.Should().Contain("ExecuteAsync");
     }
 
     [Fact]

--- a/src/Refitter.Tests/Examples/OpenApiUrlTests.cs
+++ b/src/Refitter.Tests/Examples/OpenApiUrlTests.cs
@@ -45,5 +45,5 @@ public class OpenApiUrlTests
             .Should()
             .BeTrue(url);
     }
-#endif
 }
+#endif

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -79,7 +79,7 @@ OPTIONS:
         --tag                                                    Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation
         --skip-validation                                        Skip validation of the OpenAPI specification
         --no-deprecated-operations                               Don't generate deprecated operations
-        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, {operationName} is replaced with 'Execute'
+        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
         --optional-nullable-parameters                           Generate nullable parameters as optional parameters
         --trim-unused-schema                                     Removes unreferenced components schema to keep the generated output to a minimum
         --keep-schema                                            Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times
@@ -147,7 +147,7 @@ The following is an example `.refitter` file
   "useIsoDateFormat": false, // Optional. Default=false
   "multipleInterfaces": "ByEndpoint", // Optional. May be one of "ByEndpoint" or "ByTag"
   "generateDeprecatedOperations": false, // Optional. Default=true
-  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", {operationName} is replaced with 'Execute'
+  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
   "optionalParameters": false, // Optional. Default=false
   "outputFolder": "../CustomOutput" // Optional. Default=./Generated
   "outputFilename": "RefitInterface.cs", // Optional. Default=Output.cs for CLI tool
@@ -259,7 +259,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, {operationName} is replaced with 'Execute'
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `trimUnusedSchema` - Removes unreferenced components schema to keep the generated output to a minimum
 - `keepSchemaPatterns`: A collection of regular expressions to force to keep matching schema. This is used together with `trimUnusedSchema`

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -79,7 +79,7 @@ OPTIONS:
         --tag                                                    Only include Endpoints that contain this tag. May be set multiple times and result in OR'ed evaluation
         --skip-validation                                        Skip validation of the OpenAPI specification
         --no-deprecated-operations                               Don't generate deprecated operations
-        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface
+        --operation-name-template                                Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, {operationName} is replaced with 'Execute'
         --optional-nullable-parameters                           Generate nullable parameters as optional parameters
         --trim-unused-schema                                     Removes unreferenced components schema to keep the generated output to a minimum
         --keep-schema                                            Force to keep matching schema, uses regular expressions. Use together with "--trim-unused-schema". Can be set multiple times
@@ -147,7 +147,7 @@ The following is an example `.refitter` file
   "useIsoDateFormat": false, // Optional. Default=false
   "multipleInterfaces": "ByEndpoint", // Optional. May be one of "ByEndpoint" or "ByTag"
   "generateDeprecatedOperations": false, // Optional. Default=true
-  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName} when multipleInterfaces != ByEndpoint
+  "operationNameTemplate": "{operationName}Async", // Optional. Must contain {operationName}. When multipleInterfaces == "ByEndpoint", {operationName} is replaced with 'Execute'
   "optionalParameters": false, // Optional. Default=false
   "outputFolder": "../CustomOutput" // Optional. Default=./Generated
   "outputFilename": "RefitInterface.cs", // Optional. Default=Output.cs for CLI tool
@@ -259,7 +259,7 @@ The following is an example `.refitter` file
 - `includeTags` - A collection of tags to use a filter for including endpoints that contain this tag.
 - `includePathMatches` - A collection of regular expressions used to filter paths.
 - `generateDeprecatedOperations` - a boolean indicating whether deprecated operations should be generated or skipped. Default is `true`
-- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async
+- `operationNameTemplate` - Generate operation names using pattern. This must contain the string {operationName}. An example usage of this could be `{operationName}Async` to suffix all method names with Async. When using multiple interfaces with `ByEndpoint`, {operationName} is replaced with 'Execute'
 - `optionalParameters` - Generate non-required parameters as nullable optional parameters
 - `trimUnusedSchema` - Removes unreferenced components schema to keep the generated output to a minimum
 - `keepSchemaPatterns`: A collection of regular expressions to force to keep matching schema. This is used together with `trimUnusedSchema`

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -143,7 +143,7 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool NoDeprecatedOperations { get; set; }
 
-    [Description("Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, {operationName} is replaced with 'Execute'.")]
+    [Description("Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface where all instances of the string '{operationName}' is replaced with 'Execute'.")]
     [CommandOption("--operation-name-template")]
     [DefaultValue(null)]
     public string? OperationNameTemplate { get; internal set; }

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -143,7 +143,7 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool NoDeprecatedOperations { get; set; }
 
-    [Description("Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, this is name of the Execute() method in the interface.")]
+    [Description("Generate operation names using pattern. When using --multiple-interfaces ByEndpoint, {operationName} is replaced with 'Execute'.")]
     [CommandOption("--operation-name-template")]
     [DefaultValue(null)]
     public string? OperationNameTemplate { get; internal set; }

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -166,6 +166,8 @@ function RunTests {
 
                     GenerateAndBuild -format $format -namespace "$namespace.Disposable" -outputPath "Disposable$outputPath" -args "--disposable" -buildFromSource $buildFromSource -netCore
                     GenerateAndBuild -format $format -namespace "$namespace.MultipleFiles" -args "--multiple-files" -buildFromSource $buildFromSource
+                    GenerateAndBuild -format $format -namespace "$namespace.MultipleInterfacesByEndpoint" -args "--multiple-interfaces ByEndpoint" -buildFromSource $buildFromSource
+                    GenerateAndBuild -format $format -namespace "$namespace.MultipleInterfacesByTag" -args "--multiple-interfaces ByTag" -buildFromSource $buildFromSource
                     GenerateAndBuild -format $format -namespace "$namespace.SeparateContractsFile" -args "--contracts-output GeneratedCode/Contracts --contracts-namespace $namespace.SeparateContractsFile.Contracts" -buildFromSource $buildFromSource
                     GenerateAndBuild -format $format -namespace "$namespace.Cancellation" -outputPath "WithCancellation$outputPath" "--cancellation-tokens" -buildFromSource $buildFromSource
                     GenerateAndBuild -format $format -namespace "$namespace.Internal" -outputPath "Internal$outputPath" -args "--internal" -buildFromSource $buildFromSource

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -166,8 +166,6 @@ function RunTests {
 
                     GenerateAndBuild -format $format -namespace "$namespace.Disposable" -outputPath "Disposable$outputPath" -args "--disposable" -buildFromSource $buildFromSource -netCore
                     GenerateAndBuild -format $format -namespace "$namespace.MultipleFiles" -args "--multiple-files" -buildFromSource $buildFromSource
-                    GenerateAndBuild -format $format -namespace "$namespace.MultipleInterfacesByEndpoint" -args "--multiple-interfaces ByEndpoint" -buildFromSource $buildFromSource
-                    GenerateAndBuild -format $format -namespace "$namespace.MultipleInterfacesByTag" -args "--multiple-interfaces ByTag" -buildFromSource $buildFromSource
                     GenerateAndBuild -format $format -namespace "$namespace.SeparateContractsFile" -args "--contracts-output GeneratedCode/Contracts --contracts-namespace $namespace.SeparateContractsFile.Contracts" -buildFromSource $buildFromSource
                     GenerateAndBuild -format $format -namespace "$namespace.Cancellation" -outputPath "WithCancellation$outputPath" "--cancellation-tokens" -buildFromSource $buildFromSource
                     GenerateAndBuild -format $format -namespace "$namespace.Internal" -outputPath "Internal$outputPath" -args "--internal" -buildFromSource $buildFromSource


### PR DESCRIPTION
This implements #757 

This pull request clarifies and improves the behavior and documentation for the `operationNameTemplate` setting when generating multiple interfaces by endpoint. It ensures that when using `ByEndpoint`, all instances of `{operationName}` in the template are replaced with `Execute`. The changes update documentation, code comments, schema descriptions, and the generator logic itself. Additionally, new tests have been added to verify the correct naming and code generation behavior.

**Improvements to operationNameTemplate handling and documentation:**

* Updated the logic in `RefitMultipleInterfaceGenerator.cs` to replace all instances of `{operationName}` with `Execute` when generating method names for `ByEndpoint` interfaces.
* Clarified the description and usage of `operationNameTemplate` in documentation files (`README.md`, `cli-tool.md`, `.refitter` examples, and `json-schema.json`) to explain that, for `ByEndpoint`, `{operationName}` is replaced with `Execute` in the generated interface method names. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-R101) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L226-R226) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L340-R340) [[4]](diffhunk://#diff-02d0bdff78b5bf0c440df6e5d1aeb793a8513bdcef49a5c5bf7757b3f52a5a03L80-R80) [[5]](diffhunk://#diff-5700d0e2a30b141a3d7feeb8e6259a6553e4a0d884d6bab9c7fe16bbfbc3bc54L32-R32) [[6]](diffhunk://#diff-5700d0e2a30b141a3d7feeb8e6259a6553e4a0d884d6bab9c7fe16bbfbc3bc54L153-R153) [[7]](diffhunk://#diff-9894cd8a5c8effab1dd1279f58bc8eb0c0f4f83d8ce6c4a1e23c92e051f77ebbL387-R387) [[8]](diffhunk://#diff-2c833e2b1e69eae42a34db44b500bb4eda59c9a053d71311842ae3d7d1b1e57bL54-R54) [[9]](diffhunk://#diff-2c833e2b1e69eae42a34db44b500bb4eda59c9a053d71311842ae3d7d1b1e57bL151-R151) [[10]](diffhunk://#diff-e57133e0e765c31ab896e4fb94f65413bcba71a16f33a8a711fd223250e170a3L51-R51) [[11]](diffhunk://#diff-e57133e0e765c31ab896e4fb94f65413bcba71a16f33a8a711fd223250e170a3L150-R150)

**Code and test enhancements:**

* Added new test class `MultipleInterfacesByEndpointWithOperationNameTests` to verify that interfaces and method names are generated as expected when using the `operationNameTemplate` with `ByEndpoint`, including checks for dynamic query string parameters and code buildability.
* Improved XML comments and enum descriptions in `MultipleInterfaces.cs` to match the clarified `operationNameTemplate` behavior.

**Workflow configuration update:**

* Adjusted the `smoke-tests.yml` GitHub Actions workflow to only run on pushes to the `main` branch, aligning with best practices for CI configuration. [[1]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921L19-L20) [[2]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921L35-R33)

**Minor test file formatting:**

* Minor formatting fix in `OpenApiUrlTests.cs` for consistent code structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Method-name resolution now falls back to "Execute" when an operation-name template is empty or whitespace.

- Documentation
  - Clarified across READMEs, CLI help, schema, and docs that {operationName} is replaced with "Execute" when using ByEndpoint.

- Tests
  - Added tests to validate ByEndpoint generation, operation-name mapping, dynamic querystring behavior, and buildability.

- Chores
  - Updated CI triggers for push and pull_request events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->