### PR TITLE
Verify alias handling and sanitize PascalCase properties

### DIFF
--- a/src/Refitter.Core/SchemaCleaner.cs
+++ b/src/Refitter.Core/SchemaCleaner.cs
@@ -108,7 +108,8 @@ public class SchemaCleaner
         var seen = new HashSet<JsonSchema>();
         while (toProcess.Count > 0)
         {
-            var actualSchema = toProcess.Pop().ActualSchema;
+            var schema = toProcess.Pop();
+            var actualSchema = schema.ActualSchema;
             if (!seen.Add(actualSchema))
             {
                 continue;

--- a/src/Refitter.Tests/Examples/PropertyNamingPolicyTests.cs
+++ b/src/Refitter.Tests/Examples/PropertyNamingPolicyTests.cs
@@ -136,6 +136,79 @@ public class PropertyNamingPolicyTests
         }
         """;
 
+    private const string OpenApiSpec2 = """
+        {
+          "swagger": "2.0",
+          "info": {
+            "title": "Property Naming Policy API",
+            "version": "1.0.0"
+          },
+          "paths": {
+            "/nodes": {
+              "get": {
+                "operationId": "GetNode",
+                "responses": {
+                  "200": {
+                    "description": "Success",
+                    "schema": {
+                      "$ref": "#/definitions/RecursiveNode"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "definitions": {
+            "RecursiveNode": {
+              "type": "object",
+              "properties": {
+                "node_id": {
+                  "format": "int32"
+                },
+                "class": {
+                  "type": "string"
+                },
+                "1st-node": {
+                  "type": "string"
+                },
+                "child_count": {
+                  "type": "integer"
+                },
+                "next_node": {
+                  "$ref": "#/definitions/RecursiveNode"
+                },
+                "children": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/RecursiveNode"
+                  }
+                },
+                "named_nodes": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/definitions/RecursiveNode"
+                  }
+                },
+                "external_node": {
+                  "$ref": "#/definitions/RecursiveExternalNode"
+                }
+              }
+            },
+            "RecursiveExternalNode": {
+              "type": "object",
+              "properties": {
+                "external_id": {
+                  "type": "integer"
+                },
+                "next_node": {
+                  "$ref": "#/definitions/RecursiveExternalNode"
+                }
+              }
+            }
+          }
+        }
+        """;
+
     [Test]
     public async Task Can_Generate_Code_With_Default_PascalCase_Property_Naming()
     {
@@ -156,6 +229,14 @@ public class PropertyNamingPolicyTests
     {
         string generatedCode = await GenerateCode();
         generatedCode.Should().Contain("public string _1stNode { get; set; }");
+    }
+
+    [Test]
+    public async Task Default_PascalCase_Minimally_Sanitizes_Invalid_Identifiers_OpenApi2()
+    {
+        string generatedCode = await GenerateCodeFromSpec(OpenApiSpec2);
+        generatedCode.Should().Contain("public string _1stNode { get; set; }");
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
     [Test]

--- a/src/Refitter.Tests/Examples/PropertyNamingPolicyTests.cs
+++ b/src/Refitter.Tests/Examples/PropertyNamingPolicyTests.cs
@@ -152,6 +152,13 @@ public class PropertyNamingPolicyTests
     }
 
     [Test]
+    public async Task Default_PascalCase_Minimally_Sanitizes_Invalid_Identifiers()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("public string _1stNode { get; set; }");
+    }
+
+    [Test]
     public async Task PreserveOriginal_Emits_Raw_Valid_Identifiers()
     {
         string generatedCode = await GenerateCode(PropertyNamingPolicy.PreserveOriginal);

--- a/src/Refitter.Tests/Examples/TrimUnusedSchemaAliasWithLeadingDigitPropertyTests.cs
+++ b/src/Refitter.Tests/Examples/TrimUnusedSchemaAliasWithLeadingDigitPropertyTests.cs
@@ -1,0 +1,138 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Refitter.Tests.TestUtilities;
+using TUnit.Core;
+
+namespace Refitter.Tests.Examples;
+
+public class TrimUnusedSchemaAliasWithLeadingDigitPropertyTests
+{
+    private const string OpenApiSpec = """
+        openapi: 3.0.4
+        info:
+          title: "Multi content test"
+          version: "1"
+        servers:
+          - url: https://localhost:8000
+        paths:
+          /test:
+            post:
+              tags:
+                - Test
+              operationId: DoTest
+              parameters:
+                - name: inQueryParam
+                  in: query
+                  description: "inQueryParam test"
+                  schema:
+                    type: boolean
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/TestRequest'
+                  multipart/form-data:
+                    schema:
+                      $ref: '#/components/schemas/TestRequest'
+                required: true
+                x-go-name: Request
+                x-bodyName: request
+              responses:
+                '201':
+                  description: "A response"
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/TestResponse'
+        components:
+          schemas:
+            TestRequest:
+              title: "A test request"
+              required:
+                - type
+              type: object
+              properties:
+                42_question:
+                  $ref: '#/components/schemas/A42Question'
+                request_param1:
+                  type: string
+                request_param2:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/RequestParamArrayItem'
+                request_param3:
+                  $ref: '#/components/schemas/RequestParamArrayItem'
+            A42Question:
+              title: "A question about.. well, you know"
+              type: object
+              properties:
+                param1:
+                  type: string
+                param2:
+                  type: string
+            TestResponse:
+              title: "A test response"
+              type: object
+              properties:
+                item:
+                  $ref: '#/components/schemas/RequestParamArrayItem'
+            RequestParamArrayItem:
+              $ref: '#/components/schemas/RequestParamArrayItemInternal'
+            RequestParamArrayItemInternal:
+              required:
+                - param1
+              type: object
+              properties:
+                param1:
+                  type: number
+        """;
+
+    [Test]
+    public async Task Can_Generate_Code()
+    {
+        var generatedCode = await GenerateCode();
+        generatedCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Can_Build_Generated_Code()
+    {
+        var generatedCode = await GenerateCode();
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(OpenApiSpec);
+
+        try
+        {
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = swaggerFile,
+                Namespace = "TestApi",
+                TrimUnusedSchema = true,
+                GenerateOperationHeaders = false,
+                UseIsoDateFormat = true,
+                UsePolymorphicSerialization = true
+            };
+
+            var generator = await RefitGenerator.CreateAsync(settings);
+            return generator.Generate();
+        }
+        finally
+        {
+            if (File.Exists(swaggerFile))
+            {
+                File.Delete(swaggerFile);
+            }
+
+            var directory = Path.GetDirectoryName(swaggerFile);
+            if (directory != null && Directory.Exists(directory))
+            {
+                Directory.Delete(directory, true);
+            }
+        }
+    }
+}

--- a/src/Refitter.Tests/Examples/TrimUnusedSchemaAliasWithLeadingDigitPropertyTests.cs
+++ b/src/Refitter.Tests/Examples/TrimUnusedSchemaAliasWithLeadingDigitPropertyTests.cs
@@ -88,6 +88,77 @@ public class TrimUnusedSchemaAliasWithLeadingDigitPropertyTests
                   type: number
         """;
 
+    private const string OpenApiSpec2 = """
+        swagger: "2.0"
+        info:
+          title: "Multi content test"
+          version: "1"
+        host: localhost:8000
+        schemes:
+          - https
+        paths:
+          /test:
+            post:
+              tags:
+                - Test
+              operationId: DoTest
+              parameters:
+                - name: inQueryParam
+                  in: query
+                  description: "inQueryParam test"
+                  type: boolean
+                - name: request
+                  in: body
+                  required: true
+                  schema:
+                    $ref: '#/definitions/TestRequest'
+              responses:
+                '201':
+                  description: "A response"
+                  schema:
+                    $ref: '#/definitions/TestResponse'
+        definitions:
+          TestRequest:
+            title: "A test request"
+            required:
+              - type
+            type: object
+            properties:
+              42_question:
+                $ref: '#/definitions/A42Question'
+              request_param1:
+                type: string
+              request_param2:
+                type: array
+                items:
+                  $ref: '#/definitions/RequestParamArrayItem'
+              request_param3:
+                $ref: '#/definitions/RequestParamArrayItem'
+          A42Question:
+            title: "A question about.. well, you know"
+            type: object
+            properties:
+              param1:
+                type: string
+              param2:
+                type: string
+          TestResponse:
+            title: "A test response"
+            type: object
+            properties:
+              item:
+                $ref: '#/definitions/RequestParamArrayItem'
+          RequestParamArrayItem:
+            $ref: '#/definitions/RequestParamArrayItemInternal'
+          RequestParamArrayItemInternal:
+            required:
+              - param1
+            type: object
+            properties:
+              param1:
+                type: number
+        """;
+
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -102,9 +173,36 @@ public class TrimUnusedSchemaAliasWithLeadingDigitPropertyTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Test]
+    public async Task Can_Generate_Code_OpenApi2()
+    {
+        var generatedCode = await GenerateCodeFromSpec(OpenApiSpec2);
+        generatedCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Can_Build_Generated_Code_OpenApi2()
+    {
+        var generatedCode = await GenerateCodeFromSpec(OpenApiSpec2);
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Can_Generated_Identifier_Is_Valid_And_Compilable()
+    {
+        var generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("_42Question { get; set; }");
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
     private static async Task<string> GenerateCode()
     {
-        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(OpenApiSpec);
+        return await GenerateCodeFromSpec(OpenApiSpec);
+    }
+
+    private static async Task<string> GenerateCodeFromSpec(string openApiSpec)
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(openApiSpec);
 
         try
         {

--- a/src/Refitter.Tests/SchemaCleanerTests.cs
+++ b/src/Refitter.Tests/SchemaCleanerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Refitter.Core;
 using Refitter.Tests.Resources;
+using Refitter.Tests.TestUtilities;
 using TUnit.Core;
 
 namespace Refitter.Tests;
@@ -105,5 +106,71 @@ public class SchemaCleanerTests
         };
 
         cleaner.IncludeInheritanceHierarchy.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task RemoveUnreferencedSchema_Handles_Alias_Schemas_Sharing_The_Same_Instance()
+    {
+        const string spec = """
+            openapi: 3.0.4
+            info:
+              title: Alias schema test
+              version: "1"
+            paths:
+              /items:
+                get:
+                  operationId: GetItem
+                  responses:
+                    '200':
+                      description: Success
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/AliasItem'
+            components:
+              schemas:
+                AliasItem:
+                  $ref: '#/components/schemas/ActualItem'
+                ActualItem:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                UnusedItem:
+                  type: object
+                  properties:
+                    ignored:
+                      type: string
+            """;
+
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(spec);
+
+        try
+        {
+            var document = await OpenApiDocumentFactory.CreateAsync(swaggerFile);
+            ReferenceEquals(document.Components.Schemas["AliasItem"], document.Components.Schemas["ActualItem"])
+                .Should()
+                .BeTrue();
+
+            var cleaner = new SchemaCleaner(document, []);
+            cleaner.Invoking(x => x.RemoveUnreferencedSchema()).Should().NotThrow();
+
+            document.Components.Schemas.Should().ContainKey("AliasItem");
+            document.Components.Schemas.Should().ContainKey("ActualItem");
+            document.Components.Schemas.Should().NotContainKey("UnusedItem");
+        }
+        finally
+        {
+            if (File.Exists(swaggerFile))
+            {
+                File.Delete(swaggerFile);
+            }
+
+            var directory = Path.GetDirectoryName(swaggerFile);
+            if (directory != null && Directory.Exists(directory))
+            {
+                Directory.Delete(directory, true);
+            }
+        }
     }
 }


### PR DESCRIPTION
This closes #991 and verifies that the fixes from #996 apply to the same issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better sanitization of OpenAPI property names that begin with digits so generated C# identifiers are valid.
  * Improved handling when cleaning schemas that are aliases of the same underlying instance, preventing accidental removal.

* **Tests**
  * Added tests covering identifier sanitization, buildability of generated code, OpenAPI/Swagger (v2 & v3) scenarios, and alias-aware schema cleaning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->