### PR TITLE
Fix MSBuild workflow

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -24,7 +24,6 @@ jobs:
       uses: actions/checkout@v6
     - name: 🛠️ Prepare
       working-directory: test/MSBuild
-      continue-on-error: true
       run: |
         dotnet restore ../../src/Refitter.slnx
         dotnet build -c release ../../src/Refitter/Refitter.csproj


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the MSBuild process, focusing on improving compatibility and error handling. The most important changes include switching the runner environment, adjusting error tolerance, and cleaning up branch filters.

**Workflow environment and configuration updates:**

* Changed the workflow runner from `ubuntu-latest` to `windows-latest` in the `build` job to ensure compatibility with MSBuild and related tooling.
* Added `continue-on-error: true` for the `Prepare` step, allowing the workflow to proceed even if this step fails, which can help with debugging and non-blocking issues.

**Branch filter and trigger cleanup:**

* Removed explicit branch filters from both `push` and `pull_request` triggers, simplifying workflow activation and ensuring it runs for all branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Chores**
* Removed branch restrictions from CI triggers so pushes and pull requests run without explicit branch filters.
* Switched continuous integration runner from Linux to Windows to align build environment.

---

*Note: This release contains infrastructure updates only. No user-facing features or functionality changes are included.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->