### PR TITLE
chore: add ability to skip-validation + simplify unicode logging

### DIFF
--- a/src/Refitter.MSBuild/README.md
+++ b/src/Refitter.MSBuild/README.md
@@ -5,12 +5,13 @@ Refitter is available as custom MSBuild tasks that includes the Refitter CLI exe
 The MSBuild package includes a custom `.target` file which executes the `RefitterGenerateTask` custom task and looks something like this:
 
 ```xml
-<UsingTask TaskName="RefitterGenerateTask" 
-           AssemblyFile="$(MSBuildThisFileDirectory)Refitter.MSBuild.dll" 
+<UsingTask TaskName="RefitterGenerateTask"
+           AssemblyFile="$(MSBuildThisFileDirectory)Refitter.MSBuild.dll"
            Condition="Exists('$(MSBuildThisFileDirectory)Refitter.MSBuild.dll')" />
 <Target Name="RefitterGenerate" BeforeTargets="BeforeCompile">
     <RefitterGenerateTask ProjectFileDirectory="$(MSBuildProjectDirectory)"
-                          DisableLogging="$(RefitterNoLogging)">
+                          DisableLogging="$(RefitterNoLogging)"
+                          SkipValidation="$(RefitterSkipValidation)">
         <Output TaskParameter="GeneratedFiles" ItemName="RefitterGeneratedFiles" />
     </RefitterGenerateTask>
     <ItemGroup>

--- a/src/Refitter.MSBuild/Refitter.MSBuild.targets
+++ b/src/Refitter.MSBuild/Refitter.MSBuild.targets
@@ -1,12 +1,13 @@
 <Project>
 
-    <UsingTask TaskName="RefitterGenerateTask" 
-               AssemblyFile="$(MSBuildThisFileDirectory)Refitter.MSBuild.dll" 
+    <UsingTask TaskName="RefitterGenerateTask"
+               AssemblyFile="$(MSBuildThisFileDirectory)Refitter.MSBuild.dll"
                Condition="Exists('$(MSBuildThisFileDirectory)Refitter.MSBuild.dll')" />
 
     <Target Name="RefitterGenerate" BeforeTargets="CoreCompile">
         <RefitterGenerateTask ProjectFileDirectory="$(MSBuildProjectDirectory)"
-                              DisableLogging="$(RefitterNoLogging)">
+                              DisableLogging="$(RefitterNoLogging)"
+                              SkipValidation="$(RefitterSkipValidation)">
             <Output TaskParameter="GeneratedFiles" ItemName="RefitterGeneratedFiles" />
         </RefitterGenerateTask>
         <ItemGroup>

--- a/src/Refitter.MSBuild/RefitterGenerateTask.cs
+++ b/src/Refitter.MSBuild/RefitterGenerateTask.cs
@@ -80,7 +80,7 @@ public class RefitterGenerateTask : MSBuildTask
             TryLogCommandLine("Using .NET 8 version of Refitter.");
         }
 
-        var args = $"{refitterDll} --settings-file {file} --simple-output";
+        var args = $"\"{refitterDll}\" --settings-file \"{file}\" --simple-output";
         if (DisableLogging)
         {
             args += " --no-logging";

--- a/src/Refitter.MSBuild/RefitterGenerateTask.cs
+++ b/src/Refitter.MSBuild/RefitterGenerateTask.cs
@@ -12,6 +12,8 @@ public class RefitterGenerateTask : MSBuildTask
 
     public bool DisableLogging { get; set; }
 
+    public bool SkipValidation { get; set; }
+
     [Output]
     public ITaskItem[] GeneratedFiles { get; set; }
 
@@ -78,10 +80,14 @@ public class RefitterGenerateTask : MSBuildTask
             TryLogCommandLine("Using .NET 8 version of Refitter.");
         }
 
-        var args = $"{refitterDll} --settings-file {file}";
+        var args = $"{refitterDll} --settings-file {file} --simple-output";
         if (DisableLogging)
         {
             args += " --no-logging";
+        }
+        if (SkipValidation)
+        {
+            args += " --skip-validation";
         }
 
         TryLogCommandLine($"Starting dotnet {args}");


### PR DESCRIPTION
## Description

When attempting to use `Refitter.MSBuild` I ran into an issue where the generated file wasn't being produced. Upon further investigation using `dotnet build -verbosity:Detailed` it was found that I was running into a validation issue that prevented the files from being generated.

This PR gives the consumer that ability to optionally `SkipValidation` as needed. 

As an aside, MSBuild logging has been forcefully set to simple-output to ensure readable logging.

## Additional Info

#762 
#763 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to skip validation during generation, letting configured builds bypass validation.
  * Build output is now simplified for clearer, more readable logs.

* **Documentation**
  * MSBuild usage examples updated to show the new skip-validation parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->