### PR TITLE
Fix missing interface XML docs in multi-interface generation

### DIFF
--- a/src/Refitter.Core/XmlDocumentationGenerator.cs
+++ b/src/Refitter.Core/XmlDocumentationGenerator.cs
@@ -49,10 +49,8 @@ public class XmlDocumentationGenerator
 
         var controllerTag = document.Tags?.FirstOrDefault(t => t.Name.SanitizeControllerTag() == tag);
         var controllerDescription = controllerTag?.Description;
-        if (!string.IsNullOrEmpty(controllerDescription))
-        {
-            this.AppendXmlCommentBlock(SummaryTag, EscapeSymbols(controllerDescription!), code, indent: Separator);
-        }
+        var fallbackSummary = $"Operations for {EscapeSymbols(tag)}.";
+        this.AppendInterfaceSummary(controllerDescription, fallbackSummary, code);
     }
 
     /// <summary>
@@ -68,10 +66,11 @@ public class XmlDocumentationGenerator
         }
 
         var summary = endpoint.Summary;
-        if (!string.IsNullOrEmpty(summary))
-        {
-            this.AppendXmlCommentBlock(SummaryTag, EscapeSymbols(summary), code, indent: Separator);
-        }
+        var operationId = endpoint.OperationId;
+        var fallbackSummary = !string.IsNullOrWhiteSpace(operationId)
+            ? $"Operations for {EscapeSymbols(operationId!)}."
+            : "Operations for endpoint.";
+        this.AppendInterfaceSummary(summary, fallbackSummary, code);
     }
 
     /// <summary>
@@ -259,6 +258,17 @@ public class XmlDocumentationGenerator
             // When the content only has a single line, place it on the same line as the tag.
             code.AppendLine($"{content}</{tagName}>");
         }
+    }
+
+    private void AppendInterfaceSummary(string? preferredSummary, string fallbackSummary, StringBuilder code)
+    {
+        var summary = fallbackSummary;
+        if (!string.IsNullOrWhiteSpace(preferredSummary))
+        {
+            summary = EscapeSymbols(preferredSummary!);
+        }
+
+        this.AppendXmlCommentBlock(SummaryTag, summary, code, indent: Separator);
     }
 
     /// <summary>

--- a/src/Refitter.Tests/Build/BuildHelper.cs
+++ b/src/Refitter.Tests/Build/BuildHelper.cs
@@ -28,8 +28,12 @@ public static class BuildHelper
         var projectFile = Path.Combine(path, "Project.csproj");
         var projectContent = (targetFramework, warningsAsErrors) switch
         {
+            ("net8.0", true) => ProjectFileContents.Net80AppWithWarningsAsErrors,
+            ("net8.0", false) => ProjectFileContents.Net80App,
             ("net9.0", true) => ProjectFileContents.Net90AppWithWarningsAsErrors,
             ("net9.0", false) => ProjectFileContents.Net90App,
+            ("net10.0", true) => ProjectFileContents.Net100AppWithWarningsAsErrors,
+            ("net10.0", false) => ProjectFileContents.Net100App,
             (_, true) => ProjectFileContents.Net80AppWithWarningsAsErrors,
             _ => ProjectFileContents.Net80App
         };

--- a/src/Refitter.Tests/Build/BuildHelper.cs
+++ b/src/Refitter.Tests/Build/BuildHelper.cs
@@ -7,19 +7,30 @@ public static class BuildHelper
 {
     public static bool BuildCSharp(params string[] generatedCode)
     {
-        return BuildCSharp("net8.0", generatedCode);
+        return BuildCSharp("net8.0", warningsAsErrors: false, generatedCode);
+    }
+
+    public static bool BuildCSharp(bool warningsAsErrors, params string[] generatedCode)
+    {
+        return BuildCSharp("net8.0", warningsAsErrors, generatedCode);
     }
 
     public static bool BuildCSharp(string targetFramework, params string[] generatedCode)
+    {
+        return BuildCSharp(targetFramework, warningsAsErrors: false, generatedCode);
+    }
+
+    public static bool BuildCSharp(string targetFramework, bool warningsAsErrors, params string[] generatedCode)
     {
         var folder = Path.GetDirectoryName(typeof(BuildHelper).Assembly.Location) ?? Path.GetTempPath();
         var path = Path.Combine(folder, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(path);
         var projectFile = Path.Combine(path, "Project.csproj");
-        var projectContent = targetFramework switch
+        var projectContent = (targetFramework, warningsAsErrors) switch
         {
-            "net9.0" => ProjectFileContents.Net90App,
-            "net10.0" => ProjectFileContents.Net100App,
+            ("net9.0", true) => ProjectFileContents.Net90AppWithWarningsAsErrors,
+            ("net9.0", false) => ProjectFileContents.Net90App,
+            (_, true) => ProjectFileContents.Net80AppWithWarningsAsErrors,
             _ => ProjectFileContents.Net80App
         };
         File.WriteAllText(projectFile, projectContent);

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -29,6 +29,34 @@ public static class ProjectFileContents
   </ItemGroup>
 </Project>";
 
+    public const string Net80AppWithWarningsAsErrors = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
+    <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
+    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
+    <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.1"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.11"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.10.0"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
+    <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
+    <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
+    <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Mapster"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.AutoMapper"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Akavache"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.MonkeyCache"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Extensions.Microsoft.Caching"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Fusillade"" Version=""6.4.0"" />
+  </ItemGroup>
+</Project>";
+
     public const string Net90App = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
@@ -71,6 +99,34 @@ public static class ProjectFileContents
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
+    <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
+    <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
+    <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Mapster"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.AutoMapper"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Akavache"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.MonkeyCache"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Extensions.Microsoft.Caching"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Fusillade"" Version=""6.4.0"" />
+  </ItemGroup>
+</Project>";
+
+    public const string Net90AppWithWarningsAsErrors = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
+    <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
+    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
+    <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.1"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.11"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.10.0"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -84,6 +84,34 @@ public static class ProjectFileContents
   </ItemGroup>
 </Project>";
 
+    public const string Net90AppWithWarningsAsErrors = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
+    <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
+    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
+    <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.1"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.11"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.10.0"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
+    <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
+    <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
+    <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Mapster"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.AutoMapper"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Akavache"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.MonkeyCache"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Extensions.Microsoft.Caching"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Fusillade"" Version=""6.4.0"" />
+  </ItemGroup>
+</Project>";
+
     public const string Net100App = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
@@ -111,22 +139,22 @@ public static class ProjectFileContents
   </ItemGroup>
 </Project>";
 
-    public const string Net90AppWithWarningsAsErrors = @"
+    public const string Net100AppWithWarningsAsErrors = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
-    <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
-    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
+    <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
+    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.1"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.11"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.10.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />

--- a/src/Refitter.Tests/Regression/MissingInterfaceXmlDocsWarningsAsErrorsTests.cs
+++ b/src/Refitter.Tests/Regression/MissingInterfaceXmlDocsWarningsAsErrorsTests.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Refitter.Tests.TestUtilities;
+
+namespace Refitter.Tests.Regression;
+
+public class MissingInterfaceXmlDocsWarningsAsErrorsTests
+{
+    private const string ByTagSpec = """
+        openapi: '3.0.0'
+        info:
+          title: 'Issue 1109 Repro'
+          version: '1.0'
+        paths:
+          /users:
+            get:
+              tags:
+                - 'Users'
+              operationId: 'GetUsers'
+              responses:
+                '200':
+                  description: 'ok'
+          /orders:
+            get:
+              tags:
+                - 'Orders'
+              operationId: 'GetOrders'
+              responses:
+                '200':
+                  description: 'ok'
+        """;
+
+    private const string ByEndpointSpec = """
+        openapi: '3.0.0'
+        info:
+          title: 'Issue 1109 Endpoint Repro'
+          version: '1.0'
+        paths:
+          /users:
+            get:
+              operationId: 'GetUsers'
+              responses:
+                '200':
+                  description: 'ok'
+          /orders:
+            get:
+              responses:
+                '200':
+                  description: 'ok'
+        """;
+
+    [Test]
+    public async Task ByTag_Generates_Interface_Fallback_Summary_When_Tag_Description_Is_Missing()
+    {
+        string generatedCode = await GenerateCode(ByTagSpec, MultipleInterfaces.ByTag);
+
+        generatedCode.Should().Contain("/// <summary>Operations for Users.</summary>");
+        generatedCode.Should().Contain("/// <summary>Operations for Orders.</summary>");
+    }
+
+    [Test]
+    public async Task ByTag_Generated_Code_Builds_With_Warnings_As_Errors()
+    {
+        string generatedCode = await GenerateCode(ByTagSpec, MultipleInterfaces.ByTag);
+
+        BuildHelper.BuildCSharp(warningsAsErrors: true, generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ByEndpoint_Generates_Interface_Fallback_Summary_When_Endpoint_Summary_Is_Missing()
+    {
+        string generatedCode = await GenerateCode(ByEndpointSpec, MultipleInterfaces.ByEndpoint);
+
+        generatedCode.Should().Contain("/// <summary>Operations for GetUsers.</summary>");
+        generatedCode.Should().Contain("partial interface IOrdersEndpoint");
+        generatedCode.Should().Contain("/// <summary>Operations for");
+    }
+
+    [Test]
+    public async Task ByEndpoint_Generated_Code_Builds_With_Warnings_As_Errors()
+    {
+        string generatedCode = await GenerateCode(ByEndpointSpec, MultipleInterfaces.ByEndpoint);
+
+        BuildHelper.BuildCSharp(warningsAsErrors: true, generatedCode).Should().BeTrue();
+    }
+
+    private static async Task<string> GenerateCode(string spec, MultipleInterfaces multipleInterfaces)
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(spec);
+        var settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = swaggerFile,
+            MultipleInterfaces = multipleInterfaces
+        };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        return sut.Generate();
+    }
+}

--- a/src/Refitter.Tests/XmlDocumentationGeneratorTests.cs
+++ b/src/Refitter.Tests/XmlDocumentationGeneratorTests.cs
@@ -58,7 +58,7 @@ public class XmlDocumentationGeneratorTests
 
         this._generator.AppendInterfaceDocumentationByTag(document, "TestController", docs);
 
-        docs.ToString().Trim().Should().BeEmpty();
+        docs.ToString().Trim().Should().Be("/// <summary>Operations for TestController.</summary>");
     }
 
     [Test]

--- a/test/ConsoleApp/Directory.Build.props
+++ b/test/ConsoleApp/Directory.Build.props
@@ -28,9 +28,9 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
         <PackageReference Include="Refit" Version="11.0.1" />
         <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
         <PackageReference Include="Polly" Version="8.6.6" />


### PR DESCRIPTION
## Description:

This change fixes a regression where generated multi-interface clients could fail consumer builds with `CS1591` when XML docs are enabled and warnings are treated as errors. The issue happened when OpenAPI metadata did not include tag or endpoint summaries, leaving generated public interfaces undocumented.

The generator now always emits interface-level XML summaries for multi-interface output:
- `ByTag`: uses tag description when available, otherwise a stable fallback summary.
- `ByEndpoint`: uses endpoint summary when available, otherwise a stable fallback summary.

To prevent regressions, strict warnings-as-errors build coverage was added in tests by introducing strict project-file fixtures and regression scenarios that compile generated code under XML-doc + warnings-as-errors settings. The test build helper now also supports `net10.0` target framework alongside the existing `net8.0` and `net9.0` targets.

#### Example OpenAPI Specifications:
N/A

#### Example generated Refit interface
```cs
/// <summary>Users</summary>
[System.CodeDom.Compiler.GeneratedCode("Refitter", "1.0.0.0")]
public partial interface IUsersApi
{
    [Get("/users")]
    Task GetUsers();
}
```

## Summary by CodeRabbit

* **New Features**
  * Generated client interfaces now include automatic fallback documentation summaries when API specifications lack descriptions.

* **Tests**
  * Added regression tests to validate XML documentation generation with stricter compilation settings.
  * Extended build helper to support `net10.0` target framework in test project fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client interfaces now always include fallback XML summary documentation when API specs lack descriptions.

* **Tests**
  * Added regression tests verifying fallback summaries and that generated code builds with warnings treated as errors.

* **Chores**
  * Build/test helpers and project templates updated to support warnings-as-errors across target frameworks.
  * CI workflow formatting and package dependency versions updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->