### PR TITLE
Enhance schema alias handling and property name generation

### DIFF
--- a/src/Refitter.Core/CustomCSharpPropertyNameGenerator.cs
+++ b/src/Refitter.Core/CustomCSharpPropertyNameGenerator.cs
@@ -57,6 +57,6 @@ internal class CustomCSharpPropertyNameGenerator : IPropertyNameGenerator
                 .Replace("%", "Percent");
         }
 
-        return name;
+        return IdentifierUtils.ToCompilableIdentifier(name);
     }
 }

--- a/src/Refitter.Core/SchemaCleaner.cs
+++ b/src/Refitter.Core/SchemaCleaner.cs
@@ -71,9 +71,18 @@ public class SchemaCleaner
     private (IReadOnlyCollection<JsonSchema>, HashSet<string>) FindUsedJsonSchema(OpenApiDocument doc)
     {
         var toProcess = new Stack<JsonSchema>();
-        var schemaIdLookup = document.Components.Schemas
-            .ToDictionary(x => x.Value,
-                x => x.Key);
+        var schemaIdLookup = new Dictionary<JsonSchema, List<string>>();
+        foreach (var kvp in document.Components.Schemas)
+        {
+            var actualSchema = kvp.Value.ActualSchema;
+            if (!schemaIdLookup.TryGetValue(actualSchema, out var aliases))
+            {
+                aliases = [];
+                schemaIdLookup[actualSchema] = aliases;
+            }
+
+            aliases.Add(kvp.Key);
+        }
 
         if (doc.Components?.Schemas != null)
         {
@@ -99,20 +108,21 @@ public class SchemaCleaner
         var seen = new HashSet<JsonSchema>();
         while (toProcess.Count > 0)
         {
-            var schema = toProcess.Pop();
-            if (!seen.Add(schema.ActualSchema))
+            var actualSchema = toProcess.Pop().ActualSchema;
+            if (!seen.Add(actualSchema))
             {
                 continue;
             }
 
-            // NOTE: NSwag schema stuff seems weird, with all their "Actual..."
-            if (schemaIdLookup.TryGetValue(schema.ActualSchema, out var refId) && !seenIds.Add(refId))
+            if (schemaIdLookup.TryGetValue(actualSchema, out var refIds))
             {
-                // prevent recursion
-                continue;
+                foreach (var refId in refIds)
+                {
+                    seenIds.Add(refId);
+                }
             }
 
-            foreach (var subSchema in EnumerateSchema(schema.ActualSchema))
+            foreach (var subSchema in EnumerateSchema(actualSchema))
             {
                 TryPush(subSchema, toProcess);
             }

--- a/src/Refitter.Tests/Examples/PropertyNamingPolicyTests.cs
+++ b/src/Refitter.Tests/Examples/PropertyNamingPolicyTests.cs
@@ -87,6 +87,55 @@ public class PropertyNamingPolicyTests
         }
         """;
 
+    private const string DigitPrefixedPropertyOpenApiSpec = """
+        {
+          "openapi": "3.0.1",
+          "info": {
+            "title": "Digit Prefixed Property API",
+            "version": "1.0.0"
+          },
+          "paths": {
+            "/responses": {
+              "get": {
+                "operationId": "GetResponse",
+                "responses": {
+                  "200": {
+                    "description": "Success",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/TestResponse"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "components": {
+            "schemas": {
+              "TestResponse": {
+                "type": "object",
+                "properties": {
+                  "42_question_field": {
+                    "$ref": "#/components/schemas/42Question"
+                  }
+                }
+              },
+              "42Question": {
+                "type": "object",
+                "properties": {
+                  "answer_text": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+        """;
+
     [Test]
     public async Task Can_Generate_Code_With_Default_PascalCase_Property_Naming()
     {
@@ -130,10 +179,32 @@ public class PropertyNamingPolicyTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Test]
+    public async Task Default_PascalCase_Property_Naming_Prefixes_Digit_Prefixed_Properties()
+    {
+        string generatedCode = await GenerateCodeFromSpec(DigitPrefixedPropertyOpenApiSpec);
+        generatedCode.Should().Contain("""[JsonPropertyName("42_question_field")]""");
+        generatedCode.Should().Contain("_42QuestionField { get; set; }");
+    }
+
+    [Test]
+    public async Task Default_PascalCase_Digit_Prefixed_Properties_Can_Build()
+    {
+        string generatedCode = await GenerateCodeFromSpec(DigitPrefixedPropertyOpenApiSpec);
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
     private static async Task<string> GenerateCode(
         PropertyNamingPolicy propertyNamingPolicy = PropertyNamingPolicy.PascalCase)
     {
-        var swaggerFile = await SwaggerFileHelper.CreateSwaggerJsonFile(OpenApiSpec);
+        return await GenerateCodeFromSpec(OpenApiSpec, propertyNamingPolicy);
+    }
+
+    private static async Task<string> GenerateCodeFromSpec(
+        string openApiSpec,
+        PropertyNamingPolicy propertyNamingPolicy = PropertyNamingPolicy.PascalCase)
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerJsonFile(openApiSpec);
 
         try
         {

--- a/src/Refitter.Tests/Examples/TrimUnusedSchemaAliasRegressionTests.cs
+++ b/src/Refitter.Tests/Examples/TrimUnusedSchemaAliasRegressionTests.cs
@@ -1,0 +1,282 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Refitter.Tests.TestUtilities;
+using TUnit.Core;
+
+namespace Refitter.Tests.Examples;
+
+public class TrimUnusedSchemaAliasRegressionTests
+{
+    private const string AliasSafeTrimOpenApiSpec = """
+        {
+          "openapi": "3.0.1",
+          "info": {
+            "title": "Trim Unused Schema Alias Regression API",
+            "version": "1.0.0"
+          },
+          "paths": {
+            "/test": {
+              "post": {
+                "operationId": "DoTest",
+                "requestBody": {
+                  "required": true,
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/TestRequest"
+                      }
+                    },
+                    "multipart/form-data": {
+                      "schema": {
+                        "$ref": "#/components/schemas/TestRequest"
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "201": {
+                    "description": "Created",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/TestResponse"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "components": {
+            "schemas": {
+              "TestRequest": {
+                "type": "object",
+                "properties": {
+                  "request_param2": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/RequestParamArrayItem"
+                    }
+                  },
+                  "request_param3": {
+                    "$ref": "#/components/schemas/RequestParamArrayItem"
+                  }
+                }
+              },
+              "TestResponse": {
+                "type": "object",
+                "properties": {
+                  "item": {
+                    "$ref": "#/components/schemas/RequestParamArrayItem"
+                  }
+                }
+              },
+              "RequestParamArrayItem": {
+                "$ref": "#/components/schemas/RequestParamArrayItemInternal"
+              },
+              "RequestParamArrayItemInternal": {
+                "type": "object",
+                "required": [
+                  "param1"
+                ],
+                "properties": {
+                  "param1": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    private const string CombinedOpenApiSpec = """
+        {
+          "openapi": "3.0.1",
+          "info": {
+            "title": "Combined Trim And Identifier Regression API",
+            "version": "1.0.0"
+          },
+          "paths": {
+            "/test": {
+              "post": {
+                "operationId": "DoTest",
+                "requestBody": {
+                  "required": true,
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/TestRequest"
+                      }
+                    },
+                    "multipart/form-data": {
+                      "schema": {
+                        "$ref": "#/components/schemas/TestRequest"
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "201": {
+                    "description": "Created",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/TestResponse"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "components": {
+            "schemas": {
+              "TestRequest": {
+                "type": "object",
+                "properties": {
+                  "42_question_field": {
+                    "$ref": "#/components/schemas/42Question"
+                  },
+                  "request_param2": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/RequestParamArrayItem"
+                    }
+                  },
+                  "request_param3": {
+                    "$ref": "#/components/schemas/RequestParamArrayItem"
+                  }
+                }
+              },
+              "42Question": {
+                "type": "object",
+                "properties": {
+                  "answer_text": {
+                    "type": "string"
+                  }
+                }
+              },
+              "TestResponse": {
+                "type": "object",
+                "properties": {
+                  "item": {
+                    "$ref": "#/components/schemas/RequestParamArrayItem"
+                  }
+                }
+              },
+              "RequestParamArrayItem": {
+                "$ref": "#/components/schemas/RequestParamArrayItemInternal"
+              },
+              "RequestParamArrayItemInternal": {
+                "type": "object",
+                "required": [
+                  "param1"
+                ],
+                "properties": {
+                  "param1": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    [Test]
+    public async Task Can_Generate_Code_When_TrimUnusedSchema_Uses_Aliased_Component_Schemas()
+    {
+        string generatedCode = await GenerateCode(AliasSafeTrimOpenApiSpec);
+        generatedCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task TrimUnusedSchema_With_Aliased_Component_Schemas_Can_Build()
+    {
+        string generatedCode = await GenerateCode(AliasSafeTrimOpenApiSpec);
+        generatedCode.Should().Contain("RequestParamArrayItem");
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Combined_Alias_Trim_And_Digit_Prefixed_Property_Regression_Can_Build()
+    {
+        string generatedCode = await GenerateCode(CombinedOpenApiSpec);
+        generatedCode.Should().Contain("""[JsonPropertyName("42_question_field")]""");
+        generatedCode.Should().Contain("_42QuestionField { get; set; }");
+        generatedCode.Should().Contain("RequestParamArrayItem");
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Combined_Regression_Can_Generate_From_Settings_File_Content()
+    {
+        string generatedCode = await GenerateCodeFromSettingsFileContent(CombinedOpenApiSpec);
+        generatedCode.Should().Contain("""[JsonPropertyName("42_question_field")]""");
+        generatedCode.Should().Contain("_42QuestionField { get; set; }");
+        generatedCode.Should().Contain("RequestParamArrayItem");
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    private static async Task<string> GenerateCode(string openApiSpec)
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerJsonFile(openApiSpec);
+
+        try
+        {
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = swaggerFile,
+                TrimUnusedSchema = true
+            };
+
+            var sut = await RefitGenerator.CreateAsync(settings);
+            return sut.Generate();
+        }
+        finally
+        {
+            DeleteSwaggerFile(swaggerFile);
+        }
+    }
+
+    private static async Task<string> GenerateCodeFromSettingsFileContent(string openApiSpec)
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerJsonFile(openApiSpec);
+
+        try
+        {
+            var settingsFileContent = $$"""
+                {
+                  "openApiPath": "{{swaggerFile.Replace("\\", "\\\\", StringComparison.Ordinal)}}",
+                  "trimUnusedSchema": true
+                }
+                """;
+
+            var settings = Serializer.Deserialize<RefitGeneratorSettings>(settingsFileContent);
+            var sut = await RefitGenerator.CreateAsync(settings);
+            return sut.Generate();
+        }
+        finally
+        {
+            DeleteSwaggerFile(swaggerFile);
+        }
+    }
+
+    private static void DeleteSwaggerFile(string swaggerFile)
+    {
+        if (File.Exists(swaggerFile))
+        {
+            File.Delete(swaggerFile);
+        }
+
+        var directory = Path.GetDirectoryName(swaggerFile);
+        if (directory != null && Directory.Exists(directory))
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+}

--- a/src/Refitter.Tests/IdentifierUtilsTests.cs
+++ b/src/Refitter.Tests/IdentifierUtilsTests.cs
@@ -71,6 +71,13 @@ public class IdentifierUtilsTests
     }
 
     [Test]
+    public void ToCompilableIdentifier_Prefixes_Digit_Prefixed_PascalCase_Names()
+    {
+        var result = IdentifierUtils.ToCompilableIdentifier("42QuestionField");
+        result.Should().Be("_42QuestionField");
+    }
+
+    [Test]
     public void Sanitize_Removes_Spaces()
     {
         var result = "Test Name".Sanitize();


### PR DESCRIPTION
This fixes #992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of property names that start with digits to ensure generated C# identifiers are valid and compilable.
  * Enhanced schema deduplication and alias resolution for more robust code generation.

* **Tests**
  * Added comprehensive test coverage for edge cases involving digit-prefixed properties and aliased schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->