### PR TITLE
Refactor ParameterExtractor by splitting into parameter-type extractors

### DIFF
--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -1,6 +1,6 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 using NJsonSchema;
 using NSwag;
 using NSwag.CodeGeneration.CSharp.Models;
@@ -17,208 +17,40 @@ internal static class ParameterExtractor
         string dynamicQuerystringParameterType,
         out string? dynamicQuerystringParameters)
     {
-        var routeParameters = operationModel.Parameters
-            .Where(p => p.Kind == OpenApiParameterKind.Path)
-            .Select(p =>
-            {
-                var variableName = GetVariableName(p);
-                return $"{JoinAttributes(GetAliasAsAttribute(p.Name, variableName))}{p.Type} {variableName}";
-            })
-            .ToList();
-
-        var queryParameters =
-            GetQueryParameters(operationModel, settings, dynamicQuerystringParameterType, out dynamicQuerystringParameters);
-
-        var bodyParameters = operationModel.Parameters
-            .Where(p => p.Kind == OpenApiParameterKind.Body && !p.IsBinaryBodyParameter)
-            .Select(p =>
-            {
-                var variableName = GetVariableName(p);
-                return $"{JoinAttributes(GetBodyAttribute(p, settings), GetAliasAsAttribute(p.Name, variableName))}{GetParameterType(p, settings)} {variableName}";
-            })
-            .ToList();
-
-        var headerParameters = new List<string>();
-
-        if (settings.GenerateOperationHeaders)
-        {
-            var ignoredHeaders = settings.IgnoredOperationHeaders
-                .Select(h => h.Trim())
-                .Where(h => !string.IsNullOrEmpty(h))
-                .ToArray();
-
-            var anyIgnoredHeaders = ignoredHeaders.Any();
-
-            headerParameters = operationModel.Parameters
-                .Where(p => p.Kind == OpenApiParameterKind.Header && p.IsHeader)
-                .Where(p => !anyIgnoredHeaders || !ignoredHeaders.Contains(p.Name, StringComparer.OrdinalIgnoreCase))
-                .Select(p =>
-                {
-                    var variableName = GetVariableName(p);
-                    return $"{JoinAttributes($"Header(\"{p.Name}\")")}{GetParameterType(p, settings)} {variableName}";
-                })
-                .ToList();
-        }
-
-        if (settings.AuthenticationHeaderStyle == AuthenticationHeaderStyle.Parameter)
-        {
-            var document = operation.Parent.Parent;
-            foreach (var securitySchemeName in operationModel.Security.SelectMany(x => x.Keys))
-            {
-                if ((settings.SecurityScheme != null && securitySchemeName != settings.SecurityScheme) ||
-                    !document.SecurityDefinitions.TryGetValue(securitySchemeName, out var securityScheme))
-                {
-                    continue;
-                }
-
-                if (securityScheme.Type == OpenApiSecuritySchemeType.ApiKey
-                    && securityScheme.In == OpenApiSecurityApiKeyLocation.Header
-                    && !operationModel.Parameters.Any(p => p.Kind == OpenApiParameterKind.Header && p.IsHeader && p.Name == securityScheme.Name))
-                {
-                    headerParameters.Add($"[Header(\"{securityScheme.Name}\")] string {ReplaceUnsafeCharacters(securityScheme.Name)}");
-                }
-                else if (securityScheme is { Type: OpenApiSecuritySchemeType.Http }
-                    && string.Equals(securityScheme.Scheme, "bearer", StringComparison.OrdinalIgnoreCase))
-                {
-                    headerParameters.Add($@"[Header(""Authorization: Bearer"")] string bearerToken");
-                }
-            }
-        }
-
-        // Deduplicate form parameters by sanitized identifier (#1018)
-        // Use ConvertToVariableName for both paths to ensure consistent deduplication
-        var seenFormParameterNames = new HashSet<string>(StringComparer.Ordinal);
-        var formParameters = new List<string>();
-
-        foreach (var p in operationModel.Parameters.Where(p => p.Kind == OpenApiParameterKind.FormData && !p.IsBinaryBodyParameter))
-        {
-            // Use VariableName (NSwag's processed name) not Name (original OpenAPI name)
-            var variableName = ConvertToVariableName(p.VariableName);
-            // Only add if this sanitized identifier hasn't been seen
-            if (seenFormParameterNames.Add(variableName))
-            {
-                formParameters.Add($"{JoinAttributes(GetAliasAsAttribute(p.Name, variableName))}{GetParameterType(p, settings)} {variableName}");
-            }
-        }
-
-        // Manually extract non-binary properties from multipart/form-data in OpenAPI 3.x
-        // NSwag doesn't populate these in operationModel.Parameters
-        if (operation.RequestBody?.Content?.TryGetValue("multipart/form-data", out var multipartContent) == true)
-        {
-            var schema = multipartContent.Schema;
-            if (schema?.Properties != null)
-            {
-                foreach (var property in schema.Properties)
-                {
-                    var propertySchema = property.Value;
-
-                    // Skip binary fields (files) as they're already handled as StreamPart
-                    var isBinary = (propertySchema.Type == JsonObjectType.String &&
-                                   propertySchema.Format == "binary") ||
-                                  (propertySchema.Type == JsonObjectType.Array &&
-                                   propertySchema.Item?.Type == JsonObjectType.String &&
-                                   propertySchema.Item?.Format == "binary");
-
-                    if (!isBinary)
-                    {
-                        // Generate proper C# type for the property
-                        var propertyType = GetCSharpType(propertySchema, settings);
-                        var variableName = ConvertToVariableName(property.Key);
-
-                        // Deduplicate by sanitized C# identifier, not original OpenAPI name (#1018)
-                        // HashSet.Add returns true if item was added (first occurrence), false if already present
-                        if (seenFormParameterNames.Add(variableName))
-                        {
-                            // First occurrence of this sanitized identifier - add the parameter
-                            var aliasAttribute = GetAliasAsAttribute(property.Key, variableName);
-                            var parameter = $"{JoinAttributes(aliasAttribute)}{propertyType} {variableName}";
-                            formParameters.Add(parameter);
-                        }
-                        // else: duplicate sanitized identifier - skip this parameter
-                    }
-                }
-            }
-        }
-        var binaryBodyParameters = operationModel.Parameters
-            .Where(p => p.Kind == OpenApiParameterKind.Body && p.IsBinaryBodyParameter)
-            .Select(p =>
-            {
-                var variableName = GetVariableName(p);
-                var aliasAsAttribute = GetAliasAsAttribute(p.Name, variableName);
-                var generatedAliasAsAttribute = string.IsNullOrWhiteSpace(aliasAsAttribute)
-                    ? string.Empty
-                    : $"[{aliasAsAttribute}]";
-
-                return $"{generatedAliasAsAttribute}StreamPart {variableName}";
-            })
-            .ToList();
-
-        var parameters = new List<string>();
-        parameters.AddRange(routeParameters);
-        parameters.AddRange(queryParameters);
-        parameters.AddRange(bodyParameters);
-        parameters.AddRange(headerParameters);
-        parameters.AddRange(formParameters);
-        parameters.AddRange(binaryBodyParameters);
-
-        parameters = ReOrderNullableParameters(parameters, settings, operationModel.Parameters);
-
-        if (settings.ApizrSettings?.WithRequestOptions == true)
-            parameters.Add("[RequestOptions] IApizrRequestOptions options");
-        else if (settings.UseCancellationTokens)
-            parameters.Add("CancellationToken cancellationToken = default");
-
-        return parameters;
+        var aggregator = new ParameterAggregator(settings);
+        return aggregator.ExtractParameters(
+            operationModel,
+            operation,
+            settings,
+            dynamicQuerystringParameterType,
+            out dynamicQuerystringParameters);
     }
 
-    private static string ReplaceUnsafeCharacters(
-        string unsafeText)
+    public static string GetAliasAsAttribute(CSharpParameterModel parameterModel) =>
+        string.Equals(parameterModel.Name, parameterModel.VariableName)
+            ? string.Empty
+            : $"AliasAs(\"{EscapeString(parameterModel.Name)}\")";
+
+    private static string EscapeString(string value)
     {
-        return IdentifierUtils.ToCompilableIdentifier(unsafeText);
-    }
-
-    private static List<string> ReOrderNullableParameters(
-        List<string> parameters,
-        RefitGeneratorSettings settings,
-        ICollection<CSharpParameterModel> parameterModels)
-    {
-        if (!settings.OptionalParameters || settings.ApizrSettings?.WithRequestOptions == true)
-            return parameters;
-
-        // Use regex to check for nullable type marker at the end of the type declaration
-        // Matches "?" followed by whitespace and parameter name (and optional default value)
-        var nullablePattern = new System.Text.RegularExpressions.Regex(@"\?\s+@?\w+(\s*=\s*[^,]+)?$",
-            System.Text.RegularExpressions.RegexOptions.Compiled);
-
-        parameters = parameters.OrderBy(c => nullablePattern.IsMatch(c)).ToList();
-        for (int index = 0; index < parameters.Count; index++)
+        var sb = new StringBuilder(value.Length + 10);
+        foreach (var c in value)
         {
-            if (nullablePattern.IsMatch(parameters[index]))
+            switch (c)
             {
-                var parameterString = parameters[index];
-                var defaultValue = GetDefaultValueForParameter(parameterString, parameterModels);
-                parameters[index] = parameterString + " = " + defaultValue;
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\v': sb.Append("\\v"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\0': sb.Append("\\0"); break;
+                default: sb.Append(c); break;
             }
         }
-
-        return parameters;
-    }
-
-    private static string GetDefaultValueForParameter(string parameterString, ICollection<CSharpParameterModel> parameterModels)
-    {
-        var parts = parameterString.Split([' '], StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length == 0)
-            return "default";
-
-        var variableName = parts[parts.Length - 1].TrimEnd(';', ',');
-
-        var parameterModel = parameterModels.FirstOrDefault(p => p.VariableName == variableName);
-        parameterModel ??= parameterModels.FirstOrDefault(p => GetVariableName(p) == variableName);
-        if (parameterModel?.Schema?.Default != null && !string.IsNullOrEmpty(parameterModel.Type))
-        {
-            return FormatDefaultValue(parameterModel.Schema.Default, parameterModel.Type);
-        }
-        return "default";
+        return sb.ToString();
     }
 
     private static string FormatDefaultValue(object? defaultValue, string parameterType)
@@ -235,49 +67,6 @@ internal static class ParameterExtractor
             _ when IsNumericType(type) => FormatNumericValue(defaultValue, type),
             _ => "default"
         };
-    }
-
-
-    private static string EscapeString(string value)
-    {
-        var sb = new StringBuilder(value.Length + 10);
-        foreach (var c in value)
-        {
-            switch (c)
-            {
-                case '\\':
-                    sb.Append("\\\\");
-                    break;
-                case '"':
-                    sb.Append("\\\"");
-                    break;
-                case '\n':
-                    sb.Append("\\n");
-                    break;
-                case '\r':
-                    sb.Append("\\r");
-                    break;
-                case '\t':
-                    sb.Append("\\t");
-                    break;
-                case '\f':
-                    sb.Append("\\f");
-                    break;
-                case '\v':
-                    sb.Append("\\v");
-                    break;
-                case '\b':
-                    sb.Append("\\b");
-                    break;
-                case '\0':
-                    sb.Append("\\0");
-                    break;
-                default:
-                    sb.Append(c);
-                    break;
-            }
-        }
-        return sb.ToString();
     }
 
     private static string FormatNumericValue(object defaultValue, string type)
@@ -300,11 +89,9 @@ internal static class ParameterExtractor
 
     private static string FormatDoubleLiteral(string numericString)
     {
-        // If the string already contains a decimal point or exponent, return as-is
         if (numericString.Contains('.') || numericString.Contains('e') || numericString.Contains('E'))
             return numericString;
 
-        // Otherwise, append .0 to make it a double literal
         return numericString + ".0";
     }
 
@@ -314,309 +101,5 @@ internal static class ParameterExtractor
             or "byte" or "Byte" or "decimal" or "Decimal" or "float" or "Single"
             or "double" or "Double" or "sbyte" or "SByte" or "uint" or "UInt32"
             or "ulong" or "UInt64" or "ushort" or "UInt16";
-    }
-
-    private static string GetBodyAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings)
-    {
-        var anyType = settings.CodeGeneratorSettings?.AnyType ?? "object";
-        var parameterType = WellKnownNamespaces.TrimImportedNamespaces(FindSupportedType(parameter.Type));
-
-        // Check if the parameter type matches AnyType (e.g., "object" or custom type like "System.Text.Json.JsonElement")
-        if (parameterType.Equals(anyType, StringComparison.OrdinalIgnoreCase) ||
-            parameterType.Contains("JsonElement", StringComparison.OrdinalIgnoreCase))
-        {
-            return "Body(BodySerializationMethod.Serialized)";
-        }
-
-        return "Body";
-    }
-
-    private static string GetQueryAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings)
-    {
-        return (parameter, settings) switch
-        {
-            { parameter.IsArray: true }
-                => $"Query(CollectionFormat.{settings.CollectionFormat})",
-            { parameter.IsDate: true, settings.UseIsoDateFormat: true }
-                => "Query(Format = \"yyyy-MM-dd\")",
-            { parameter.IsDate: true, settings.CodeGeneratorSettings.DateFormat: not null }
-                => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateFormat}\")",
-            {
-                parameter.IsDateOrDateTime: true, parameter.Schema.Format: "date-time",
-                settings.CodeGeneratorSettings.DateTimeFormat: not null
-            } => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateTimeFormat}\")",
-            _ => "Query",
-        };
-    }
-
-    private static string GetAliasAsAttribute(CSharpParameterModel parameterModel) =>
-        string.Equals(parameterModel.Name, parameterModel.VariableName)
-            ? string.Empty
-            : $"AliasAs(\"{EscapeString(parameterModel.Name)}\")";
-
-    private static string GetAliasAsAttribute(string originalName, string variableName) =>
-        string.Equals(originalName, variableName, StringComparison.Ordinal)
-            ? string.Empty
-            : $"AliasAs(\"{EscapeString(originalName)}\")";
-
-    private static string JoinAttributes(params string[] attributes)
-    {
-        var filteredAttributes = attributes
-            .Where(a => !string.IsNullOrWhiteSpace(a))
-            .ToList();
-
-        if (filteredAttributes.Count == 0)
-            return string.Empty;
-
-        return "[" + string.Join(", ", filteredAttributes) + "] ";
-    }
-
-    private static string GetParameterType(
-        ParameterModelBase parameterModel,
-        RefitGeneratorSettings settings)
-    {
-        var type = WellKnownNamespaces
-            .TrimImportedNamespaces(
-                FindSupportedType(
-                    parameterModel.Type));
-
-        if (settings.OptionalParameters &&
-            !type.EndsWith("?") &&
-            (parameterModel.IsNullable || parameterModel.IsOptional || !parameterModel.IsRequired))
-            type += "?";
-
-        return type;
-    }
-
-    private static string GetQueryParameterType(
-        ParameterModelBase parameterModel,
-        RefitGeneratorSettings settings)
-    {
-        var type = GetParameterType(parameterModel, settings);
-
-        if (parameterModel.IsQuery &&
-            parameterModel.Type.Equals("object", StringComparison.OrdinalIgnoreCase))
-            type = "string";
-
-        return type;
-    }
-
-    private static string FindSupportedType(string typeName)
-    {
-        if (typeName is "FileResponse" or "FileParameter")
-            return "StreamPart";
-
-        // Handle collections of FileParameter/FileResponse
-        if (typeName.Contains("FileParameter") || typeName.Contains("FileResponse"))
-        {
-            return typeName
-                .Replace("FileParameter", "StreamPart")
-                .Replace("FileResponse", "StreamPart");
-        }
-
-        return typeName;
-    }
-
-    private static List<string> GetQueryParameters(CSharpOperationModel operationModel, RefitGeneratorSettings settings, string dynamicQuerystringParameterType, out string? dynamicQuerystringParameters)
-    {
-        List<string>? parameters = null;
-        var dynamicQuerystringParametersCodeBuilder = new StringBuilder();
-        var queryParameters = operationModel.Parameters
-            .Where(p => p.Kind == OpenApiParameterKind.Query)
-            .ToList();
-
-        if (settings.UseDynamicQuerystringParameters && queryParameters.Count >= 2)
-        {
-            var modifier = settings.TypeAccessibility.ToString().ToLowerInvariant();
-            var isRecord = settings.ImmutableRecords ||
-                           settings.CodeGeneratorSettings?.GenerateNativeRecords is true;
-            var classStyle = isRecord
-                ? "record"
-                : "class";
-            var setterStyle = isRecord
-                ? "init"
-                : "set";
-
-            var injectedParametersCodeBuilder = new StringBuilder();
-            var initializedParametersCodeBuilder = new StringBuilder();
-            var propertiesCodeBuilder = new StringBuilder();
-            var allNullable = true;
-            foreach (var operationParameter in queryParameters)
-            {
-                var propertyType = GetQueryParameterType(operationParameter, settings);
-                allNullable = allNullable && propertyType.EndsWith("?");
-                var variableName = GetVariableName(operationParameter);
-                var attributes = $"{JoinAttributes(GetQueryAttribute(operationParameter, settings), GetAliasAsAttribute(operationParameter.Name, variableName))}";
-                var propertyName = variableName.CapitalizeFirstCharacter();
-                if (operationParameter.IsRequired)
-                {
-                    injectedParametersCodeBuilder.Append(injectedParametersCodeBuilder.Length == 0
-                        ? $$"""{{propertyType}} {{variableName}}"""
-                        : $$""", {{propertyType}} {{variableName}}""");
-
-                    initializedParametersCodeBuilder.AppendLine();
-                    initializedParametersCodeBuilder.Append(
-        $$"""
-                        this.{{propertyName}} = {{variableName}};
-            """);
-                }
-
-                propertiesCodeBuilder.AppendLine();
-                if (settings.GenerateXmlDocCodeComments && !string.IsNullOrWhiteSpace(operationParameter.Description))
-                {
-                    var escapedDescription = XmlDocumentationGenerator.SanitizeResponseDescription(operationParameter.Description);
-                    AppendXmlDocComment(escapedDescription, propertiesCodeBuilder);
-                }
-
-                propertiesCodeBuilder.Append(
-        $$"""
-                    {{attributes}}
-                    {{modifier}} {{propertyType}} {{propertyName}} { get; {{setterStyle}}; }
-            """);
-                var defaultValue = operationParameter.Schema.Default;
-                if (defaultValue != null)
-                {
-                    var formattedDefaultValue = FormatDefaultValue(defaultValue, propertyType);
-                    propertiesCodeBuilder.Append($" = {formattedDefaultValue};");
-                }
-                propertiesCodeBuilder.AppendLine();
-            }
-
-            dynamicQuerystringParametersCodeBuilder.AppendLine(
-        $$"""
-                {{modifier}} {{classStyle}} {{dynamicQuerystringParameterType}}
-                {
-            """);
-
-            if (injectedParametersCodeBuilder.Length > 0)
-            {
-                dynamicQuerystringParametersCodeBuilder.AppendLine(
-        $$"""
-                    {{modifier}} {{dynamicQuerystringParameterType}}({{injectedParametersCodeBuilder}})
-                    {
-                        {{initializedParametersCodeBuilder}}
-                    }
-            """);
-            }
-
-            dynamicQuerystringParametersCodeBuilder.AppendLine(
-        $$"""
-                    {{propertiesCodeBuilder}}
-                }
-            """);
-
-            var dynamicQuerystringParameter = $"[Query] {dynamicQuerystringParameterType}";
-            if (allNullable)
-                dynamicQuerystringParameter += "?";
-            dynamicQuerystringParameter += " queryParams";
-            parameters = [dynamicQuerystringParameter];
-        }
-
-        dynamicQuerystringParameters = dynamicQuerystringParametersCodeBuilder.ToString();
-
-        parameters ??= queryParameters
-            .Select(p =>
-            {
-                var variableName = GetVariableName(p);
-                return $"{JoinAttributes(GetQueryAttribute(p, settings), GetAliasAsAttribute(p.Name, variableName))}{GetQueryParameterType(p, settings)} {variableName}";
-            })
-            .ToList();
-
-        return parameters;
-    }
-
-    private static void AppendXmlDocComment(string description, StringBuilder codeBuilder)
-    {
-        codeBuilder.Append(
-"""
-                /// <summary>
-""");
-
-        var lines = description.Split(
-            ["\r\n", "\r", "\n"],
-            StringSplitOptions.None);
-
-        foreach (var line in lines)
-        {
-            codeBuilder.AppendLine();
-            codeBuilder.Append(
-$$"""
-                /// {{line.Trim()}}
-""");
-        }
-
-        codeBuilder.AppendLine();
-        codeBuilder.Append(
-"""
-                /// </summary>
-""");
-        codeBuilder.AppendLine();
-    }
-
-    private static string GetCSharpType(JsonSchema propertySchema, RefitGeneratorSettings settings)
-    {
-        var type = propertySchema.Type switch
-        {
-            JsonObjectType.String => "string",
-            JsonObjectType.Integer => GetIntegerTypeName(propertySchema, settings),
-            JsonObjectType.Number => "double",
-            JsonObjectType.Boolean => "bool",
-            JsonObjectType.Array => GetArrayType(propertySchema, settings),
-            JsonObjectType.Object => "object",
-            _ => "object"
-        };
-
-        // Add nullable modifier if needed
-        if (settings.OptionalParameters && propertySchema.IsNullable(SchemaType.OpenApi3))
-        {
-            type += "?";
-        }
-
-        return type;
-    }
-
-    private static string GetIntegerTypeName(JsonSchema schema, RefitGeneratorSettings settings)
-    {
-        // Check the format first
-        if (schema.Format == "int64")
-            return "long";
-        if (schema.Format == "int32")
-            return "int";
-
-        // Fall back to settings
-        var integerType = settings.CodeGeneratorSettings?.IntegerType ?? IntegerType.Int32;
-        return integerType == IntegerType.Int64 ? "long" : "int";
-    }
-
-    private static string GetArrayType(JsonSchema arraySchema, RefitGeneratorSettings settings)
-    {
-        if (arraySchema.Item != null)
-        {
-            var itemType = GetCSharpType(arraySchema.Item, settings);
-            return $"{itemType}[]";
-        }
-        return "object[]";
-    }
-
-    private static string ConvertToVariableName(string propertyName)
-    {
-        if (string.IsNullOrEmpty(propertyName))
-            return "value";
-
-        // Use ToCompilableIdentifier to handle reserved keywords and invalid characters
-        var identifier = IdentifierUtils.ToCompilableIdentifier(propertyName);
-
-        // Convert first character to lowercase for camelCase, if it's a letter
-        if (identifier.Length > 0 && char.IsUpper(identifier[0]))
-        {
-            return char.ToLowerInvariant(identifier[0]) + identifier.Substring(1);
-        }
-
-        return identifier;
-    }
-
-    private static string GetVariableName(ParameterModelBase parameterModel)
-    {
-        return IdentifierUtils.ToCompilableIdentifier(parameterModel.VariableName);
     }
 }

--- a/src/Refitter.Core/ParameterExtractors/BodyParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractors/BodyParameterExtractor.cs
@@ -1,0 +1,141 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration.Models;
+using Refitter.Core;
+using System.Text;
+
+namespace Refitter.Core;
+
+internal sealed class BodyParameterExtractor : IParameterTypeExtractor
+{
+    public bool CanExtract(OpenApiParameterKind kind) => kind == OpenApiParameterKind.Body;
+
+    public IEnumerable<string> Extract(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings)
+    {
+        var parameters = new List<string>();
+
+        // Non-binary body parameters
+        var bodyParams = operationModel.Parameters
+            .Where(p => p.Kind == OpenApiParameterKind.Body && !p.IsBinaryBodyParameter)
+            .Select(p =>
+            {
+                var variableName = GetVariableName(p);
+                return $"{JoinAttributes(GetBodyAttribute(p, settings), GetAliasAsAttribute(p.Name, variableName))}{GetParameterType(p, settings)} {variableName}";
+            })
+            .ToList();
+        parameters.AddRange(bodyParams);
+
+        // Binary body parameters
+        var binaryParams = operationModel.Parameters
+            .Where(p => p.Kind == OpenApiParameterKind.Body && p.IsBinaryBodyParameter)
+            .Select(p =>
+            {
+                var variableName = GetVariableName(p);
+                var aliasAsAttribute = GetAliasAsAttribute(p.Name, variableName);
+                var generatedAliasAsAttribute = string.IsNullOrWhiteSpace(aliasAsAttribute)
+                    ? string.Empty
+                    : $"[{aliasAsAttribute}]";
+
+                return $"{generatedAliasAsAttribute}StreamPart {variableName}";
+            })
+            .ToList();
+        parameters.AddRange(binaryParams);
+
+        return parameters;
+    }
+
+    private static string GetVariableName(ParameterModelBase parameterModel)
+    {
+        return IdentifierUtils.ToCompilableIdentifier(parameterModel.VariableName);
+    }
+
+    private static string GetAliasAsAttribute(string originalName, string variableName)
+    {
+        return string.Equals(originalName, variableName, StringComparison.Ordinal)
+            ? string.Empty
+            : $"AliasAs(\"{EscapeString(originalName)}\")";
+    }
+
+    private static string EscapeString(string value)
+    {
+        var sb = new StringBuilder(value.Length + 10);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\v': sb.Append("\\v"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\0': sb.Append("\\0"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string JoinAttributes(params string[] attributes)
+    {
+        var filteredAttributes = attributes
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .ToList();
+
+        if (filteredAttributes.Count == 0)
+            return string.Empty;
+
+        return "[" + string.Join(", ", filteredAttributes) + "] ";
+    }
+
+    private static string GetBodyAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings)
+    {
+        var anyType = settings.CodeGeneratorSettings?.AnyType ?? "object";
+        var parameterType = WellKnownNamespaces.TrimImportedNamespaces(FindSupportedType(parameter.Type));
+
+        if (parameterType.Equals(anyType, StringComparison.OrdinalIgnoreCase) ||
+            parameterType.Contains("JsonElement", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Body(BodySerializationMethod.Serialized)";
+        }
+
+        return "Body";
+    }
+
+    private static string GetParameterType(
+        ParameterModelBase parameterModel,
+        RefitGeneratorSettings settings)
+    {
+        var type = WellKnownNamespaces
+            .TrimImportedNamespaces(
+                FindSupportedType(
+                    parameterModel.Type));
+
+        if (settings.OptionalParameters &&
+            !type.EndsWith("?") &&
+            (parameterModel.IsNullable || parameterModel.IsOptional || !parameterModel.IsRequired))
+            type += "?";
+
+        return type;
+    }
+
+    private static string FindSupportedType(string typeName)
+    {
+        if (typeName is "FileResponse" or "FileParameter")
+            return "StreamPart";
+
+        if (typeName.Contains("FileParameter") || typeName.Contains("FileResponse"))
+        {
+            return typeName
+                .Replace("FileParameter", "StreamPart")
+                .Replace("FileResponse", "StreamPart");
+        }
+
+        return typeName;
+    }
+}

--- a/src/Refitter.Core/ParameterExtractors/DynamicQuerystringParameterBuilder.cs
+++ b/src/Refitter.Core/ParameterExtractors/DynamicQuerystringParameterBuilder.cs
@@ -1,0 +1,298 @@
+using NJsonSchema;
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration.Models;
+using Refitter.Core;
+using System.Text;
+
+namespace Refitter.Core;
+
+internal static class DynamicQuerystringParameterBuilder
+{
+    public static IEnumerable<string> Build(
+        CSharpOperationModel operationModel,
+        IList<CSharpParameterModel> queryParameters,
+        RefitGeneratorSettings settings,
+        string dynamicQuerystringParameterType)
+    {
+        var dynamicQuerystringParametersCodeBuilder = new StringBuilder();
+        var modifier = settings.TypeAccessibility.ToString().ToLowerInvariant();
+        var isRecord = settings.ImmutableRecords ||
+                       settings.CodeGeneratorSettings?.GenerateNativeRecords is true;
+        var classStyle = isRecord
+            ? "record"
+            : "class";
+        var setterStyle = isRecord
+            ? "init"
+            : "set";
+
+        var injectedParametersCodeBuilder = new StringBuilder();
+        var initializedParametersCodeBuilder = new StringBuilder();
+        var propertiesCodeBuilder = new StringBuilder();
+        var allNullable = true;
+
+        foreach (var operationParameter in queryParameters)
+        {
+            var propertyType = GetQueryParameterType(operationParameter, settings);
+            allNullable = allNullable && propertyType.EndsWith("?");
+            var variableName = GetVariableName(operationParameter);
+            var attributes = $"{JoinAttributes(GetQueryAttribute(operationParameter, settings), GetAliasAsAttribute(operationParameter.Name, variableName))}";
+            var propertyName = variableName.CapitalizeFirstCharacter();
+
+            if (operationParameter.IsRequired)
+            {
+                injectedParametersCodeBuilder.Append(injectedParametersCodeBuilder.Length == 0
+                    ? $"{propertyType} {variableName}"
+                    : $", {propertyType} {variableName}");
+
+                initializedParametersCodeBuilder.AppendLine();
+                initializedParametersCodeBuilder.Append(
+                    $"        this.{propertyName} = {variableName};\n");
+            }
+
+            propertiesCodeBuilder.AppendLine();
+            if (settings.GenerateXmlDocCodeComments && !string.IsNullOrWhiteSpace(operationParameter.Description))
+            {
+                var escapedDescription = XmlDocumentationGenerator.SanitizeResponseDescription(operationParameter.Description);
+                AppendXmlDocComment(escapedDescription, propertiesCodeBuilder);
+            }
+
+            propertiesCodeBuilder.Append(
+                $"\n        {attributes}\n        {modifier} {propertyType} {propertyName} {{ get; {setterStyle}; }}");
+            var defaultValue = operationParameter.Schema?.Default;
+            if (defaultValue != null)
+            {
+                var formattedDefaultValue = FormatDefaultValue(defaultValue, propertyType);
+                propertiesCodeBuilder.Append($" = {formattedDefaultValue};");
+            }
+
+            propertiesCodeBuilder.AppendLine();
+        }
+
+        dynamicQuerystringParametersCodeBuilder.AppendLine(
+            $"\n    {modifier} {classStyle} {dynamicQuerystringParameterType}");
+        dynamicQuerystringParametersCodeBuilder.AppendLine("    {");
+
+        if (injectedParametersCodeBuilder.Length > 0)
+        {
+            dynamicQuerystringParametersCodeBuilder.AppendLine(
+                $"\n        {modifier} {dynamicQuerystringParameterType}({injectedParametersCodeBuilder})");
+            dynamicQuerystringParametersCodeBuilder.AppendLine("        {");
+            dynamicQuerystringParametersCodeBuilder.Append(initializedParametersCodeBuilder);
+            dynamicQuerystringParametersCodeBuilder.AppendLine("        }");
+        }
+
+        dynamicQuerystringParametersCodeBuilder.Append(propertiesCodeBuilder);
+        dynamicQuerystringParametersCodeBuilder.AppendLine("    }");
+
+        var dynamicQuerystringParameter = $"[Query] {dynamicQuerystringParameterType}";
+        if (allNullable)
+            dynamicQuerystringParameter += "?";
+        dynamicQuerystringParameter += " queryParams";
+
+        return [dynamicQuerystringParameter];
+    }
+
+    private static string GetVariableName(ParameterModelBase parameterModel)
+    {
+        return IdentifierUtils.ToCompilableIdentifier(parameterModel.VariableName);
+    }
+
+    private static string GetQueryAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings)
+    {
+        return (parameter, settings) switch
+        {
+            { parameter.IsArray: true }
+                => $"Query(CollectionFormat.{settings.CollectionFormat})",
+            { parameter.IsDate: true, settings.UseIsoDateFormat: true }
+                => "Query(Format = \"yyyy-MM-dd\")",
+            { parameter.IsDate: true, settings.CodeGeneratorSettings.DateFormat: not null }
+                => $"Query(Format = \"{settings.CodeGeneratorSettings!.DateFormat}\")",
+            {
+                parameter.IsDateOrDateTime: true, parameter.Schema.Format: "date-time",
+                settings.CodeGeneratorSettings.DateTimeFormat: not null
+            } => $"Query(Format = \"{settings.CodeGeneratorSettings!.DateTimeFormat}\")",
+            _ => "Query",
+        };
+    }
+
+    private static string GetAliasAsAttribute(string originalName, string variableName)
+    {
+        return string.Equals(originalName, variableName, StringComparison.Ordinal)
+            ? string.Empty
+            : $"AliasAs(\"{EscapeString(originalName)}\")";
+    }
+
+    private static string EscapeString(string value)
+    {
+        var sb = new StringBuilder(value.Length + 10);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\v': sb.Append("\\v"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\0': sb.Append("\\0"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string JoinAttributes(params string[] attributes)
+    {
+        var filteredAttributes = attributes
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .ToList();
+
+        if (filteredAttributes.Count == 0)
+            return string.Empty;
+
+        return "[" + string.Join(", ", filteredAttributes) + "] ";
+    }
+
+    private static string GetQueryParameterType(
+        ParameterModelBase parameterModel,
+        RefitGeneratorSettings settings)
+    {
+        var type = GetParameterType(parameterModel, settings);
+
+        if (parameterModel.IsQuery &&
+            parameterModel.Type.Equals("object", StringComparison.OrdinalIgnoreCase))
+            type = "string";
+
+        return type;
+    }
+
+    private static string GetParameterType(
+        ParameterModelBase parameterModel,
+        RefitGeneratorSettings settings)
+    {
+        var type = WellKnownNamespaces
+            .TrimImportedNamespaces(
+                FindSupportedType(
+                    parameterModel.Type));
+
+        if (settings.OptionalParameters &&
+            !type.EndsWith("?") &&
+            (parameterModel.IsNullable || parameterModel.IsOptional || !parameterModel.IsRequired))
+            type += "?";
+
+        return type;
+    }
+
+    private static string FindSupportedType(string typeName)
+    {
+        if (typeName is "FileResponse" or "FileParameter")
+            return "StreamPart";
+
+        if (typeName.Contains("FileParameter") || typeName.Contains("FileResponse"))
+        {
+            return typeName
+                .Replace("FileParameter", "StreamPart")
+                .Replace("FileResponse", "StreamPart");
+        }
+
+        return typeName;
+    }
+
+    private static string FormatDefaultValue(object? defaultValue, string parameterType)
+    {
+        if (defaultValue == null)
+            return "default";
+
+        var type = parameterType.TrimEnd('?').Trim();
+
+        return type switch
+        {
+            "bool" => defaultValue.ToString()?.ToLowerInvariant() ?? "default",
+            "string" => $"\"{EscapeStringForLiteral(defaultValue.ToString() ?? string.Empty)}\"",
+            _ when IsNumericType(type) => FormatNumericValue(defaultValue, type),
+            _ => "default"
+        };
+    }
+
+    private static string EscapeStringForLiteral(string value)
+    {
+        var sb = new StringBuilder(value.Length + 10);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\v': sb.Append("\\v"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\0': sb.Append("\\0"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string FormatNumericValue(object defaultValue, string type)
+    {
+        var numericString = defaultValue is IFormattable formattable
+            ? formattable.ToString(null, System.Globalization.CultureInfo.InvariantCulture)
+            : (defaultValue.ToString() ?? "default");
+
+        return type switch
+        {
+            "float" or "Single" => $"{numericString}f",
+            "decimal" or "Decimal" => $"{numericString}m",
+            "double" or "Double" => FormatDoubleLiteral(numericString),
+            "long" or "Int64" => $"{numericString}L",
+            "ulong" or "UInt64" => $"{numericString}UL",
+            "uint" or "UInt32" => $"{numericString}U",
+            _ => numericString
+        };
+    }
+
+    private static string FormatDoubleLiteral(string numericString)
+    {
+        if (numericString.Contains('.') || numericString.Contains('e') || numericString.Contains('E'))
+            return numericString;
+
+        return numericString + ".0";
+    }
+
+    private static bool IsNumericType(string type)
+    {
+        return type is "int" or "Int32" or "long" or "Int64" or "short" or "Int16"
+            or "byte" or "Byte" or "decimal" or "Decimal" or "float" or "Single"
+            or "double" or "Double" or "sbyte" or "SByte" or "uint" or "UInt32"
+            or "ulong" or "UInt64" or "ushort" or "UInt16";
+    }
+
+    private static void AppendXmlDocComment(string description, StringBuilder codeBuilder)
+    {
+        codeBuilder.Append(
+            "\n        /// <summary>");
+
+        var lines = description.Split(
+            ["\r\n", "\r", "\n"],
+            StringSplitOptions.None);
+
+        foreach (var line in lines)
+        {
+            codeBuilder.AppendLine();
+            codeBuilder.Append(
+                $"        /// {line.Trim()}");
+        }
+
+        codeBuilder.AppendLine();
+        codeBuilder.Append(
+            "        /// </summary>");
+        codeBuilder.AppendLine();
+    }
+}

--- a/src/Refitter.Core/ParameterExtractors/FormParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractors/FormParameterExtractor.cs
@@ -1,0 +1,194 @@
+using NJsonSchema;
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration.Models;
+using Refitter.Core;
+using System.Text;
+
+namespace Refitter.Core;
+
+internal sealed class FormParameterExtractor : IParameterTypeExtractor
+{
+    public bool CanExtract(OpenApiParameterKind kind) => kind == OpenApiParameterKind.FormData;
+
+    public IEnumerable<string> Extract(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings)
+    {
+        var seenFormParameterNames = new HashSet<string>(StringComparer.Ordinal);
+        var formParameters = new List<string>();
+
+        foreach (var p in operationModel.Parameters.Where(p => p.Kind == OpenApiParameterKind.FormData && !p.IsBinaryBodyParameter))
+        {
+            var variableName = ConvertToVariableName(p.VariableName);
+            if (seenFormParameterNames.Add(variableName))
+            {
+                formParameters.Add($"{JoinAttributes(GetAliasAsAttribute(p.Name, variableName))}{GetParameterType(p, settings)} {variableName}");
+            }
+        }
+
+        if (operation.RequestBody?.Content?.TryGetValue("multipart/form-data", out var multipartContent) == true)
+        {
+            var schema = multipartContent.Schema;
+            if (schema?.Properties != null)
+            {
+                foreach (var property in schema.Properties)
+                {
+                    var propertySchema = property.Value;
+
+                    var isBinary = (propertySchema.Type == JsonObjectType.String &&
+                                   propertySchema.Format == "binary") ||
+                                  (propertySchema.Type == JsonObjectType.Array &&
+                                   propertySchema.Item?.Type == JsonObjectType.String &&
+                                   propertySchema.Item?.Format == "binary");
+
+                    if (!isBinary)
+                    {
+                        var propertyType = GetCSharpType(propertySchema, settings);
+                        var variableName = ConvertToVariableName(property.Key);
+
+                        if (seenFormParameterNames.Add(variableName))
+                        {
+                            var aliasAttribute = GetAliasAsAttribute(property.Key, variableName);
+                            var parameter = $"{JoinAttributes(aliasAttribute)}{propertyType} {variableName}";
+                            formParameters.Add(parameter);
+                        }
+                    }
+                }
+            }
+        }
+
+        return formParameters;
+    }
+
+    private static string ConvertToVariableName(string propertyName)
+    {
+        if (string.IsNullOrEmpty(propertyName))
+            return "value";
+
+        var identifier = IdentifierUtils.ToCompilableIdentifier(propertyName);
+
+        if (identifier.Length > 0 && char.IsUpper(identifier[0]))
+        {
+            return char.ToLowerInvariant(identifier[0]) + identifier.Substring(1);
+        }
+
+        return identifier;
+    }
+
+    private static string GetAliasAsAttribute(string originalName, string variableName)
+    {
+        return string.Equals(originalName, variableName, StringComparison.Ordinal)
+            ? string.Empty
+            : $"AliasAs(\"{EscapeString(originalName)}\")";
+    }
+
+    private static string EscapeString(string value)
+    {
+        var sb = new StringBuilder(value.Length + 10);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\v': sb.Append("\\v"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\0': sb.Append("\\0"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string JoinAttributes(params string[] attributes)
+    {
+        var filteredAttributes = attributes
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .ToList();
+
+        if (filteredAttributes.Count == 0)
+            return string.Empty;
+
+        return "[" + string.Join(", ", filteredAttributes) + "] ";
+    }
+
+    private static string GetParameterType(
+        ParameterModelBase parameterModel,
+        RefitGeneratorSettings settings)
+    {
+        var type = WellKnownNamespaces
+            .TrimImportedNamespaces(
+                FindSupportedType(
+                    parameterModel.Type));
+
+        if (settings.OptionalParameters &&
+            !type.EndsWith("?") &&
+            (parameterModel.IsNullable || parameterModel.IsOptional || !parameterModel.IsRequired))
+            type += "?";
+
+        return type;
+    }
+
+    private static string GetCSharpType(JsonSchema propertySchema, RefitGeneratorSettings settings)
+    {
+        var type = propertySchema.Type switch
+        {
+            JsonObjectType.String => "string",
+            JsonObjectType.Integer => GetIntegerTypeName(propertySchema, settings),
+            JsonObjectType.Number => "double",
+            JsonObjectType.Boolean => "bool",
+            JsonObjectType.Array => GetArrayType(propertySchema, settings),
+            JsonObjectType.Object => "object",
+            _ => "object"
+        };
+
+        if (settings.OptionalParameters && propertySchema.IsNullable(SchemaType.OpenApi3))
+        {
+            type += "?";
+        }
+
+        return type;
+    }
+
+    private static string GetIntegerTypeName(JsonSchema schema, RefitGeneratorSettings settings)
+    {
+        if (schema.Format == "int64")
+            return "long";
+        if (schema.Format == "int32")
+            return "int";
+
+        var integerType = settings.CodeGeneratorSettings?.IntegerType ?? IntegerType.Int32;
+        return integerType == IntegerType.Int64 ? "long" : "int";
+    }
+
+    private static string GetArrayType(JsonSchema arraySchema, RefitGeneratorSettings settings)
+    {
+        if (arraySchema.Item != null)
+        {
+            var itemType = GetCSharpType(arraySchema.Item, settings);
+            return $"{itemType}[]";
+        }
+        return "object[]";
+    }
+
+    private static string FindSupportedType(string typeName)
+    {
+        if (typeName is "FileResponse" or "FileParameter")
+            return "StreamPart";
+
+        if (typeName.Contains("FileParameter") || typeName.Contains("FileResponse"))
+        {
+            return typeName
+                .Replace("FileParameter", "StreamPart")
+                .Replace("FileResponse", "StreamPart");
+        }
+
+        return typeName;
+    }
+}

--- a/src/Refitter.Core/ParameterExtractors/HeaderParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractors/HeaderParameterExtractor.cs
@@ -1,0 +1,129 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration.Models;
+using Refitter.Core;
+using System.Text;
+
+namespace Refitter.Core;
+
+internal sealed class HeaderParameterExtractor : IParameterTypeExtractor
+{
+    private readonly RefitGeneratorSettings _settings;
+
+    public HeaderParameterExtractor(RefitGeneratorSettings settings)
+    {
+        _settings = settings;
+    }
+
+    public bool CanExtract(OpenApiParameterKind kind) => kind == OpenApiParameterKind.Header;
+
+    public IEnumerable<string> Extract(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings)
+    {
+        var headerParameters = new List<string>();
+
+        if (_settings.GenerateOperationHeaders)
+        {
+            var ignoredHeaders = _settings.IgnoredOperationHeaders
+                .Select(h => h.Trim())
+                .Where(h => !string.IsNullOrEmpty(h))
+                .ToArray();
+
+            var anyIgnoredHeaders = ignoredHeaders.Any();
+
+            var parameters = operationModel.Parameters
+                .Where(p => p.Kind == OpenApiParameterKind.Header && p.IsHeader)
+                .Where(p => !anyIgnoredHeaders || !ignoredHeaders.Contains(p.Name, StringComparer.OrdinalIgnoreCase))
+                .Select(p =>
+                {
+                    var variableName = GetVariableName(p);
+                    return $"{JoinAttributes($"Header(\"{p.Name}\")")}{GetParameterType(p, settings)} {variableName}";
+                })
+                .ToList();
+            headerParameters.AddRange(parameters);
+        }
+
+        if (_settings.AuthenticationHeaderStyle == AuthenticationHeaderStyle.Parameter)
+        {
+            var document = operation.Parent.Parent;
+            foreach (var securitySchemeName in operationModel.Security.SelectMany(x => x.Keys))
+            {
+                if ((_settings.SecurityScheme != null && securitySchemeName != _settings.SecurityScheme) ||
+                    !document.SecurityDefinitions.TryGetValue(securitySchemeName, out var securityScheme))
+                {
+                    continue;
+                }
+
+                if (securityScheme.Type == OpenApiSecuritySchemeType.ApiKey
+                    && securityScheme.In == OpenApiSecurityApiKeyLocation.Header
+                    && !operationModel.Parameters.Any(p => p.Kind == OpenApiParameterKind.Header && p.IsHeader && p.Name == securityScheme.Name))
+                {
+                    headerParameters.Add($"[Header(\"{securityScheme.Name}\")] string {ReplaceUnsafeCharacters(securityScheme.Name)}");
+                }
+                else if (securityScheme is { Type: OpenApiSecuritySchemeType.Http }
+                    && string.Equals(securityScheme.Scheme, "bearer", StringComparison.OrdinalIgnoreCase))
+                {
+                    headerParameters.Add($@"[Header(""Authorization: Bearer"")] string bearerToken");
+                }
+            }
+        }
+
+        return headerParameters;
+    }
+
+    private static string ReplaceUnsafeCharacters(string unsafeText)
+    {
+        return IdentifierUtils.ToCompilableIdentifier(unsafeText);
+    }
+
+    private static string GetVariableName(ParameterModelBase parameterModel)
+    {
+        return IdentifierUtils.ToCompilableIdentifier(parameterModel.VariableName);
+    }
+
+    private static string JoinAttributes(params string[] attributes)
+    {
+        var filteredAttributes = attributes
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .ToList();
+
+        if (filteredAttributes.Count == 0)
+            return string.Empty;
+
+        return "[" + string.Join(", ", filteredAttributes) + "] ";
+    }
+
+    private static string GetParameterType(
+        ParameterModelBase parameterModel,
+        RefitGeneratorSettings settings)
+    {
+        var type = WellKnownNamespaces
+            .TrimImportedNamespaces(
+                FindSupportedType(
+                    parameterModel.Type));
+
+        if (settings.OptionalParameters &&
+            !type.EndsWith("?") &&
+            (parameterModel.IsNullable || parameterModel.IsOptional || !parameterModel.IsRequired))
+            type += "?";
+
+        return type;
+    }
+
+    private static string FindSupportedType(string typeName)
+    {
+        if (typeName is "FileResponse" or "FileParameter")
+            return "StreamPart";
+
+        if (typeName.Contains("FileParameter") || typeName.Contains("FileResponse"))
+        {
+            return typeName
+                .Replace("FileParameter", "StreamPart")
+                .Replace("FileResponse", "StreamPart");
+        }
+
+        return typeName;
+    }
+}

--- a/src/Refitter.Core/ParameterExtractors/IParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractors/IParameterExtractor.cs
@@ -1,0 +1,15 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration.Models;
+
+namespace Refitter.Core;
+
+internal interface IParameterExtractor
+{
+    IEnumerable<string> ExtractParameters(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings,
+        string dynamicQuerystringParameterType,
+        out string? dynamicQuerystringParameters);
+}

--- a/src/Refitter.Core/ParameterExtractors/IParameterTypeExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractors/IParameterTypeExtractor.cs
@@ -1,0 +1,16 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration.Models;
+using System.Text;
+
+namespace Refitter.Core;
+
+internal interface IParameterTypeExtractor
+{
+    bool CanExtract(OpenApiParameterKind kind);
+
+    IEnumerable<string> Extract(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings);
+}

--- a/src/Refitter.Core/ParameterExtractors/OptionalParameterReorderer.cs
+++ b/src/Refitter.Core/ParameterExtractors/OptionalParameterReorderer.cs
@@ -1,0 +1,128 @@
+using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration.Models;
+using Refitter.Core;
+using System.Text;
+
+namespace Refitter.Core;
+
+internal static class OptionalParameterReorderer
+{
+    public static IEnumerable<string> Reorder(
+        List<string> parameters,
+        RefitGeneratorSettings settings,
+        ICollection<CSharpParameterModel> parameterModels)
+    {
+        if (!settings.OptionalParameters || settings.ApizrSettings?.WithRequestOptions == true)
+            return parameters;
+
+        var nullablePattern = new System.Text.RegularExpressions.Regex(@"\?\s+@?\w+(\s*=\s*[^,]+)?$",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        parameters = parameters.OrderBy(c => nullablePattern.IsMatch(c)).ToList();
+        for (int index = 0; index < parameters.Count; index++)
+        {
+            if (nullablePattern.IsMatch(parameters[index]))
+            {
+                var parameterString = parameters[index];
+                var defaultValue = GetDefaultValueForParameter(parameterString, parameterModels);
+                parameters[index] = parameterString + " = " + defaultValue;
+            }
+        }
+
+        return parameters;
+    }
+
+    private static string GetDefaultValueForParameter(string parameterString, ICollection<CSharpParameterModel> parameterModels)
+    {
+        var parts = parameterString.Split([' '], StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+            return "default";
+
+        var variableName = parts[parts.Length - 1].TrimEnd(';', ',');
+
+        var parameterModel = parameterModels.FirstOrDefault(p => p.VariableName == variableName);
+        parameterModel ??= parameterModels.FirstOrDefault(p => GetVariableName(p) == variableName);
+        if (parameterModel?.Schema?.Default != null && !string.IsNullOrEmpty(parameterModel.Type))
+        {
+            return FormatDefaultValue(parameterModel.Schema.Default, parameterModel.Type);
+        }
+        return "default";
+    }
+
+    private static string GetVariableName(ParameterModelBase parameterModel)
+    {
+        return IdentifierUtils.ToCompilableIdentifier(parameterModel.VariableName);
+    }
+
+    private static string FormatDefaultValue(object? defaultValue, string parameterType)
+    {
+        if (defaultValue == null)
+            return "default";
+
+        var type = parameterType.TrimEnd('?').Trim();
+
+        return type switch
+        {
+            "bool" => defaultValue.ToString()?.ToLowerInvariant() ?? "default",
+            "string" => $"\"{EscapeString(defaultValue.ToString() ?? string.Empty)}\"",
+            _ when IsNumericType(type) => FormatNumericValue(defaultValue, type),
+            _ => "default"
+        };
+    }
+
+    private static string EscapeString(string value)
+    {
+        var sb = new StringBuilder(value.Length + 10);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\v': sb.Append("\\v"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\0': sb.Append("\\0"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string FormatNumericValue(object defaultValue, string type)
+    {
+        var numericString = defaultValue is IFormattable formattable
+            ? formattable.ToString(null, System.Globalization.CultureInfo.InvariantCulture)
+            : (defaultValue.ToString() ?? "default");
+
+        return type switch
+        {
+            "float" or "Single" => $"{numericString}f",
+            "decimal" or "Decimal" => $"{numericString}m",
+            "double" or "Double" => FormatDoubleLiteral(numericString),
+            "long" or "Int64" => $"{numericString}L",
+            "ulong" or "UInt64" => $"{numericString}UL",
+            "uint" or "UInt32" => $"{numericString}U",
+            _ => numericString
+        };
+    }
+
+    private static string FormatDoubleLiteral(string numericString)
+    {
+        if (numericString.Contains('.') || numericString.Contains('e') || numericString.Contains('E'))
+            return numericString;
+
+        return numericString + ".0";
+    }
+
+    private static bool IsNumericType(string type)
+    {
+        return type is "int" or "Int32" or "long" or "Int64" or "short" or "Int16"
+            or "byte" or "Byte" or "decimal" or "Decimal" or "float" or "Single"
+            or "double" or "Double" or "sbyte" or "SByte" or "uint" or "UInt32"
+            or "ulong" or "UInt64" or "ushort" or "UInt16";
+    }
+}

--- a/src/Refitter.Core/ParameterExtractors/ParameterAggregator.cs
+++ b/src/Refitter.Core/ParameterExtractors/ParameterAggregator.cs
@@ -1,0 +1,358 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration.Models;
+using Refitter.Core;
+using System.Text;
+
+namespace Refitter.Core;
+
+internal sealed class ParameterAggregator : IParameterExtractor
+{
+    private readonly List<IParameterTypeExtractor> _extractors;
+    private readonly RefitGeneratorSettings _settings;
+
+    public ParameterAggregator(RefitGeneratorSettings settings)
+    {
+        _settings = settings;
+        _extractors = new List<IParameterTypeExtractor>
+        {
+            new RouteParameterExtractor(),
+            new QueryParameterExtractor(),
+            new BodyParameterExtractor(),
+            new HeaderParameterExtractor(settings),
+            new FormParameterExtractor()
+        };
+    }
+
+    public IEnumerable<string> ExtractParameters(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings,
+        string dynamicQuerystringParameterType,
+        out string? dynamicQuerystringParameters)
+    {
+        var parameters = new List<string>();
+
+        foreach (var extractor in _extractors)
+        {
+            var kind = GetKindForExtractor(extractor);
+            if (kind == null)
+                continue;
+
+            var hasParameters = operationModel.Parameters.Any(p => p.Kind == kind);
+            if (!hasParameters)
+                continue;
+
+            var extracted = extractor.Extract(operationModel, operation, settings);
+            parameters.AddRange(extracted);
+        }
+
+        // Extract dynamic querystring parameters code
+        var queryParameters = operationModel.Parameters
+            .Where(p => p.Kind == OpenApiParameterKind.Query)
+            .ToList();
+
+        dynamicQuerystringParameters = ExtractDynamicQuerystringCode(
+            operationModel,
+            settings,
+            dynamicQuerystringParameterType,
+            queryParameters);
+
+        // Reorder optional parameters
+        if (_settings.OptionalParameters || settings.OptionalParameters)
+        {
+            parameters = (List<string>)OptionalParameterReorderer.Reorder(
+                parameters,
+                _settings,
+                operationModel.Parameters);
+        }
+
+        // Add request options or cancellation token
+        if (_settings.ApizrSettings?.WithRequestOptions == true)
+            parameters.Add("[RequestOptions] IApizrRequestOptions options");
+        else if (_settings.UseCancellationTokens)
+            parameters.Add("CancellationToken cancellationToken = default");
+
+        return parameters;
+    }
+
+    private static OpenApiParameterKind? GetKindForExtractor(IParameterTypeExtractor extractor)
+    {
+        return extractor switch
+        {
+            RouteParameterExtractor => OpenApiParameterKind.Path,
+            QueryParameterExtractor => OpenApiParameterKind.Query,
+            BodyParameterExtractor => OpenApiParameterKind.Body,
+            HeaderParameterExtractor => OpenApiParameterKind.Header,
+            FormParameterExtractor => OpenApiParameterKind.FormData,
+            _ => null
+        };
+    }
+
+    private static string ExtractDynamicQuerystringCode(
+        CSharpOperationModel operationModel,
+        RefitGeneratorSettings settings,
+        string dynamicQuerystringParameterType,
+        IList<CSharpParameterModel> queryParameters)
+    {
+        if (!settings.UseDynamicQuerystringParameters || queryParameters.Count < 2)
+            return string.Empty;
+
+        var csharpQueryParameters = queryParameters.ToList();
+        var codeBuilder = new StringBuilder();
+        var result = DynamicQuerystringParameterBuilder.Build(
+            operationModel,
+            csharpQueryParameters,
+            settings,
+            dynamicQuerystringParameterType);
+
+        // Build the dynamic querystring class code
+        var modifier = settings.TypeAccessibility.ToString().ToLowerInvariant();
+        var isRecord = settings.ImmutableRecords ||
+                       settings.CodeGeneratorSettings?.GenerateNativeRecords is true;
+        var classStyle = isRecord ? "record" : "class";
+        var setterStyle = isRecord ? "init" : "set";
+
+        var injectedParametersCodeBuilder = new StringBuilder();
+        var initializedParametersCodeBuilder = new StringBuilder();
+        var propertiesCodeBuilder = new StringBuilder();
+        var allNullable = true;
+
+        foreach (var operationParameter in csharpQueryParameters)
+        {
+            var propertyType = GetQueryParameterType(operationParameter, settings);
+            allNullable = allNullable && propertyType.EndsWith("?");
+            var variableName = GetVariableName(operationParameter);
+            var attributes = $"{JoinAttributes(GetQueryAttribute(operationParameter, settings), GetAliasAsAttribute(operationParameter.Name, variableName))}";
+            var propertyName = variableName.CapitalizeFirstCharacter();
+
+            if (operationParameter.IsRequired)
+            {
+                injectedParametersCodeBuilder.Append(injectedParametersCodeBuilder.Length == 0
+                    ? $"{propertyType} {variableName}"
+                    : $", {propertyType} {variableName}");
+
+                initializedParametersCodeBuilder.AppendLine();
+                initializedParametersCodeBuilder.Append(
+                    $"        this.{propertyName} = {variableName};\n");
+            }
+
+            propertiesCodeBuilder.AppendLine();
+            if (settings.GenerateXmlDocCodeComments && !string.IsNullOrWhiteSpace(operationParameter.Description))
+            {
+                var escapedDescription = XmlDocumentationGenerator.SanitizeResponseDescription(operationParameter.Description);
+                AppendXmlDocComment(escapedDescription, propertiesCodeBuilder);
+            }
+
+            propertiesCodeBuilder.Append(
+                $"\n        {attributes}\n        {modifier} {propertyType} {propertyName} {{ get; {setterStyle}; }}");
+            var defaultValue = operationParameter.Schema?.Default;
+            if (defaultValue != null)
+            {
+                var formattedDefaultValue = FormatDefaultValue(defaultValue, propertyType);
+                propertiesCodeBuilder.Append($" = {formattedDefaultValue};");
+            }
+
+            propertiesCodeBuilder.AppendLine();
+        }
+
+        codeBuilder.AppendLine(
+            $"\n    {modifier} {classStyle} {dynamicQuerystringParameterType}");
+        codeBuilder.AppendLine("    {");
+
+        if (injectedParametersCodeBuilder.Length > 0)
+        {
+            codeBuilder.AppendLine(
+                $"\n        {modifier} {dynamicQuerystringParameterType}({injectedParametersCodeBuilder})");
+            codeBuilder.AppendLine("        {");
+            codeBuilder.Append(initializedParametersCodeBuilder);
+            codeBuilder.AppendLine("        }");
+        }
+
+        codeBuilder.Append(propertiesCodeBuilder);
+        codeBuilder.AppendLine("    }");
+
+        return codeBuilder.ToString();
+    }
+
+    private static string GetVariableName(ParameterModelBase parameterModel)
+    {
+        return IdentifierUtils.ToCompilableIdentifier(parameterModel.VariableName);
+    }
+
+    private static string GetQueryAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings)
+    {
+        return (parameter, settings) switch
+        {
+            { parameter.IsArray: true }
+                => $"Query(CollectionFormat.{settings.CollectionFormat})",
+            { parameter.IsDate: true, settings.UseIsoDateFormat: true }
+                => "Query(Format = \"yyyy-MM-dd\")",
+            { parameter.IsDate: true, settings.CodeGeneratorSettings.DateFormat: not null }
+                => $"Query(Format = \"{settings.CodeGeneratorSettings!.DateFormat}\")",
+            {
+                parameter.IsDateOrDateTime: true, parameter.Schema.Format: "date-time",
+                settings.CodeGeneratorSettings.DateTimeFormat: not null
+            } => $"Query(Format = \"{settings.CodeGeneratorSettings!.DateTimeFormat}\")",
+            _ => "Query",
+        };
+    }
+
+    private static string GetAliasAsAttribute(string originalName, string variableName)
+    {
+        return string.Equals(originalName, variableName, StringComparison.Ordinal)
+            ? string.Empty
+            : $"AliasAs(\"{EscapeString(originalName)}\")";
+    }
+
+    private static string EscapeString(string value)
+    {
+        var sb = new StringBuilder(value.Length + 10);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\v': sb.Append("\\v"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\0': sb.Append("\\0"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string JoinAttributes(params string[] attributes)
+    {
+        var filteredAttributes = attributes
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .ToList();
+
+        if (filteredAttributes.Count == 0)
+            return string.Empty;
+
+        return "[" + string.Join(", ", filteredAttributes) + "] ";
+    }
+
+    private static string GetQueryParameterType(
+        ParameterModelBase parameterModel,
+        RefitGeneratorSettings settings)
+    {
+        var type = GetParameterType(parameterModel, settings);
+
+        if (parameterModel.IsQuery &&
+            parameterModel.Type.Equals("object", StringComparison.OrdinalIgnoreCase))
+            type = "string";
+
+        return type;
+    }
+
+    private static string GetParameterType(
+        ParameterModelBase parameterModel,
+        RefitGeneratorSettings settings)
+    {
+        var type = WellKnownNamespaces
+            .TrimImportedNamespaces(
+                FindSupportedType(
+                    parameterModel.Type));
+
+        if (settings.OptionalParameters &&
+            !type.EndsWith("?") &&
+            (parameterModel.IsNullable || parameterModel.IsOptional || !parameterModel.IsRequired))
+            type += "?";
+
+        return type;
+    }
+
+    private static string FindSupportedType(string typeName)
+    {
+        if (typeName is "FileResponse" or "FileParameter")
+            return "StreamPart";
+
+        if (typeName.Contains("FileParameter") || typeName.Contains("FileResponse"))
+        {
+            return typeName
+                .Replace("FileParameter", "StreamPart")
+                .Replace("FileResponse", "StreamPart");
+        }
+
+        return typeName;
+    }
+
+    private static string FormatDefaultValue(object? defaultValue, string parameterType)
+    {
+        if (defaultValue == null)
+            return "default";
+
+        var type = parameterType.TrimEnd('?').Trim();
+
+        return type switch
+        {
+            "bool" => defaultValue.ToString()?.ToLowerInvariant() ?? "default",
+            "string" => $"\"{EscapeString(defaultValue.ToString() ?? string.Empty)}\"",
+            _ when IsNumericType(type) => FormatNumericValue(defaultValue, type),
+            _ => "default"
+        };
+    }
+
+    private static string FormatNumericValue(object defaultValue, string type)
+    {
+        var numericString = defaultValue is IFormattable formattable
+            ? formattable.ToString(null, System.Globalization.CultureInfo.InvariantCulture)
+            : (defaultValue.ToString() ?? "default");
+
+        return type switch
+        {
+            "float" or "Single" => $"{numericString}f",
+            "decimal" or "Decimal" => $"{numericString}m",
+            "double" or "Double" => FormatDoubleLiteral(numericString),
+            "long" or "Int64" => $"{numericString}L",
+            "ulong" or "UInt64" => $"{numericString}UL",
+            "uint" or "UInt32" => $"{numericString}U",
+            _ => numericString
+        };
+    }
+
+    private static string FormatDoubleLiteral(string numericString)
+    {
+        if (numericString.Contains('.') || numericString.Contains('e') || numericString.Contains('E'))
+            return numericString;
+
+        return numericString + ".0";
+    }
+
+    private static bool IsNumericType(string type)
+    {
+        return type is "int" or "Int32" or "long" or "Int64" or "short" or "Int16"
+            or "byte" or "Byte" or "decimal" or "Decimal" or "float" or "Single"
+            or "double" or "Double" or "sbyte" or "SByte" or "uint" or "UInt32"
+            or "ulong" or "UInt64" or "ushort" or "UInt16";
+    }
+
+    private static void AppendXmlDocComment(string description, StringBuilder codeBuilder)
+    {
+        codeBuilder.Append(
+            "\n        /// <summary>");
+
+        var lines = description.Split(
+            ["\r\n", "\r", "\n"],
+            StringSplitOptions.None);
+
+        foreach (var line in lines)
+        {
+            codeBuilder.AppendLine();
+            codeBuilder.Append(
+                $"        /// {line.Trim()}");
+        }
+
+        codeBuilder.AppendLine();
+        codeBuilder.Append(
+            "        /// </summary>");
+        codeBuilder.AppendLine();
+    }
+}

--- a/src/Refitter.Core/ParameterExtractors/QueryParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractors/QueryParameterExtractor.cs
@@ -1,0 +1,293 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration.Models;
+using Refitter.Core;
+using System.Text;
+
+namespace Refitter.Core;
+
+internal sealed class QueryParameterExtractor : IParameterTypeExtractor
+{
+    public bool CanExtract(OpenApiParameterKind kind) => kind == OpenApiParameterKind.Query;
+
+    public IEnumerable<string> Extract(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings)
+    {
+        var queryParameters = operationModel.Parameters
+            .Where(p => p.Kind == OpenApiParameterKind.Query)
+            .ToList();
+
+        if (settings.UseDynamicQuerystringParameters && queryParameters.Count >= 2)
+        {
+            var modifier = settings.TypeAccessibility.ToString().ToLowerInvariant();
+            var isRecord = settings.ImmutableRecords ||
+                           settings.CodeGeneratorSettings?.GenerateNativeRecords is true;
+            var classStyle = isRecord
+                ? "record"
+                : "class";
+            var setterStyle = isRecord
+                ? "init"
+                : "set";
+
+            var injectedParametersCodeBuilder = new StringBuilder();
+            var initializedParametersCodeBuilder = new StringBuilder();
+            var propertiesCodeBuilder = new StringBuilder();
+            var allNullable = true;
+
+            foreach (var operationParameter in queryParameters)
+            {
+                var propertyType = GetQueryParameterType(operationParameter, settings);
+                allNullable = allNullable && propertyType.EndsWith("?");
+                var variableName = GetVariableName(operationParameter);
+                var attributes = $"{JoinAttributes(GetQueryAttribute(operationParameter, settings), GetAliasAsAttribute(operationParameter.Name, variableName))}";
+                var propertyName = variableName.CapitalizeFirstCharacter();
+
+                if (operationParameter.IsRequired)
+                {
+                    injectedParametersCodeBuilder.Append(injectedParametersCodeBuilder.Length == 0
+                        ? $"{propertyType} {variableName}"
+                        : $", {propertyType} {variableName}");
+
+                    initializedParametersCodeBuilder.AppendLine();
+                    initializedParametersCodeBuilder.Append(
+                        $"        this.{propertyName} = {variableName};\n");
+                }
+
+                propertiesCodeBuilder.AppendLine();
+                if (settings.GenerateXmlDocCodeComments && !string.IsNullOrWhiteSpace(operationParameter.Description))
+                {
+                    var escapedDescription = XmlDocumentationGenerator.SanitizeResponseDescription(operationParameter.Description);
+                    AppendXmlDocComment(escapedDescription, propertiesCodeBuilder);
+                }
+
+                propertiesCodeBuilder.Append(
+                    $"\n        {attributes}\n        {modifier} {propertyType} {propertyName} {{ get; {setterStyle}; }}");
+                var defaultValue = operationParameter.Schema?.Default;
+                if (defaultValue != null)
+                {
+                    var formattedDefaultValue = FormatDefaultValue(defaultValue, propertyType);
+                    propertiesCodeBuilder.Append($" = {formattedDefaultValue};");
+                }
+
+                propertiesCodeBuilder.AppendLine();
+            }
+
+            var dynamicQuerystringParameterType = $"QueryParamsFor{queryParameters.Count}";
+
+            var codeBuilder = new StringBuilder();
+            codeBuilder.AppendLine(
+                $"\n    {modifier} {classStyle} {dynamicQuerystringParameterType}");
+            codeBuilder.AppendLine("    {");
+
+            if (injectedParametersCodeBuilder.Length > 0)
+            {
+                codeBuilder.AppendLine(
+                    $"\n        {modifier} {dynamicQuerystringParameterType}({injectedParametersCodeBuilder})");
+                codeBuilder.AppendLine("        {");
+                codeBuilder.Append(initializedParametersCodeBuilder);
+                codeBuilder.AppendLine("        }");
+            }
+
+            codeBuilder.Append(propertiesCodeBuilder);
+            codeBuilder.AppendLine("    }");
+
+            var dynamicQuerystringParameter = $"[Query] {dynamicQuerystringParameterType}";
+            if (allNullable)
+                dynamicQuerystringParameter += "?";
+            dynamicQuerystringParameter += " queryParams";
+
+            return [dynamicQuerystringParameter];
+        }
+
+        return queryParameters
+            .Select(p =>
+            {
+                var variableName = GetVariableName(p);
+                return $"{JoinAttributes(GetQueryAttribute(p, settings), GetAliasAsAttribute(p.Name, variableName))}{GetQueryParameterType(p, settings)} {variableName}";
+            })
+            .ToList();
+    }
+
+    private static string GetVariableName(ParameterModelBase parameterModel)
+    {
+        return IdentifierUtils.ToCompilableIdentifier(parameterModel.VariableName);
+    }
+
+    private static string GetAliasAsAttribute(string originalName, string variableName)
+    {
+        return string.Equals(originalName, variableName, StringComparison.Ordinal)
+            ? string.Empty
+            : $"AliasAs(\"{EscapeString(originalName)}\")";
+    }
+
+    private static string EscapeString(string value)
+    {
+        var sb = new StringBuilder(value.Length + 10);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\v': sb.Append("\\v"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\0': sb.Append("\\0"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string JoinAttributes(params string[] attributes)
+    {
+        var filteredAttributes = attributes
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .ToList();
+
+        if (filteredAttributes.Count == 0)
+            return string.Empty;
+
+        return "[" + string.Join(", ", filteredAttributes) + "] ";
+    }
+
+    private static string GetQueryAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings)
+    {
+        return (parameter, settings) switch
+        {
+            { parameter.IsArray: true }
+                => $"Query(CollectionFormat.{settings.CollectionFormat})",
+            { parameter.IsDate: true, settings.UseIsoDateFormat: true }
+                => "Query(Format = \"yyyy-MM-dd\")",
+            { parameter.IsDate: true, settings.CodeGeneratorSettings.DateFormat: not null }
+                => $"Query(Format = \"{settings.CodeGeneratorSettings!.DateFormat}\")",
+            {
+                parameter.IsDateOrDateTime: true, parameter.Schema.Format: "date-time",
+                settings.CodeGeneratorSettings.DateTimeFormat: not null
+            } => $"Query(Format = \"{settings.CodeGeneratorSettings!.DateTimeFormat}\")",
+            _ => "Query",
+        };
+    }
+
+    private static string GetQueryParameterType(
+        ParameterModelBase parameterModel,
+        RefitGeneratorSettings settings)
+    {
+        var type = GetParameterType(parameterModel, settings);
+
+        if (parameterModel.IsQuery &&
+            parameterModel.Type.Equals("object", StringComparison.OrdinalIgnoreCase))
+            type = "string";
+
+        return type;
+    }
+
+    private static string GetParameterType(
+        ParameterModelBase parameterModel,
+        RefitGeneratorSettings settings)
+    {
+        var type = WellKnownNamespaces
+            .TrimImportedNamespaces(
+                FindSupportedType(
+                    parameterModel.Type));
+
+        if (settings.OptionalParameters &&
+            !type.EndsWith("?") &&
+            (parameterModel.IsNullable || parameterModel.IsOptional || !parameterModel.IsRequired))
+            type += "?";
+
+        return type;
+    }
+
+    private static string FindSupportedType(string typeName)
+    {
+        if (typeName is "FileResponse" or "FileParameter")
+            return "StreamPart";
+
+        if (typeName.Contains("FileParameter") || typeName.Contains("FileResponse"))
+        {
+            return typeName
+                .Replace("FileParameter", "StreamPart")
+                .Replace("FileResponse", "StreamPart");
+        }
+
+        return typeName;
+    }
+
+    private static string FormatDefaultValue(object? defaultValue, string parameterType)
+    {
+        if (defaultValue == null)
+            return "default";
+
+        var type = parameterType.TrimEnd('?').Trim();
+
+        return type switch
+        {
+            "bool" => defaultValue.ToString()?.ToLowerInvariant() ?? "default",
+            "string" => $"\"{EscapeString(defaultValue.ToString() ?? string.Empty)}\"",
+            _ when IsNumericType(type) => FormatNumericValue(defaultValue, type),
+            _ => "default"
+        };
+    }
+
+    private static string FormatNumericValue(object defaultValue, string type)
+    {
+        var numericString = defaultValue is IFormattable formattable
+            ? formattable.ToString(null, System.Globalization.CultureInfo.InvariantCulture)
+            : (defaultValue.ToString() ?? "default");
+
+        return type switch
+        {
+            "float" or "Single" => $"{numericString}f",
+            "decimal" or "Decimal" => $"{numericString}m",
+            "double" or "Double" => FormatDoubleLiteral(numericString),
+            "long" or "Int64" => $"{numericString}L",
+            "ulong" or "UInt64" => $"{numericString}UL",
+            "uint" or "UInt32" => $"{numericString}U",
+            _ => numericString
+        };
+    }
+
+    private static string FormatDoubleLiteral(string numericString)
+    {
+        if (numericString.Contains('.') || numericString.Contains('e') || numericString.Contains('E'))
+            return numericString;
+
+        return numericString + ".0";
+    }
+
+    private static bool IsNumericType(string type)
+    {
+        return type is "int" or "Int32" or "long" or "Int64" or "short" or "Int16"
+            or "byte" or "Byte" or "decimal" or "Decimal" or "float" or "Single"
+            or "double" or "Double" or "sbyte" or "SByte" or "uint" or "UInt32"
+            or "ulong" or "UInt64" or "ushort" or "UInt16";
+    }
+
+    private static void AppendXmlDocComment(string description, StringBuilder codeBuilder)
+    {
+        codeBuilder.Append(
+            "\n        /// <summary>");
+
+        var lines = description.Split(
+            ["\r\n", "\r", "\n"],
+            StringSplitOptions.None);
+
+        foreach (var line in lines)
+        {
+            codeBuilder.AppendLine();
+            codeBuilder.Append(
+                $"        /// {line.Trim()}");
+        }
+
+        codeBuilder.AppendLine();
+        codeBuilder.Append(
+            "        /// </summary>");
+        codeBuilder.AppendLine();
+    }
+}

--- a/src/Refitter.Core/ParameterExtractors/RouteParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractors/RouteParameterExtractor.cs
@@ -1,0 +1,73 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration.Models;
+using Refitter.Core;
+using System.Text;
+
+namespace Refitter.Core;
+
+internal sealed class RouteParameterExtractor : IParameterTypeExtractor
+{
+    public bool CanExtract(OpenApiParameterKind kind) => kind == OpenApiParameterKind.Path;
+
+    public IEnumerable<string> Extract(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings)
+    {
+        return operationModel.Parameters
+            .Where(p => p.Kind == OpenApiParameterKind.Path)
+            .Select(p =>
+            {
+                var variableName = GetVariableName(p);
+                return $"{JoinAttributes(GetAliasAsAttribute(p.Name, variableName))}{p.Type} {variableName}";
+            })
+            .ToList();
+    }
+
+    private static string GetVariableName(ParameterModelBase parameterModel)
+    {
+        return IdentifierUtils.ToCompilableIdentifier(parameterModel.VariableName);
+    }
+
+    private static string GetAliasAsAttribute(string originalName, string variableName)
+    {
+        return string.Equals(originalName, variableName, StringComparison.Ordinal)
+            ? string.Empty
+            : $"AliasAs(\"{EscapeString(originalName)}\")";
+    }
+
+    private static string EscapeString(string value)
+    {
+        var sb = new StringBuilder(value.Length + 10);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\v': sb.Append("\\v"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\0': sb.Append("\\0"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string JoinAttributes(params string[] attributes)
+    {
+        var filteredAttributes = attributes
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .ToList();
+
+        if (filteredAttributes.Count == 0)
+            return string.Empty;
+
+        return "[" + string.Join(", ", filteredAttributes) + "] ";
+    }
+}

--- a/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
+++ b/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
@@ -26,6 +26,7 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(AssemblyName).props" Pack="true" PackagePath="build" />
     <Compile Include="../Refitter.Core/*.cs" />
+    <Compile Include="../Refitter.Core/ParameterExtractors/*.cs" />
     <Compile Include="../Refitter.Core/Settings/*.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Part of the architecture deepening initiative

This PR splits the 622-line ParameterExtractor into focused, single-responsibility modules as described in [issue #1115](https://github.com/christianhelle/refitter/issues/1115).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dynamic querystring parameter wrapping for more intuitive handling of multiple query parameters in API method generation.

* **Refactor**
  * Restructured the parameter extraction pipeline to provide more robust handling of route, query, body, header, and form parameters across all generated API client methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->