### PR TITLE
Ensure Refit v11 compatibility

### DIFF
--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -13,10 +13,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.1"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.11"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.10.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -40,10 +40,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.1"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.11"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.10.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />

--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -9,7 +9,7 @@ public static class ProjectFileContents
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -36,7 +36,7 @@ public static class ProjectFileContents
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />

--- a/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
+++ b/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
@@ -21,7 +21,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.5" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>

--- a/src/Refitter.Tests/Build/BuildHelper.cs
+++ b/src/Refitter.Tests/Build/BuildHelper.cs
@@ -19,6 +19,7 @@ public static class BuildHelper
         var projectContent = targetFramework switch
         {
             "net9.0" => ProjectFileContents.Net90App,
+            "net10.0" => ProjectFileContents.Net100App,
             _ => ProjectFileContents.Net80App
         };
         File.WriteAllText(projectFile, projectContent);

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -9,14 +9,14 @@ public static class ProjectFileContents
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
-    <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
-    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
+    <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
+    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.1"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.11"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.10.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -36,14 +36,41 @@ public static class ProjectFileContents
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
-    <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
-    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
+    <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
+    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.1"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.11"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.10.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
+    <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
+    <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
+    <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Mapster"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.AutoMapper"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Akavache"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.MonkeyCache"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Extensions.Microsoft.Caching"" Version=""6.4.0"" />
+    <PackageReference Include=""Apizr.Integrations.Fusillade"" Version=""6.4.0"" />
+  </ItemGroup>
+</Project>";
+
+    public const string Net100App = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
+    <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
+    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
+    <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />

--- a/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
@@ -64,7 +64,7 @@ public class GenerateJsonSerializerContextPolymorphismTests
             <RestorePackagesPath>packages</RestorePackagesPath>
           </PropertyGroup>
           <ItemGroup>
-            <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
+            <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
           </ItemGroup>
         </Project>
         """;

--- a/src/Refitter.Tests/Scenarios/Refit11CompatibilityTests.cs
+++ b/src/Refitter.Tests/Scenarios/Refit11CompatibilityTests.cs
@@ -1,0 +1,306 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Refitter.Tests.Resources;
+using Refitter.Tests.TestUtilities;
+using TUnit.Core;
+
+namespace Refitter.Tests.Scenarios;
+
+public class Refit11CompatibilityTests
+{
+    private const string Refit11TargetFramework = "net10.0";
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var generatedCode = await GenerateCode(version, filename);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_IApiResponse_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            ReturnIApiResponse = true
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_IObservableResponse_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            ReturnIObservable = true
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_Multiple_Interfaces_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            MultipleInterfaces = MultipleInterfaces.ByEndpoint
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_Multiple_Interfaces_ByTag_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            MultipleInterfaces = MultipleInterfaces.ByTag
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_Dependency_Injection_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            DependencyInjectionSettings = new DependencyInjectionSettings
+            {
+                BaseUrl = "https://petstore3.swagger.io/api/v3"
+            }
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_Polly_Error_Handler_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            DependencyInjectionSettings = new DependencyInjectionSettings
+            {
+                BaseUrl = "https://petstore3.swagger.io/api/v3",
+                TransientErrorHandler = TransientErrorHandler.Polly
+            }
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_Microsoft_Http_Resilience_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            DependencyInjectionSettings = new DependencyInjectionSettings
+            {
+                BaseUrl = "https://petstore3.swagger.io/api/v3",
+                TransientErrorHandler = TransientErrorHandler.HttpResilience
+            }
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_Cancellation_Tokens_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            UseCancellationTokens = true
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_Operation_Headers_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            GenerateOperationHeaders = true
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3WithBearerAuthenticationHeaders, "SwaggerPetstoreWithBearerAuthenticationHeaders.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3WithBearerAuthenticationHeaders, "SwaggerPetstoreWithBearerAuthenticationHeaders.yaml")]
+    public async Task Can_Build_Generated_Code_With_Bearer_Authentication_Method_Style_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            AuthenticationHeaderStyle = AuthenticationHeaderStyle.Method
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3WithBearerAuthenticationHeaders, "SwaggerPetstoreWithBearerAuthenticationHeaders.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3WithBearerAuthenticationHeaders, "SwaggerPetstoreWithBearerAuthenticationHeaders.yaml")]
+    public async Task Can_Build_Generated_Code_With_Bearer_Authentication_Parameter_Style_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            AuthenticationHeaderStyle = AuthenticationHeaderStyle.Parameter
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_Immutable_Records_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            ImmutableRecords = true
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_Internal_Type_Accessibility_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            TypeAccessibility = TypeAccessibility.Internal
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_NonNullable_Reference_Types_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            CodeGeneratorSettings = new CodeGeneratorSettings
+            {
+                GenerateNullableReferenceTypes = true,
+                GenerateOptionalPropertiesAsNullable = true
+            }
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
+    public async Task Can_Build_Generated_Code_With_JsonSerializerContext_Using_Refit_11(SampleOpenSpecifications version, string filename)
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            GenerateJsonSerializerContext = true,
+            Naming = new NamingSettings
+            {
+                UseOpenApiTitle = false,
+                InterfaceName = "ISwaggerPetstore"
+            }
+        };
+        var generatedCode = await GenerateCode(version, filename, settings);
+        BuildHelper
+            .BuildCSharp(Refit11TargetFramework, generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode(
+        SampleOpenSpecifications version,
+        string filename,
+        RefitGeneratorSettings? settings = null)
+    {
+        var swaggerFile = await TestFile.CreateSwaggerFile(EmbeddedResources.GetSwaggerPetstore(version), filename);
+        if (settings is null)
+        {
+            settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+        }
+        else
+        {
+            settings.OpenApiPath = swaggerFile;
+        }
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        return sut.Generate();
+    }
+}

--- a/test/ConsoleApp/Directory.Build.props
+++ b/test/ConsoleApp/Directory.Build.props
@@ -31,8 +31,8 @@
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.5" />
-        <PackageReference Include="Refit" Version="10.2.0" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
+        <PackageReference Include="Refit" Version="11.0.1" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
         <PackageReference Include="Polly" Version="8.6.6" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/test/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/test/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Refit" Version="10.2.0" />
+    <PackageReference Include="Refit" Version="11.0.1" />
     <PackageReference Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>
 

--- a/test/MSBuild/Refitter.MSBuild.Tests.csproj
+++ b/test/MSBuild/Refitter.MSBuild.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
     </ItemGroup>
 
 </Project>

--- a/test/MinimalApi/MinimalApi.csproj
+++ b/test/MinimalApi/MinimalApi.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.0" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
     <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/test/MultipleFiles/Client/Client.csproj
+++ b/test/MultipleFiles/Client/Client.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
-    <PackageReference Include="Refit" Version="10.2.0" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
+    <PackageReference Include="Refit" Version="11.0.1" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This pull request updates the test infrastructure and dependencies to support and validate compatibility with Refit 11 and .NET 10.0. The main changes include upgrading all relevant Refit and related package references to their latest versions, introducing support for .NET 10.0 in test project scaffolding, and adding comprehensive compatibility tests to ensure generated code works with Refit 11 and the new framework version.

Dependency upgrades:

* Updated all `Refit` and `Refit.HttpClientFactory` package references in test and sample projects to version `11.0.1`, and upgraded related dependencies (such as `System.Text.Json`, `System.ComponentModel.Annotations`, and Microsoft.Extensions.* packages) to their latest compatible versions. [[1]](diffhunk://#diff-c80c9faae50aa4dbb3d1c1e9a100c1f39a3ffea609b609b3dadc67a84baed600L34-R35) [[2]](diffhunk://#diff-78a6499ba2fedd347ea6f937b198943f27cd53099cec98e2111a889ab2f3a163L15-R15) [[3]](diffhunk://#diff-773b3552d883590491553f82cedb5b099d6fd3cc65a980c59424a05c3027bb0cL12-R12) [[4]](diffhunk://#diff-931c3541dce1274c8d31ebb778bde43e329aeb9df2da11b443e77ae6ae114f13L23-R23) [[5]](diffhunk://#diff-29928c01690cfbdc825c5255a80b262456052e6e751db1d0a24ac45a1d3961c3L67-R67) [[6]](diffhunk://#diff-c28d4d24d9f0de2dfb70c7cd04fbf289b8bf2c27b761c57abb4e5aabbcadb6fdL24-R24) [[7]](diffhunk://#diff-85e848e84abcebc77e4aa9ab717be826fc49499d3a86604ccae2fa223472ae08L12-R12) [[8]](diffhunk://#diff-85e848e84abcebc77e4aa9ab717be826fc49499d3a86604ccae2fa223472ae08L39-R39) [[9]](diffhunk://#diff-b50eea9ef8bc22e552467f370a0388c3036d02b4d024b5b854a6cd0dff53db01L12-R19) [[10]](diffhunk://#diff-b50eea9ef8bc22e552467f370a0388c3036d02b4d024b5b854a6cd0dff53db01L39-R73)

Test project enhancements:

* Added a new constant `Net100App` to `ProjectFileContents` and updated `BuildHelper.BuildCSharp` to support building projects targeting `.NET 10.0`, enabling testing against the latest framework. [[1]](diffhunk://#diff-b50eea9ef8bc22e552467f370a0388c3036d02b4d024b5b854a6cd0dff53db01L39-R73) [[2]](diffhunk://#diff-0aeaa2bc1a4e15a33e1e51568f9620014b6a29c768309c53b9167808d16e1236R22)

Compatibility tests:

* Introduced a new test class `Refit11CompatibilityTests` that verifies generated code builds successfully with Refit 11 under various settings and OpenAPI inputs, ensuring robust compatibility for multiple generator features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive compatibility tests for Refit 11 covering many code-generation options and build scenarios.

* **Chores**
  * Bumped Refit and Refit.HttpClientFactory to v11.0.1 and updated System.Text.Json / Microsoft.Extensions packages to newer 10.x/11.x series.
  * Added support for targeting .NET 10.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->