### PR TITLE
Update Spectre.Console.Cli to v0.55.0

### DIFF
--- a/src/Refitter.Tests/GenerateCommandTests.cs
+++ b/src/Refitter.Tests/GenerateCommandTests.cs
@@ -125,22 +125,26 @@ public class GenerateCommandTests
     }
 
     [Test]
-    public void Command_Should_Have_Public_Validate_Method()
+    public void Command_Should_Have_Protected_Validate_Method()
     {
         var command = new GenerateCommand();
-        var method = command.GetType().GetMethod("Validate");
+        var method = command.GetType().GetMethod(
+            "Validate",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 
         method.Should().NotBeNull();
-        method!.IsPublic.Should().BeTrue();
+        method!.IsFamily.Should().BeTrue();
     }
 
     [Test]
-    public void Command_Should_Have_Public_ExecuteAsync_Method()
+    public void Command_Should_Have_Protected_ExecuteAsync_Method()
     {
         var command = new GenerateCommand();
-        var method = command.GetType().GetMethod("ExecuteAsync");
+        var method = command.GetType().GetMethod(
+            "ExecuteAsync",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 
         method.Should().NotBeNull();
-        method!.IsPublic.Should().BeTrue();
+        method!.IsFamily.Should().BeTrue();
     }
 }

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -23,7 +23,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
 
     private static readonly string Crlf = Environment.NewLine;
 
-    public override ValidationResult Validate(CommandContext context, Settings settings)
+    protected override ValidationResult Validate(CommandContext context, Settings settings)
     {
         if (!settings.NoLogging)
             Analytics.Configure();
@@ -35,7 +35,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         return SettingsValidator.Validate(settings);
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         var refitGeneratorSettings = CreateRefitGeneratorSettings(settings);
         try

--- a/src/Refitter/Refitter.csproj
+++ b/src/Refitter/Refitter.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Exceptionless" Version="6.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.23.0" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>


### PR DESCRIPTION
- **Update Spectre.Console.Cli to v0.55.0**
- **Fix breaking changes from Spectre.Console.Cli update**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Spectre.Console.Cli dependency to version 0.55.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->