### PR TITLE
Refactor ParameterExtractor by splitting into parameter-type extractors

### DIFF
--- a/src/Refitter.Core/BodyParameterExtractor.cs
+++ b/src/Refitter.Core/BodyParameterExtractor.cs
@@ -1,0 +1,43 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+
+namespace Refitter.Core;
+
+internal class BodyParameterExtractor : IParameterTypeExtractor
+{
+    public bool CanExtract(OpenApiParameterKind kind) =>
+        kind == OpenApiParameterKind.Body;
+
+    public IEnumerable<string> Extract(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings)
+    {
+        var bodyParameters = operationModel.Parameters
+            .Where(p => p.Kind == OpenApiParameterKind.Body && !p.IsBinaryBodyParameter)
+            .Select(p =>
+            {
+                var variableName = ParameterShared.GetVariableName(p);
+                return $"{ParameterShared.JoinAttributes(ParameterShared.GetBodyAttribute(p, settings), ParameterShared.GetAliasAsAttribute(p.Name, variableName))}{ParameterShared.GetParameterType(p, settings)} {variableName}";
+            })
+            .ToList();
+
+        var binaryBodyParameters = operationModel.Parameters
+            .Where(p => p.Kind == OpenApiParameterKind.Body && p.IsBinaryBodyParameter)
+            .Select(p =>
+            {
+                var variableName = ParameterShared.GetVariableName(p);
+                var aliasAsAttribute = ParameterShared.GetAliasAsAttribute(p.Name, variableName);
+                var generatedAliasAsAttribute = string.IsNullOrWhiteSpace(aliasAsAttribute)
+                    ? string.Empty
+                    : $"[{aliasAsAttribute}]";
+
+                return $"{generatedAliasAsAttribute}StreamPart {variableName}";
+            })
+            .ToList();
+
+        return bodyParameters
+            .Concat(binaryBodyParameters)
+            .ToList();
+    }
+}

--- a/src/Refitter.Core/DynamicQuerystringParameterBuilder.cs
+++ b/src/Refitter.Core/DynamicQuerystringParameterBuilder.cs
@@ -1,0 +1,95 @@
+using System.Text;
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+
+namespace Refitter.Core;
+
+internal static class DynamicQuerystringParameterBuilder
+{
+    public static string Build(
+        List<CSharpParameterModel> queryParameters,
+        string dynamicQuerystringParameterType,
+        RefitGeneratorSettings settings)
+    {
+        var codeBuilder = new StringBuilder();
+        var modifier = settings.TypeAccessibility.ToString().ToLowerInvariant();
+        var isRecord = settings.ImmutableRecords ||
+                       settings.CodeGeneratorSettings?.GenerateNativeRecords is true;
+        var classStyle = isRecord
+            ? "record"
+            : "class";
+        var setterStyle = isRecord
+            ? "init"
+            : "set";
+
+        var injectedParametersCodeBuilder = new StringBuilder();
+        var initializedParametersCodeBuilder = new StringBuilder();
+        var propertiesCodeBuilder = new StringBuilder();
+
+        foreach (var operationParameter in queryParameters)
+        {
+            var propertyType = ParameterShared.GetQueryParameterType(operationParameter, settings);
+            var variableName = ParameterShared.GetVariableName(operationParameter);
+            var attributes = $"{ParameterShared.JoinAttributes(ParameterShared.GetQueryAttribute(operationParameter, settings), ParameterShared.GetAliasAsAttribute(operationParameter.Name, variableName))}";
+            var propertyName = variableName.CapitalizeFirstCharacter();
+            if (operationParameter.IsRequired)
+            {
+                injectedParametersCodeBuilder.Append(injectedParametersCodeBuilder.Length == 0
+                    ? $$"""{{propertyType}} {{variableName}}"""
+                    : $$""", {{propertyType}} {{variableName}}""");
+
+                initializedParametersCodeBuilder.AppendLine();
+                initializedParametersCodeBuilder.Append(
+    $$"""
+                    this.{{propertyName}} = {{variableName}};
+        """);
+            }
+
+            propertiesCodeBuilder.AppendLine();
+            if (settings.GenerateXmlDocCodeComments && !string.IsNullOrWhiteSpace(operationParameter.Description))
+            {
+                var escapedDescription = XmlDocumentationGenerator.SanitizeResponseDescription(operationParameter.Description);
+                ParameterShared.AppendXmlDocComment(escapedDescription, propertiesCodeBuilder);
+            }
+
+            propertiesCodeBuilder.Append(
+    $$"""
+                {{attributes}}
+                {{modifier}} {{propertyType}} {{propertyName}} { get; {{setterStyle}}; }
+        """);
+            var defaultValue = operationParameter.Schema.Default;
+            if (defaultValue != null)
+            {
+                var formattedDefaultValue = ParameterShared.FormatDefaultValue(defaultValue, propertyType);
+                propertiesCodeBuilder.Append($" = {formattedDefaultValue};");
+            }
+
+            propertiesCodeBuilder.AppendLine();
+        }
+
+        codeBuilder.AppendLine(
+    $$"""
+            {{modifier}} {{classStyle}} {{dynamicQuerystringParameterType}}
+            {
+        """);
+
+        if (injectedParametersCodeBuilder.Length > 0)
+        {
+            codeBuilder.AppendLine(
+    $$"""
+                {{modifier}} {{dynamicQuerystringParameterType}}({{injectedParametersCodeBuilder}})
+                {
+                    {{initializedParametersCodeBuilder}}
+                }
+        """);
+        }
+
+        codeBuilder.AppendLine(
+    $$"""
+                {{propertiesCodeBuilder}}
+            }
+        """);
+
+        return codeBuilder.ToString();
+    }
+}

--- a/src/Refitter.Core/FormParameterExtractor.cs
+++ b/src/Refitter.Core/FormParameterExtractor.cs
@@ -1,0 +1,62 @@
+using NJsonSchema;
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+
+namespace Refitter.Core;
+
+internal class FormParameterExtractor : IParameterTypeExtractor
+{
+    public bool CanExtract(OpenApiParameterKind kind) =>
+        kind == OpenApiParameterKind.FormData;
+
+    public IEnumerable<string> Extract(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings)
+    {
+        var seenFormParameterNames = new HashSet<string>(StringComparer.Ordinal);
+        var formParameters = new List<string>();
+
+        foreach (var p in operationModel.Parameters.Where(p => p.Kind == OpenApiParameterKind.FormData && !p.IsBinaryBodyParameter))
+        {
+            var variableName = ParameterShared.ConvertToVariableName(p.VariableName);
+            if (seenFormParameterNames.Add(variableName))
+            {
+                formParameters.Add($"{ParameterShared.JoinAttributes(ParameterShared.GetAliasAsAttribute(p.Name, variableName))}{ParameterShared.GetParameterType(p, settings)} {variableName}");
+            }
+        }
+
+        if (operation.RequestBody?.Content?.TryGetValue("multipart/form-data", out var multipartContent) == true)
+        {
+            var schema = multipartContent.Schema;
+            if (schema?.Properties != null)
+            {
+                foreach (var property in schema.Properties)
+                {
+                    var propertySchema = property.Value;
+
+                    var isBinary = (propertySchema.Type == JsonObjectType.String &&
+                                   propertySchema.Format == "binary") ||
+                                  (propertySchema.Type == JsonObjectType.Array &&
+                                   propertySchema.Item?.Type == JsonObjectType.String &&
+                                   propertySchema.Item?.Format == "binary");
+
+                    if (!isBinary)
+                    {
+                        var propertyType = ParameterShared.GetCSharpType(propertySchema, settings);
+                        var variableName = ParameterShared.ConvertToVariableName(property.Key);
+
+                        if (seenFormParameterNames.Add(variableName))
+                        {
+                            var aliasAttribute = ParameterShared.GetAliasAsAttribute(property.Key, variableName);
+                            var parameter = $"{ParameterShared.JoinAttributes(aliasAttribute)}{propertyType} {variableName}";
+                            formParameters.Add(parameter);
+                        }
+                    }
+                }
+            }
+        }
+
+        return formParameters;
+    }
+}

--- a/src/Refitter.Core/HeaderParameterExtractor.cs
+++ b/src/Refitter.Core/HeaderParameterExtractor.cs
@@ -1,0 +1,65 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+
+namespace Refitter.Core;
+
+internal class HeaderParameterExtractor : IParameterTypeExtractor
+{
+    public bool CanExtract(OpenApiParameterKind kind) =>
+        kind == OpenApiParameterKind.Header;
+
+    public IEnumerable<string> Extract(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings)
+    {
+        var headerParameters = new List<string>();
+
+        if (settings.GenerateOperationHeaders)
+        {
+            var ignoredHeaders = settings.IgnoredOperationHeaders
+                .Select(h => h.Trim())
+                .Where(h => !string.IsNullOrEmpty(h))
+                .ToArray();
+
+            var anyIgnoredHeaders = ignoredHeaders.Any();
+
+            headerParameters = operationModel.Parameters
+                .Where(p => p.Kind == OpenApiParameterKind.Header && p.IsHeader)
+                .Where(p => !anyIgnoredHeaders || !ignoredHeaders.Contains(p.Name, StringComparer.OrdinalIgnoreCase))
+                .Select(p =>
+                {
+                    var variableName = ParameterShared.GetVariableName(p);
+                    return $"{ParameterShared.JoinAttributes($"Header(\"{p.Name}\")")}{ParameterShared.GetParameterType(p, settings)} {variableName}";
+                })
+                .ToList();
+        }
+
+        if (settings.AuthenticationHeaderStyle == AuthenticationHeaderStyle.Parameter)
+        {
+            var document = operation.Parent.Parent;
+            foreach (var securitySchemeName in operationModel.Security.SelectMany(x => x.Keys))
+            {
+                if ((settings.SecurityScheme != null && securitySchemeName != settings.SecurityScheme) ||
+                    !document.SecurityDefinitions.TryGetValue(securitySchemeName, out var securityScheme))
+                {
+                    continue;
+                }
+
+                if (securityScheme.Type == OpenApiSecuritySchemeType.ApiKey
+                    && securityScheme.In == OpenApiSecurityApiKeyLocation.Header
+                    && !operationModel.Parameters.Any(p => p.Kind == OpenApiParameterKind.Header && p.IsHeader && p.Name == securityScheme.Name))
+                {
+                    headerParameters.Add($"[Header(\"{securityScheme.Name}\")] string {ParameterShared.ReplaceUnsafeCharacters(securityScheme.Name)}");
+                }
+                else if (securityScheme is { Type: OpenApiSecuritySchemeType.Http }
+                    && string.Equals(securityScheme.Scheme, "bearer", StringComparison.OrdinalIgnoreCase))
+                {
+                    headerParameters.Add(@"[Header(""Authorization: Bearer"")] string bearerToken");
+                }
+            }
+        }
+
+        return headerParameters;
+    }
+}

--- a/src/Refitter.Core/IParameterExtractor.cs
+++ b/src/Refitter.Core/IParameterExtractor.cs
@@ -1,0 +1,14 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+
+namespace Refitter.Core;
+
+internal interface IParameterExtractor
+{
+    IEnumerable<string> ExtractParameters(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings,
+        string dynamicQuerystringParameterType,
+        out string? dynamicQuerystringParameters);
+}

--- a/src/Refitter.Core/IParameterTypeExtractor.cs
+++ b/src/Refitter.Core/IParameterTypeExtractor.cs
@@ -1,0 +1,13 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+
+namespace Refitter.Core;
+
+internal interface IParameterTypeExtractor
+{
+    bool CanExtract(OpenApiParameterKind kind);
+    IEnumerable<string> Extract(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings);
+}

--- a/src/Refitter.Core/InterfaceGenerator.cs
+++ b/src/Refitter.Core/InterfaceGenerator.cs
@@ -15,17 +15,20 @@ internal class InterfaceGenerator
     private readonly OpenApiDocument document;
     private readonly CustomCSharpClientGenerator generator;
     private readonly XmlDocumentationGenerator docGenerator;
+    private readonly IParameterExtractor parameterExtractor;
 
     internal InterfaceGenerator(
         RefitGeneratorSettings settings,
         OpenApiDocument document,
         CustomCSharpClientGenerator generator,
-        XmlDocumentationGenerator docGenerator)
+        XmlDocumentationGenerator docGenerator,
+        IParameterExtractor? parameterExtractor = null)
     {
         this.settings = settings;
         this.document = document;
         this.generator = generator;
         this.docGenerator = docGenerator;
+        this.parameterExtractor = parameterExtractor ?? new ParameterAggregator();
         generator.BaseSettings.OperationNameGenerator = new OperationNameGenerator(document, settings);
     }
 
@@ -164,7 +167,7 @@ internal class InterfaceGenerator
 
         var dynamicQuerystringParameterType = partitioning.GetDynamicQuerystringParameterType(interfaceName, methodName);
         var operationModel = generator.CreateOperationModel(operation);
-        var parameters = ParameterExtractor.GetParameters(operationModel, operation, settings, dynamicQuerystringParameterType, out var operationDynamicQuerystringParameters).ToList();
+        var parameters = parameterExtractor.ExtractParameters(operationModel, operation, settings, dynamicQuerystringParameterType, out var operationDynamicQuerystringParameters).ToList();
 
         var hasDynamicQuerystringParameter = !string.IsNullOrWhiteSpace(operationDynamicQuerystringParameters);
         var parametersString = string.Join(", ", parameters);

--- a/src/Refitter.Core/OptionalParameterReorderer.cs
+++ b/src/Refitter.Core/OptionalParameterReorderer.cs
@@ -1,0 +1,33 @@
+using System.Text.RegularExpressions;
+using NSwag.CodeGeneration.CSharp.Models;
+
+namespace Refitter.Core;
+
+internal static class OptionalParameterReorderer
+{
+    private static readonly Regex NullablePattern = new(
+        @"\?\s+@?\w+(\s*=\s*[^,]+)?$",
+        RegexOptions.Compiled);
+
+    public static List<string> Reorder(
+        List<string> parameters,
+        RefitGeneratorSettings settings,
+        ICollection<CSharpParameterModel> parameterModels)
+    {
+        if (!settings.OptionalParameters || settings.ApizrSettings?.WithRequestOptions == true)
+            return parameters;
+
+        parameters = parameters.OrderBy(c => NullablePattern.IsMatch(c)).ToList();
+        for (int index = 0; index < parameters.Count; index++)
+        {
+            if (NullablePattern.IsMatch(parameters[index]))
+            {
+                var parameterString = parameters[index];
+                var defaultValue = ParameterShared.GetDefaultValueForParameter(parameterString, parameterModels);
+                parameters[index] = parameterString + " = " + defaultValue;
+            }
+        }
+
+        return parameters;
+    }
+}

--- a/src/Refitter.Core/ParameterAggregator.cs
+++ b/src/Refitter.Core/ParameterAggregator.cs
@@ -1,0 +1,120 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+
+namespace Refitter.Core;
+
+internal class ParameterAggregator : IParameterExtractor
+{
+    private readonly IReadOnlyList<IParameterTypeExtractor> extractors;
+
+    public ParameterAggregator()
+        : this(GetDefaultExtractors())
+    {
+    }
+
+    public ParameterAggregator(IReadOnlyList<IParameterTypeExtractor> extractors)
+    {
+        this.extractors = extractors;
+    }
+
+    public IEnumerable<string> ExtractParameters(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings,
+        string dynamicQuerystringParameterType,
+        out string? dynamicQuerystringParameters)
+    {
+        var allParameters = new List<string>();
+
+        // Route parameters
+        allParameters.AddRange(GetExtractor<RouteParameterExtractor>().Extract(operationModel, operation, settings));
+
+        // Query parameters (with dynamic querystring support)
+        var queryParameters = operationModel.Parameters
+            .Where(p => p.Kind == OpenApiParameterKind.Query)
+            .ToList();
+
+        allParameters.AddRange(ExtractQueryParameters(
+            operationModel,
+            settings,
+            dynamicQuerystringParameterType,
+            queryParameters,
+            out dynamicQuerystringParameters));
+
+        // Body parameters (including binary body)
+        allParameters.AddRange(GetExtractor<BodyParameterExtractor>().Extract(operationModel, operation, settings));
+
+        // Header parameters
+        allParameters.AddRange(GetExtractor<HeaderParameterExtractor>().Extract(operationModel, operation, settings));
+
+        // Form parameters
+        allParameters.AddRange(GetExtractor<FormParameterExtractor>().Extract(operationModel, operation, settings));
+
+        allParameters = OptionalParameterReorderer.Reorder(
+            allParameters,
+            settings,
+            operationModel.Parameters);
+
+        if (settings.ApizrSettings?.WithRequestOptions == true)
+            allParameters.Add("[RequestOptions] IApizrRequestOptions options");
+        else if (settings.UseCancellationTokens)
+            allParameters.Add("CancellationToken cancellationToken = default");
+
+        return allParameters;
+    }
+
+    private IParameterTypeExtractor GetExtractor<T>() where T : IParameterTypeExtractor
+    {
+        return extractors.OfType<T>().First();
+    }
+
+    private static List<string> ExtractQueryParameters(
+        CSharpOperationModel operationModel,
+        RefitGeneratorSettings settings,
+        string dynamicQuerystringParameterType,
+        List<CSharpParameterModel> queryParameters,
+        out string? dynamicQuerystringParameters)
+    {
+        List<string>? parameters = null;
+        var dynamicQuerystringParametersCodeBuilder = string.Empty;
+
+        if (settings.UseDynamicQuerystringParameters && queryParameters.Count >= 2)
+        {
+            var allNullable = queryParameters.All(p =>
+                ParameterShared.GetQueryParameterType(p, settings).EndsWith("?"));
+
+            var dynamicQuerystringCode = DynamicQuerystringParameterBuilder.Build(
+                queryParameters,
+                dynamicQuerystringParameterType,
+                settings);
+
+            if (!string.IsNullOrWhiteSpace(dynamicQuerystringCode))
+            {
+                dynamicQuerystringParametersCodeBuilder = dynamicQuerystringCode;
+            }
+
+            var dynamicQuerystringParameter = $"[Query] {dynamicQuerystringParameterType}";
+            if (allNullable)
+                dynamicQuerystringParameter += "?";
+            dynamicQuerystringParameter += " queryParams";
+            parameters = [dynamicQuerystringParameter];
+        }
+
+        dynamicQuerystringParameters = dynamicQuerystringParametersCodeBuilder;
+
+        parameters ??= QueryParameterExtractor.ExtractSimple(operationModel, settings).ToList();
+
+        return parameters;
+    }
+
+    private static IReadOnlyList<IParameterTypeExtractor> GetDefaultExtractors()
+    {
+        return new IParameterTypeExtractor[]
+        {
+            new RouteParameterExtractor(),
+            new BodyParameterExtractor(),
+            new HeaderParameterExtractor(),
+            new FormParameterExtractor(),
+        };
+    }
+}

--- a/src/Refitter.Core/ParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtractor.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Text;
 using NJsonSchema;
 using NSwag;
@@ -10,6 +8,8 @@ namespace Refitter.Core;
 
 internal static class ParameterExtractor
 {
+    private static readonly ParameterAggregator Aggregator = new();
+
     public static IEnumerable<string> GetParameters(
         CSharpOperationModel operationModel,
         OpenApiOperation operation,
@@ -17,493 +17,105 @@ internal static class ParameterExtractor
         string dynamicQuerystringParameterType,
         out string? dynamicQuerystringParameters)
     {
-        var routeParameters = operationModel.Parameters
-            .Where(p => p.Kind == OpenApiParameterKind.Path)
-            .Select(p =>
-            {
-                var variableName = GetVariableName(p);
-                return $"{JoinAttributes(GetAliasAsAttribute(p.Name, variableName))}{p.Type} {variableName}";
-            })
-            .ToList();
-
-        var queryParameters =
-            GetQueryParameters(operationModel, settings, dynamicQuerystringParameterType, out dynamicQuerystringParameters);
-
-        var bodyParameters = operationModel.Parameters
-            .Where(p => p.Kind == OpenApiParameterKind.Body && !p.IsBinaryBodyParameter)
-            .Select(p =>
-            {
-                var variableName = GetVariableName(p);
-                return $"{JoinAttributes(GetBodyAttribute(p, settings), GetAliasAsAttribute(p.Name, variableName))}{GetParameterType(p, settings)} {variableName}";
-            })
-            .ToList();
-
-        var headerParameters = new List<string>();
-
-        if (settings.GenerateOperationHeaders)
-        {
-            var ignoredHeaders = settings.IgnoredOperationHeaders
-                .Select(h => h.Trim())
-                .Where(h => !string.IsNullOrEmpty(h))
-                .ToArray();
-
-            var anyIgnoredHeaders = ignoredHeaders.Any();
-
-            headerParameters = operationModel.Parameters
-                .Where(p => p.Kind == OpenApiParameterKind.Header && p.IsHeader)
-                .Where(p => !anyIgnoredHeaders || !ignoredHeaders.Contains(p.Name, StringComparer.OrdinalIgnoreCase))
-                .Select(p =>
-                {
-                    var variableName = GetVariableName(p);
-                    return $"{JoinAttributes($"Header(\"{p.Name}\")")}{GetParameterType(p, settings)} {variableName}";
-                })
-                .ToList();
-        }
-
-        if (settings.AuthenticationHeaderStyle == AuthenticationHeaderStyle.Parameter)
-        {
-            var document = operation.Parent.Parent;
-            foreach (var securitySchemeName in operationModel.Security.SelectMany(x => x.Keys))
-            {
-                if ((settings.SecurityScheme != null && securitySchemeName != settings.SecurityScheme) ||
-                    !document.SecurityDefinitions.TryGetValue(securitySchemeName, out var securityScheme))
-                {
-                    continue;
-                }
-
-                if (securityScheme.Type == OpenApiSecuritySchemeType.ApiKey
-                    && securityScheme.In == OpenApiSecurityApiKeyLocation.Header
-                    && !operationModel.Parameters.Any(p => p.Kind == OpenApiParameterKind.Header && p.IsHeader && p.Name == securityScheme.Name))
-                {
-                    headerParameters.Add($"[Header(\"{securityScheme.Name}\")] string {ReplaceUnsafeCharacters(securityScheme.Name)}");
-                }
-                else if (securityScheme is { Type: OpenApiSecuritySchemeType.Http }
-                    && string.Equals(securityScheme.Scheme, "bearer", StringComparison.OrdinalIgnoreCase))
-                {
-                    headerParameters.Add($@"[Header(""Authorization: Bearer"")] string bearerToken");
-                }
-            }
-        }
-
-        // Deduplicate form parameters by sanitized identifier (#1018)
-        // Use ConvertToVariableName for both paths to ensure consistent deduplication
-        var seenFormParameterNames = new HashSet<string>(StringComparer.Ordinal);
-        var formParameters = new List<string>();
-
-        foreach (var p in operationModel.Parameters.Where(p => p.Kind == OpenApiParameterKind.FormData && !p.IsBinaryBodyParameter))
-        {
-            // Use VariableName (NSwag's processed name) not Name (original OpenAPI name)
-            var variableName = ConvertToVariableName(p.VariableName);
-            // Only add if this sanitized identifier hasn't been seen
-            if (seenFormParameterNames.Add(variableName))
-            {
-                formParameters.Add($"{JoinAttributes(GetAliasAsAttribute(p.Name, variableName))}{GetParameterType(p, settings)} {variableName}");
-            }
-        }
-
-        // Manually extract non-binary properties from multipart/form-data in OpenAPI 3.x
-        // NSwag doesn't populate these in operationModel.Parameters
-        if (operation.RequestBody?.Content?.TryGetValue("multipart/form-data", out var multipartContent) == true)
-        {
-            var schema = multipartContent.Schema;
-            if (schema?.Properties != null)
-            {
-                foreach (var property in schema.Properties)
-                {
-                    var propertySchema = property.Value;
-
-                    // Skip binary fields (files) as they're already handled as StreamPart
-                    var isBinary = (propertySchema.Type == JsonObjectType.String &&
-                                   propertySchema.Format == "binary") ||
-                                  (propertySchema.Type == JsonObjectType.Array &&
-                                   propertySchema.Item?.Type == JsonObjectType.String &&
-                                   propertySchema.Item?.Format == "binary");
-
-                    if (!isBinary)
-                    {
-                        // Generate proper C# type for the property
-                        var propertyType = GetCSharpType(propertySchema, settings);
-                        var variableName = ConvertToVariableName(property.Key);
-
-                        // Deduplicate by sanitized C# identifier, not original OpenAPI name (#1018)
-                        // HashSet.Add returns true if item was added (first occurrence), false if already present
-                        if (seenFormParameterNames.Add(variableName))
-                        {
-                            // First occurrence of this sanitized identifier - add the parameter
-                            var aliasAttribute = GetAliasAsAttribute(property.Key, variableName);
-                            var parameter = $"{JoinAttributes(aliasAttribute)}{propertyType} {variableName}";
-                            formParameters.Add(parameter);
-                        }
-                        // else: duplicate sanitized identifier - skip this parameter
-                    }
-                }
-            }
-        }
-        var binaryBodyParameters = operationModel.Parameters
-            .Where(p => p.Kind == OpenApiParameterKind.Body && p.IsBinaryBodyParameter)
-            .Select(p =>
-            {
-                var variableName = GetVariableName(p);
-                var aliasAsAttribute = GetAliasAsAttribute(p.Name, variableName);
-                var generatedAliasAsAttribute = string.IsNullOrWhiteSpace(aliasAsAttribute)
-                    ? string.Empty
-                    : $"[{aliasAsAttribute}]";
-
-                return $"{generatedAliasAsAttribute}StreamPart {variableName}";
-            })
-            .ToList();
-
-        var parameters = new List<string>();
-        parameters.AddRange(routeParameters);
-        parameters.AddRange(queryParameters);
-        parameters.AddRange(bodyParameters);
-        parameters.AddRange(headerParameters);
-        parameters.AddRange(formParameters);
-        parameters.AddRange(binaryBodyParameters);
-
-        parameters = ReOrderNullableParameters(parameters, settings, operationModel.Parameters);
-
-        if (settings.ApizrSettings?.WithRequestOptions == true)
-            parameters.Add("[RequestOptions] IApizrRequestOptions options");
-        else if (settings.UseCancellationTokens)
-            parameters.Add("CancellationToken cancellationToken = default");
-
-        return parameters;
+        return Aggregator.ExtractParameters(
+            operationModel,
+            operation,
+            settings,
+            dynamicQuerystringParameterType,
+            out dynamicQuerystringParameters);
     }
 
-    private static string ReplaceUnsafeCharacters(
-        string unsafeText)
-    {
-        return IdentifierUtils.ToCompilableIdentifier(unsafeText);
-    }
+    // Reflection-based backward compatibility for ParameterExtractorPrivateCoverageTests
+
+    private static string ReplaceUnsafeCharacters(string unsafeText) =>
+        ParameterShared.ReplaceUnsafeCharacters(unsafeText);
 
     private static List<string> ReOrderNullableParameters(
         List<string> parameters,
         RefitGeneratorSettings settings,
-        ICollection<CSharpParameterModel> parameterModels)
-    {
-        if (!settings.OptionalParameters || settings.ApizrSettings?.WithRequestOptions == true)
-            return parameters;
+        ICollection<CSharpParameterModel> parameterModels) =>
+        OptionalParameterReorderer.Reorder(parameters, settings, parameterModels);
 
-        // Use regex to check for nullable type marker at the end of the type declaration
-        // Matches "?" followed by whitespace and parameter name (and optional default value)
-        var nullablePattern = new System.Text.RegularExpressions.Regex(@"\?\s+@?\w+(\s*=\s*[^,]+)?$",
-            System.Text.RegularExpressions.RegexOptions.Compiled);
+    private static string GetDefaultValueForParameter(
+        string parameterString,
+        ICollection<CSharpParameterModel> parameterModels) =>
+        ParameterShared.GetDefaultValueForParameter(parameterString, parameterModels);
 
-        parameters = parameters.OrderBy(c => nullablePattern.IsMatch(c)).ToList();
-        for (int index = 0; index < parameters.Count; index++)
-        {
-            if (nullablePattern.IsMatch(parameters[index]))
-            {
-                var parameterString = parameters[index];
-                var defaultValue = GetDefaultValueForParameter(parameterString, parameterModels);
-                parameters[index] = parameterString + " = " + defaultValue;
-            }
-        }
+    private static string FormatDefaultValue(object? defaultValue, string parameterType) =>
+        ParameterShared.FormatDefaultValue(defaultValue, parameterType);
 
-        return parameters;
-    }
+    private static string EscapeString(string value) =>
+        ParameterShared.EscapeString(value);
 
-    private static string GetDefaultValueForParameter(string parameterString, ICollection<CSharpParameterModel> parameterModels)
-    {
-        var parts = parameterString.Split([' '], StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length == 0)
-            return "default";
-
-        var variableName = parts[parts.Length - 1].TrimEnd(';', ',');
-
-        var parameterModel = parameterModels.FirstOrDefault(p => p.VariableName == variableName);
-        parameterModel ??= parameterModels.FirstOrDefault(p => GetVariableName(p) == variableName);
-        if (parameterModel?.Schema?.Default != null && !string.IsNullOrEmpty(parameterModel.Type))
-        {
-            return FormatDefaultValue(parameterModel.Schema.Default, parameterModel.Type);
-        }
-        return "default";
-    }
-
-    private static string FormatDefaultValue(object? defaultValue, string parameterType)
-    {
-        if (defaultValue == null)
-            return "default";
-
-        var type = parameterType.TrimEnd('?').Trim();
-
-        return type switch
-        {
-            "bool" => defaultValue.ToString()?.ToLowerInvariant() ?? "default",
-            "string" => $"\"{EscapeString(defaultValue.ToString() ?? string.Empty)}\"",
-            _ when IsNumericType(type) => FormatNumericValue(defaultValue, type),
-            _ => "default"
-        };
-    }
-
-
-    private static string EscapeString(string value)
-    {
-        var sb = new StringBuilder(value.Length + 10);
-        foreach (var c in value)
-        {
-            switch (c)
-            {
-                case '\\':
-                    sb.Append("\\\\");
-                    break;
-                case '"':
-                    sb.Append("\\\"");
-                    break;
-                case '\n':
-                    sb.Append("\\n");
-                    break;
-                case '\r':
-                    sb.Append("\\r");
-                    break;
-                case '\t':
-                    sb.Append("\\t");
-                    break;
-                case '\f':
-                    sb.Append("\\f");
-                    break;
-                case '\v':
-                    sb.Append("\\v");
-                    break;
-                case '\b':
-                    sb.Append("\\b");
-                    break;
-                case '\0':
-                    sb.Append("\\0");
-                    break;
-                default:
-                    sb.Append(c);
-                    break;
-            }
-        }
-        return sb.ToString();
-    }
-
-    private static string FormatNumericValue(object defaultValue, string type)
-    {
-        var numericString = defaultValue is IFormattable formattable
-            ? formattable.ToString(null, CultureInfo.InvariantCulture)
-            : (defaultValue.ToString() ?? "default");
-
-        return type switch
-        {
-            "float" or "Single" => $"{numericString}f",
-            "decimal" or "Decimal" => $"{numericString}m",
-            "double" or "Double" => FormatDoubleLiteral(numericString),
-            "long" or "Int64" => $"{numericString}L",
-            "ulong" or "UInt64" => $"{numericString}UL",
-            "uint" or "UInt32" => $"{numericString}U",
-            _ => numericString
-        };
-    }
+    private static string FormatNumericValue(object defaultValue, string type) =>
+        ParameterShared.FormatNumericValue(defaultValue, type);
 
     private static string FormatDoubleLiteral(string numericString)
     {
-        // If the string already contains a decimal point or exponent, return as-is
         if (numericString.Contains('.') || numericString.Contains('e') || numericString.Contains('E'))
             return numericString;
 
-        // Otherwise, append .0 to make it a double literal
         return numericString + ".0";
     }
 
-    private static bool IsNumericType(string type)
-    {
-        return type is "int" or "Int32" or "long" or "Int64" or "short" or "Int16"
-            or "byte" or "Byte" or "decimal" or "Decimal" or "float" or "Single"
-            or "double" or "Double" or "sbyte" or "SByte" or "uint" or "UInt32"
-            or "ulong" or "UInt64" or "ushort" or "UInt16";
-    }
+    private static bool IsNumericType(string type) =>
+        ParameterShared.IsNumericType(type);
 
-    private static string GetBodyAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings)
-    {
-        var anyType = settings.CodeGeneratorSettings?.AnyType ?? "object";
-        var parameterType = WellKnownNamespaces.TrimImportedNamespaces(FindSupportedType(parameter.Type));
+    private static string GetBodyAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings) =>
+        ParameterShared.GetBodyAttribute(parameter, settings);
 
-        // Check if the parameter type matches AnyType (e.g., "object" or custom type like "System.Text.Json.JsonElement")
-        if (parameterType.Equals(anyType, StringComparison.OrdinalIgnoreCase) ||
-            parameterType.Contains("JsonElement", StringComparison.OrdinalIgnoreCase))
-        {
-            return "Body(BodySerializationMethod.Serialized)";
-        }
-
-        return "Body";
-    }
-
-    private static string GetQueryAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings)
-    {
-        return (parameter, settings) switch
-        {
-            { parameter.IsArray: true }
-                => $"Query(CollectionFormat.{settings.CollectionFormat})",
-            { parameter.IsDate: true, settings.UseIsoDateFormat: true }
-                => "Query(Format = \"yyyy-MM-dd\")",
-            { parameter.IsDate: true, settings.CodeGeneratorSettings.DateFormat: not null }
-                => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateFormat}\")",
-            {
-                parameter.IsDateOrDateTime: true, parameter.Schema.Format: "date-time",
-                settings.CodeGeneratorSettings.DateTimeFormat: not null
-            } => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateTimeFormat}\")",
-            _ => "Query",
-        };
-    }
+    private static string GetQueryAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings) =>
+        ParameterShared.GetQueryAttribute(parameter, settings);
 
     private static string GetAliasAsAttribute(CSharpParameterModel parameterModel) =>
-        string.Equals(parameterModel.Name, parameterModel.VariableName)
-            ? string.Empty
-            : $"AliasAs(\"{EscapeString(parameterModel.Name)}\")";
+        ParameterShared.GetAliasAsAttribute(parameterModel);
 
     private static string GetAliasAsAttribute(string originalName, string variableName) =>
-        string.Equals(originalName, variableName, StringComparison.Ordinal)
-            ? string.Empty
-            : $"AliasAs(\"{EscapeString(originalName)}\")";
+        ParameterShared.GetAliasAsAttribute(originalName, variableName);
 
-    private static string JoinAttributes(params string[] attributes)
-    {
-        var filteredAttributes = attributes
-            .Where(a => !string.IsNullOrWhiteSpace(a))
-            .ToList();
-
-        if (filteredAttributes.Count == 0)
-            return string.Empty;
-
-        return "[" + string.Join(", ", filteredAttributes) + "] ";
-    }
+    private static string JoinAttributes(params string[] attributes) =>
+        ParameterShared.JoinAttributes(attributes);
 
     private static string GetParameterType(
         ParameterModelBase parameterModel,
-        RefitGeneratorSettings settings)
-    {
-        var type = WellKnownNamespaces
-            .TrimImportedNamespaces(
-                FindSupportedType(
-                    parameterModel.Type));
-
-        if (settings.OptionalParameters &&
-            !type.EndsWith("?") &&
-            (parameterModel.IsNullable || parameterModel.IsOptional || !parameterModel.IsRequired))
-            type += "?";
-
-        return type;
-    }
+        RefitGeneratorSettings settings) =>
+        ParameterShared.GetParameterType(parameterModel, settings);
 
     private static string GetQueryParameterType(
         ParameterModelBase parameterModel,
-        RefitGeneratorSettings settings)
+        RefitGeneratorSettings settings) =>
+        ParameterShared.GetQueryParameterType(parameterModel, settings);
+
+    private static string FindSupportedType(string typeName) =>
+        ParameterShared.FindSupportedType(typeName);
+
+    private static List<string> GetQueryParameters(
+        CSharpOperationModel operationModel,
+        RefitGeneratorSettings settings,
+        string dynamicQuerystringParameterType,
+        out string? dynamicQuerystringParameters)
     {
-        var type = GetParameterType(parameterModel, settings);
-
-        if (parameterModel.IsQuery &&
-            parameterModel.Type.Equals("object", StringComparison.OrdinalIgnoreCase))
-            type = "string";
-
-        return type;
-    }
-
-    private static string FindSupportedType(string typeName)
-    {
-        if (typeName is "FileResponse" or "FileParameter")
-            return "StreamPart";
-
-        // Handle collections of FileParameter/FileResponse
-        if (typeName.Contains("FileParameter") || typeName.Contains("FileResponse"))
-        {
-            return typeName
-                .Replace("FileParameter", "StreamPart")
-                .Replace("FileResponse", "StreamPart");
-        }
-
-        return typeName;
-    }
-
-    private static List<string> GetQueryParameters(CSharpOperationModel operationModel, RefitGeneratorSettings settings, string dynamicQuerystringParameterType, out string? dynamicQuerystringParameters)
-    {
-        List<string>? parameters = null;
-        var dynamicQuerystringParametersCodeBuilder = new StringBuilder();
         var queryParameters = operationModel.Parameters
             .Where(p => p.Kind == OpenApiParameterKind.Query)
             .ToList();
 
+        List<string>? parameters = null;
+        var dynamicQuerystringParametersCodeBuilder = new StringBuilder();
+
         if (settings.UseDynamicQuerystringParameters && queryParameters.Count >= 2)
         {
-            var modifier = settings.TypeAccessibility.ToString().ToLowerInvariant();
-            var isRecord = settings.ImmutableRecords ||
-                           settings.CodeGeneratorSettings?.GenerateNativeRecords is true;
-            var classStyle = isRecord
-                ? "record"
-                : "class";
-            var setterStyle = isRecord
-                ? "init"
-                : "set";
+            var dynamicQuerystringCode = DynamicQuerystringParameterBuilder.Build(
+                queryParameters,
+                dynamicQuerystringParameterType,
+                settings);
 
-            var injectedParametersCodeBuilder = new StringBuilder();
-            var initializedParametersCodeBuilder = new StringBuilder();
-            var propertiesCodeBuilder = new StringBuilder();
-            var allNullable = true;
-            foreach (var operationParameter in queryParameters)
+            if (!string.IsNullOrWhiteSpace(dynamicQuerystringCode))
             {
-                var propertyType = GetQueryParameterType(operationParameter, settings);
-                allNullable = allNullable && propertyType.EndsWith("?");
-                var variableName = GetVariableName(operationParameter);
-                var attributes = $"{JoinAttributes(GetQueryAttribute(operationParameter, settings), GetAliasAsAttribute(operationParameter.Name, variableName))}";
-                var propertyName = variableName.CapitalizeFirstCharacter();
-                if (operationParameter.IsRequired)
-                {
-                    injectedParametersCodeBuilder.Append(injectedParametersCodeBuilder.Length == 0
-                        ? $$"""{{propertyType}} {{variableName}}"""
-                        : $$""", {{propertyType}} {{variableName}}""");
-
-                    initializedParametersCodeBuilder.AppendLine();
-                    initializedParametersCodeBuilder.Append(
-        $$"""
-                        this.{{propertyName}} = {{variableName}};
-            """);
-                }
-
-                propertiesCodeBuilder.AppendLine();
-                if (settings.GenerateXmlDocCodeComments && !string.IsNullOrWhiteSpace(operationParameter.Description))
-                {
-                    var escapedDescription = XmlDocumentationGenerator.SanitizeResponseDescription(operationParameter.Description);
-                    AppendXmlDocComment(escapedDescription, propertiesCodeBuilder);
-                }
-
-                propertiesCodeBuilder.Append(
-        $$"""
-                    {{attributes}}
-                    {{modifier}} {{propertyType}} {{propertyName}} { get; {{setterStyle}}; }
-            """);
-                var defaultValue = operationParameter.Schema.Default;
-                if (defaultValue != null)
-                {
-                    var formattedDefaultValue = FormatDefaultValue(defaultValue, propertyType);
-                    propertiesCodeBuilder.Append($" = {formattedDefaultValue};");
-                }
-                propertiesCodeBuilder.AppendLine();
+                dynamicQuerystringParametersCodeBuilder.Append(dynamicQuerystringCode);
             }
 
-            dynamicQuerystringParametersCodeBuilder.AppendLine(
-        $$"""
-                {{modifier}} {{classStyle}} {{dynamicQuerystringParameterType}}
-                {
-            """);
-
-            if (injectedParametersCodeBuilder.Length > 0)
-            {
-                dynamicQuerystringParametersCodeBuilder.AppendLine(
-        $$"""
-                    {{modifier}} {{dynamicQuerystringParameterType}}({{injectedParametersCodeBuilder}})
-                    {
-                        {{initializedParametersCodeBuilder}}
-                    }
-            """);
-            }
-
-            dynamicQuerystringParametersCodeBuilder.AppendLine(
-        $$"""
-                    {{propertiesCodeBuilder}}
-                }
-            """);
+            var allNullable = queryParameters.All(p =>
+                ParameterShared.GetQueryParameterType(p, settings).EndsWith("?"));
 
             var dynamicQuerystringParameter = $"[Query] {dynamicQuerystringParameterType}";
             if (allNullable)
@@ -512,111 +124,30 @@ internal static class ParameterExtractor
             parameters = [dynamicQuerystringParameter];
         }
 
-        dynamicQuerystringParameters = dynamicQuerystringParametersCodeBuilder.ToString();
+        dynamicQuerystringParameters = dynamicQuerystringParametersCodeBuilder.Length > 0
+            ? dynamicQuerystringParametersCodeBuilder.ToString()
+            : null;
 
-        parameters ??= queryParameters
-            .Select(p =>
-            {
-                var variableName = GetVariableName(p);
-                return $"{JoinAttributes(GetQueryAttribute(p, settings), GetAliasAsAttribute(p.Name, variableName))}{GetQueryParameterType(p, settings)} {variableName}";
-            })
-            .ToList();
+        parameters ??= QueryParameterExtractor.ExtractSimple(operationModel, settings).ToList();
 
         return parameters;
     }
 
-    private static void AppendXmlDocComment(string description, StringBuilder codeBuilder)
-    {
-        codeBuilder.Append(
-"""
-                /// <summary>
-""");
+    private static void AppendXmlDocComment(string description, StringBuilder codeBuilder) =>
+        ParameterShared.AppendXmlDocComment(description, codeBuilder);
 
-        var lines = description.Split(
-            ["\r\n", "\r", "\n"],
-            StringSplitOptions.None);
+    private static string GetCSharpType(JsonSchema propertySchema, RefitGeneratorSettings settings) =>
+        ParameterShared.GetCSharpType(propertySchema, settings);
 
-        foreach (var line in lines)
-        {
-            codeBuilder.AppendLine();
-            codeBuilder.Append(
-$$"""
-                /// {{line.Trim()}}
-""");
-        }
+    private static string GetIntegerTypeName(JsonSchema schema, RefitGeneratorSettings settings) =>
+        ParameterShared.GetIntegerTypeName(schema, settings);
 
-        codeBuilder.AppendLine();
-        codeBuilder.Append(
-"""
-                /// </summary>
-""");
-        codeBuilder.AppendLine();
-    }
+    private static string GetArrayType(JsonSchema arraySchema, RefitGeneratorSettings settings) =>
+        ParameterShared.GetArrayType(arraySchema, settings);
 
-    private static string GetCSharpType(JsonSchema propertySchema, RefitGeneratorSettings settings)
-    {
-        var type = propertySchema.Type switch
-        {
-            JsonObjectType.String => "string",
-            JsonObjectType.Integer => GetIntegerTypeName(propertySchema, settings),
-            JsonObjectType.Number => "double",
-            JsonObjectType.Boolean => "bool",
-            JsonObjectType.Array => GetArrayType(propertySchema, settings),
-            JsonObjectType.Object => "object",
-            _ => "object"
-        };
+    private static string ConvertToVariableName(string propertyName) =>
+        ParameterShared.ConvertToVariableName(propertyName);
 
-        // Add nullable modifier if needed
-        if (settings.OptionalParameters && propertySchema.IsNullable(SchemaType.OpenApi3))
-        {
-            type += "?";
-        }
-
-        return type;
-    }
-
-    private static string GetIntegerTypeName(JsonSchema schema, RefitGeneratorSettings settings)
-    {
-        // Check the format first
-        if (schema.Format == "int64")
-            return "long";
-        if (schema.Format == "int32")
-            return "int";
-
-        // Fall back to settings
-        var integerType = settings.CodeGeneratorSettings?.IntegerType ?? IntegerType.Int32;
-        return integerType == IntegerType.Int64 ? "long" : "int";
-    }
-
-    private static string GetArrayType(JsonSchema arraySchema, RefitGeneratorSettings settings)
-    {
-        if (arraySchema.Item != null)
-        {
-            var itemType = GetCSharpType(arraySchema.Item, settings);
-            return $"{itemType}[]";
-        }
-        return "object[]";
-    }
-
-    private static string ConvertToVariableName(string propertyName)
-    {
-        if (string.IsNullOrEmpty(propertyName))
-            return "value";
-
-        // Use ToCompilableIdentifier to handle reserved keywords and invalid characters
-        var identifier = IdentifierUtils.ToCompilableIdentifier(propertyName);
-
-        // Convert first character to lowercase for camelCase, if it's a letter
-        if (identifier.Length > 0 && char.IsUpper(identifier[0]))
-        {
-            return char.ToLowerInvariant(identifier[0]) + identifier.Substring(1);
-        }
-
-        return identifier;
-    }
-
-    private static string GetVariableName(ParameterModelBase parameterModel)
-    {
-        return IdentifierUtils.ToCompilableIdentifier(parameterModel.VariableName);
-    }
+    private static string GetVariableName(ParameterModelBase parameterModel) =>
+        ParameterShared.GetVariableName(parameterModel);
 }

--- a/src/Refitter.Core/ParameterShared.cs
+++ b/src/Refitter.Core/ParameterShared.cs
@@ -1,0 +1,320 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+using NJsonSchema;
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration.Models;
+
+namespace Refitter.Core;
+
+internal static class ParameterShared
+{
+    public static string ReplaceUnsafeCharacters(string unsafeText)
+    {
+        return IdentifierUtils.ToCompilableIdentifier(unsafeText);
+    }
+
+    public static string EscapeString(string value)
+    {
+        var sb = new StringBuilder(value.Length + 10);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\':
+                    sb.Append("\\\\");
+                    break;
+                case '"':
+                    sb.Append("\\\"");
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                case '\r':
+                    sb.Append("\\r");
+                    break;
+                case '\t':
+                    sb.Append("\\t");
+                    break;
+                case '\f':
+                    sb.Append("\\f");
+                    break;
+                case '\v':
+                    sb.Append("\\v");
+                    break;
+                case '\b':
+                    sb.Append("\\b");
+                    break;
+                case '\0':
+                    sb.Append("\\0");
+                    break;
+                default:
+                    sb.Append(c);
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    public static bool IsNumericType(string type)
+    {
+        return type is "int" or "Int32" or "long" or "Int64" or "short" or "Int16"
+            or "byte" or "Byte" or "decimal" or "Decimal" or "float" or "Single"
+            or "double" or "Double" or "sbyte" or "SByte" or "uint" or "UInt32"
+            or "ulong" or "UInt64" or "ushort" or "UInt16";
+    }
+
+    private static string FormatDoubleLiteral(string numericString)
+    {
+        if (numericString.Contains('.') || numericString.Contains('e') || numericString.Contains('E'))
+            return numericString;
+
+        return numericString + ".0";
+    }
+
+    public static string FormatNumericValue(object defaultValue, string type)
+    {
+        var numericString = defaultValue is IFormattable formattable
+            ? formattable.ToString(null, CultureInfo.InvariantCulture)
+            : (defaultValue.ToString() ?? "default");
+
+        return type switch
+        {
+            "float" or "Single" => $"{numericString}f",
+            "decimal" or "Decimal" => $"{numericString}m",
+            "double" or "Double" => FormatDoubleLiteral(numericString),
+            "long" or "Int64" => $"{numericString}L",
+            "ulong" or "UInt64" => $"{numericString}UL",
+            "uint" or "UInt32" => $"{numericString}U",
+            _ => numericString
+        };
+    }
+
+    public static string FormatDefaultValue(object? defaultValue, string parameterType)
+    {
+        if (defaultValue == null)
+            return "default";
+
+        var type = parameterType.TrimEnd('?').Trim();
+
+        return type switch
+        {
+            "bool" => defaultValue.ToString()?.ToLowerInvariant() ?? "default",
+            "string" => $"\"{EscapeString(defaultValue.ToString() ?? string.Empty)}\"",
+            _ when IsNumericType(type) => FormatNumericValue(defaultValue, type),
+            _ => "default"
+        };
+    }
+
+    public static string GetDefaultValueForParameter(
+        string parameterString,
+        ICollection<CSharpParameterModel> parameterModels)
+    {
+        var parts = parameterString.Split([' '], StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+            return "default";
+
+        var variableName = parts[parts.Length - 1].TrimEnd(';', ',');
+
+        var parameterModel = parameterModels.FirstOrDefault(p => p.VariableName == variableName);
+        parameterModel ??= parameterModels.FirstOrDefault(p => GetVariableName(p) == variableName);
+        if (parameterModel?.Schema?.Default != null && !string.IsNullOrEmpty(parameterModel.Type))
+        {
+            return FormatDefaultValue(parameterModel.Schema.Default, parameterModel.Type);
+        }
+
+        return "default";
+    }
+
+    public static string GetAliasAsAttribute(CSharpParameterModel parameterModel) =>
+        string.Equals(parameterModel.Name, parameterModel.VariableName)
+            ? string.Empty
+            : $"AliasAs(\"{EscapeString(parameterModel.Name)}\")";
+
+    public static string GetAliasAsAttribute(string originalName, string variableName) =>
+        string.Equals(originalName, variableName, StringComparison.Ordinal)
+            ? string.Empty
+            : $"AliasAs(\"{EscapeString(originalName)}\")";
+
+    public static string JoinAttributes(params string[] attributes)
+    {
+        var filteredAttributes = attributes
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .ToList();
+
+        if (filteredAttributes.Count == 0)
+            return string.Empty;
+
+        return "[" + string.Join(", ", filteredAttributes) + "] ";
+    }
+
+    public static string FindSupportedType(string typeName)
+    {
+        if (typeName is "FileResponse" or "FileParameter")
+            return "StreamPart";
+
+        if (typeName.Contains("FileParameter") || typeName.Contains("FileResponse"))
+        {
+            return typeName
+                .Replace("FileParameter", "StreamPart")
+                .Replace("FileResponse", "StreamPart");
+        }
+
+        return typeName;
+    }
+
+    public static string GetParameterType(
+        ParameterModelBase parameterModel,
+        RefitGeneratorSettings settings)
+    {
+        var type = WellKnownNamespaces
+            .TrimImportedNamespaces(
+                FindSupportedType(
+                    parameterModel.Type));
+
+        if (settings.OptionalParameters &&
+            !type.EndsWith("?") &&
+            (parameterModel.IsNullable || parameterModel.IsOptional || !parameterModel.IsRequired))
+            type += "?";
+
+        return type;
+    }
+
+    public static string GetQueryParameterType(
+        ParameterModelBase parameterModel,
+        RefitGeneratorSettings settings)
+    {
+        var type = GetParameterType(parameterModel, settings);
+
+        if (parameterModel.IsQuery &&
+            parameterModel.Type.Equals("object", StringComparison.OrdinalIgnoreCase))
+            type = "string";
+
+        return type;
+    }
+
+    public static string GetBodyAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings)
+    {
+        var anyType = settings.CodeGeneratorSettings?.AnyType ?? "object";
+        var parameterType = WellKnownNamespaces.TrimImportedNamespaces(FindSupportedType(parameter.Type));
+
+        if (parameterType.Equals(anyType, StringComparison.OrdinalIgnoreCase) ||
+            parameterType.Contains("JsonElement", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Body(BodySerializationMethod.Serialized)";
+        }
+
+        return "Body";
+    }
+
+    public static string GetQueryAttribute(CSharpParameterModel parameter, RefitGeneratorSettings settings)
+    {
+        return (parameter, settings) switch
+        {
+            { parameter.IsArray: true }
+                => $"Query(CollectionFormat.{settings.CollectionFormat})",
+            { parameter.IsDate: true, settings.UseIsoDateFormat: true }
+                => "Query(Format = \"yyyy-MM-dd\")",
+            { parameter.IsDate: true, settings.CodeGeneratorSettings.DateFormat: not null }
+                => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateFormat}\")",
+            {
+                parameter.IsDateOrDateTime: true, parameter.Schema.Format: "date-time",
+                settings.CodeGeneratorSettings.DateTimeFormat: not null
+            } => $"Query(Format = \"{settings.CodeGeneratorSettings?.DateTimeFormat}\")",
+            _ => "Query",
+        };
+    }
+
+    public static string GetCSharpType(JsonSchema propertySchema, RefitGeneratorSettings settings)
+    {
+        var type = propertySchema.Type switch
+        {
+            JsonObjectType.String => "string",
+            JsonObjectType.Integer => GetIntegerTypeName(propertySchema, settings),
+            JsonObjectType.Number => "double",
+            JsonObjectType.Boolean => "bool",
+            JsonObjectType.Array => GetArrayType(propertySchema, settings),
+            JsonObjectType.Object => "object",
+            _ => "object"
+        };
+
+        if (settings.OptionalParameters && propertySchema.IsNullable(SchemaType.OpenApi3))
+        {
+            type += "?";
+        }
+
+        return type;
+    }
+
+    public static string GetIntegerTypeName(JsonSchema schema, RefitGeneratorSettings settings)
+    {
+        if (schema.Format == "int64")
+            return "long";
+        if (schema.Format == "int32")
+            return "int";
+
+        var integerType = settings.CodeGeneratorSettings?.IntegerType ?? IntegerType.Int32;
+        return integerType == IntegerType.Int64 ? "long" : "int";
+    }
+
+    public static string GetArrayType(JsonSchema arraySchema, RefitGeneratorSettings settings)
+    {
+        if (arraySchema.Item != null)
+        {
+            var itemType = GetCSharpType(arraySchema.Item, settings);
+            return $"{itemType}[]";
+        }
+
+        return "object[]";
+    }
+
+    public static string ConvertToVariableName(string propertyName)
+    {
+        if (string.IsNullOrEmpty(propertyName))
+            return "value";
+
+        var identifier = IdentifierUtils.ToCompilableIdentifier(propertyName);
+
+        if (identifier.Length > 0 && char.IsUpper(identifier[0]))
+        {
+            return char.ToLowerInvariant(identifier[0]) + identifier.Substring(1);
+        }
+
+        return identifier;
+    }
+
+    public static string GetVariableName(ParameterModelBase parameterModel)
+    {
+        return IdentifierUtils.ToCompilableIdentifier(parameterModel.VariableName);
+    }
+
+    public static void AppendXmlDocComment(string description, StringBuilder codeBuilder)
+    {
+        codeBuilder.Append(
+"""
+                /// <summary>
+""");
+
+        var lines = description.Split(
+            ["\r\n", "\r", "\n"],
+            StringSplitOptions.None);
+
+        foreach (var line in lines)
+        {
+            codeBuilder.AppendLine();
+            codeBuilder.Append(
+$$"""
+                /// {{line.Trim()}}
+""");
+        }
+
+        codeBuilder.AppendLine();
+        codeBuilder.Append(
+"""
+                /// </summary>
+""");
+        codeBuilder.AppendLine();
+    }
+}

--- a/src/Refitter.Core/QueryParameterExtractor.cs
+++ b/src/Refitter.Core/QueryParameterExtractor.cs
@@ -1,0 +1,21 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+
+namespace Refitter.Core;
+
+internal static class QueryParameterExtractor
+{
+    public static IEnumerable<string> ExtractSimple(
+        CSharpOperationModel operationModel,
+        RefitGeneratorSettings settings)
+    {
+        return operationModel.Parameters
+            .Where(p => p.Kind == OpenApiParameterKind.Query)
+            .Select(p =>
+            {
+                var variableName = ParameterShared.GetVariableName(p);
+                return $"{ParameterShared.JoinAttributes(ParameterShared.GetQueryAttribute(p, settings), ParameterShared.GetAliasAsAttribute(p.Name, variableName))}{ParameterShared.GetQueryParameterType(p, settings)} {variableName}";
+            })
+            .ToList();
+    }
+}

--- a/src/Refitter.Core/RouteParameterExtractor.cs
+++ b/src/Refitter.Core/RouteParameterExtractor.cs
@@ -1,0 +1,25 @@
+using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
+
+namespace Refitter.Core;
+
+internal class RouteParameterExtractor : IParameterTypeExtractor
+{
+    public bool CanExtract(OpenApiParameterKind kind) =>
+        kind == OpenApiParameterKind.Path;
+
+    public IEnumerable<string> Extract(
+        CSharpOperationModel operationModel,
+        OpenApiOperation operation,
+        RefitGeneratorSettings settings)
+    {
+        return operationModel.Parameters
+            .Where(p => p.Kind == OpenApiParameterKind.Path)
+            .Select(p =>
+            {
+                var variableName = ParameterShared.GetVariableName(p);
+                return $"{ParameterShared.JoinAttributes(ParameterShared.GetAliasAsAttribute(p.Name, variableName))}{p.Type} {variableName}";
+            })
+            .ToList();
+    }
+}

--- a/src/Refitter.Tests/Scenarios/OpenApiUrlTests.cs
+++ b/src/Refitter.Tests/Scenarios/OpenApiUrlTests.cs
@@ -15,8 +15,6 @@ public class OpenApiUrlTests
     [Arguments("https://raw.githubusercontent.com/christianhelle/refitter/main/test/OpenAPI/v3.0/link-example.json")]
     [Arguments("https://raw.githubusercontent.com/christianhelle/refitter/main/test/OpenAPI/v3.0/petstore-expanded.json")]
     [Arguments("https://raw.githubusercontent.com/christianhelle/refitter/main/test/OpenAPI/v3.0/uspto.json")]
-    [Arguments("https://raw.githubusercontent.com/christianhelle/refitter/main/test/OpenAPI/v3.0/hubspot-events.json")]
-    [Arguments("https://raw.githubusercontent.com/christianhelle/refitter/main/test/OpenAPI/v3.0/hubspot-webhooks.json")]
     [Arguments("https://raw.githubusercontent.com/christianhelle/refitter/main/test/OpenAPI/v3.0/ingram-micro.json")]
     public async Task Can_Build_Generated_Code_From_OpenApi_v3_Url_Json(string url)
     {


### PR DESCRIPTION
Closes #1115

This pull request introduces a modular and extensible parameter extraction system to the core of the codebase, refactoring the way interface method parameters are generated for API clients. The changes decouple parameter extraction logic by introducing new extractor interfaces and implementations for different parameter types (route, query, body, header, and form), centralize aggregation logic, and improve support for advanced features like dynamic querystring parameters and optional parameter reordering.

The most important changes are:

### Parameter Extraction Refactoring

- Introduced the `IParameterTypeExtractor` and `IParameterExtractor` interfaces, along with concrete implementations for extracting route, body, header, and form parameters, enabling a modular and extensible approach to parameter extraction. (`src/Refitter.Core/IParameterTypeExtractor.cs` [[1]](diffhunk://#diff-b0f85c4cb4614bfb83c08a2bc998247e0e8c911e556ecf522042d70a2061bca3R1-R13) `src/Refitter.Core/IParameterExtractor.cs` [[2]](diffhunk://#diff-7140a5bf35d80cdaa7216054f83f3feb653ec0ae45cbeed29c5c13f045b51dc4R1-R14) `src/Refitter.Core/BodyParameterExtractor.cs` [[3]](diffhunk://#diff-c0f79f883fabff359c2d124572c2d70033a7e63092352b44c153212fbf663e27R1-R43) `src/Refitter.Core/HeaderParameterExtractor.cs` [[4]](diffhunk://#diff-28f9f409abd1218197f85efccd3a455428823a562ef261fe5300baa0de9b0457R1-R65) `src/Refitter.Core/FormParameterExtractor.cs` [[5]](diffhunk://#diff-77cff0766ba252ae2711507faf44e6010714a5a2ba12c0e14eb7aec7f99ac3ddR1-R62)

- Added the `ParameterAggregator` class to aggregate parameters from all extractors, handle dynamic querystring parameters, reorder optional parameters, and append special parameters like request options or cancellation tokens. (`src/Refitter.Core/ParameterAggregator.cs` [src/Refitter.Core/ParameterAggregator.csR1-R120](diffhunk://#diff-e3abb6fce5aee252803a1cf223422b1f44c737b1e2282804eccf8a7f4ebfe47dR1-R120))

### Dynamic Querystring and Optional Parameters

- Implemented `DynamicQuerystringParameterBuilder` to generate types for dynamic querystring parameters when multiple query parameters are present, supporting both class and record styles, XML documentation, and default values. (`src/Refitter.Core/DynamicQuerystringParameterBuilder.cs` [src/Refitter.Core/DynamicQuerystringParameterBuilder.csR1-R95](diffhunk://#diff-c9205466f8ddba91e78169085bb888f927861925088656687a84c32ff8f08b54R1-R95))

- Added `OptionalParameterReorderer` to ensure optional parameters are reordered to the end of the parameter list and default values are set appropriately. (`src/Refitter.Core/OptionalParameterReorderer.cs` [src/Refitter.Core/OptionalParameterReorderer.csR1-R33](diffhunk://#diff-b746b819d9047674a63afccd28c181aab56216addaef50c3fe98a65db9681cd8R1-R33))

### Integration with Interface Generation

- Refactored `InterfaceGenerator` to use the new `IParameterExtractor` abstraction, allowing for dependency injection and improved testability. (`src/Refitter.Core/InterfaceGenerator.cs` [[1]](diffhunk://#diff-7e3c665e6ac88344c98c312c0a3300d1cf1aca73810ae71ae79849560aa806dfR18-R31) [[2]](diffhunk://#diff-7e3c665e6ac88344c98c312c0a3300d1cf1aca73810ae71ae79849560aa806dfL167-R170)

These changes lay the foundation for easier maintenance and future extension of parameter extraction logic, and improve correctness and flexibility in the generated API client interfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modularized parameter extraction into reusable components and added a configurable extractor to improve generation flexibility and maintainability.

* **New Features**
  * Dynamic querystring type generation for grouped query parameters.
  * Improved handling of body (including binary), form and header parameters.
  * Optional-parameter reordering and clearer handling of request-options vs. cancellation-token parameters.

* **Tests**
  * Trimmed test inputs to remove two external OpenAPI URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->