### PR TITLE
Extract GenerationPipeline from RefitGenerator orchestration

### DIFF
--- a/src/Refitter.Core/GeneratorPipeline.cs
+++ b/src/Refitter.Core/GeneratorPipeline.cs
@@ -1,0 +1,224 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NSwag;
+
+namespace Refitter.Core;
+
+internal sealed class GeneratorPipeline
+{
+    private static readonly Regex JsonStringEnumConverterAttributeRegex = new(
+        @"^\s*\[(System\.Text\.Json\.Serialization\.)?JsonConverter\(typeof\((System\.Text\.Json\.Serialization\.)?JsonStringEnumConverter(?:<[\w.]+>)?\)\)\]\s*\r?\n?",
+        RegexOptions.Compiled | RegexOptions.Multiline,
+        TimeSpan.FromSeconds(1));
+
+    private static readonly Regex EnumDeclarationRegex = new(
+        @"^(\s*)((?:public|internal)\s+(?:partial\s+)?enum\s+\w+\b)",
+        RegexOptions.Compiled | RegexOptions.Multiline,
+        TimeSpan.FromSeconds(1));
+
+    public GenerationResult Run(
+        OpenApiDocument document,
+        RefitGeneratorSettings settings,
+        CustomCSharpClientGenerator generator)
+    {
+        var docGenerator = new XmlDocumentationGenerator(settings);
+
+        // Create the interface generator before calling GenerateFile() so that
+        // OperationNameGenerator.CheckForDuplicateOperationIds() sees the original
+        // (pre-generation) operation IDs. GenerateFile() auto-populates operation IDs
+        // with globally unique names which would prevent the switch to the path segments
+        // generator, causing unnecessary numeric suffixes in ByTag mode.
+        var interfaceGenerator = new InterfaceGenerator(settings, document, generator, docGenerator);
+
+        var contracts = generator.GenerateFile();
+        contracts = SanitizeGeneratedContracts(document, settings, contracts);
+        var serializerContext = GenerateJsonSerializerContext(document, settings, contracts);
+        var interfaces = GenerateClient(document, settings, interfaceGenerator);
+        var interfaceNames = interfaces.Select(c => c.TypeName).ToArray();
+        var title = settings.Naming.UseOpenApiTitle && !string.IsNullOrWhiteSpace(document.Info?.Title)
+            ? document.Info!.Title.Sanitize()
+            : settings.Naming.InterfaceName;
+        var dependencyInjectionCode = settings.ApizrSettings != null
+            ? ApizrRegistrationGenerator.Generate(settings, interfaceNames, title)
+            : DependencyInjectionGenerator.Generate(settings, interfaceNames);
+
+        return new GenerationResult(contracts, interfaces, serializerContext, dependencyInjectionCode, interfaceNames);
+    }
+
+    private static IInterfacePartitioning GetInterfacePartitioning(OpenApiDocument document, RefitGeneratorSettings settings)
+    {
+        return settings.MultipleInterfaces switch
+        {
+            MultipleInterfaces.ByEndpoint => new ByEndpointInterfacePartitioning(settings),
+            MultipleInterfaces.ByTag => new ByTagInterfacePartitioning(settings, document),
+            _ => new SingleInterfacePartitioning(settings),
+        };
+    }
+
+    internal static string SanitizeGeneratedContracts(OpenApiDocument document, RefitGeneratorSettings settings, string contracts)
+    {
+        contracts = NormalizeSwagger2OptionalReferencePropertyNullability(document, settings, contracts);
+
+        if (settings.CodeGeneratorSettings is not { InlineJsonConverters: false })
+        {
+            contracts = JsonStringEnumConverterAttributeRegex.Replace(contracts, string.Empty);
+            var newLine = GetPreferredNewLine(contracts);
+            return EnumDeclarationRegex
+                .Replace(
+                    contracts,
+                    match =>
+                        $"{match.Groups[1].Value}[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]{newLine}{match.Groups[1].Value}{match.Groups[2].Value}")
+                .TrimEnd();
+        }
+
+        return JsonStringEnumConverterAttributeRegex
+            .Replace(contracts, string.Empty)
+            .TrimEnd();
+    }
+
+    private static string GetPreferredNewLine(string content) =>
+        content.Contains("\r\n", StringComparison.Ordinal)
+            ? "\r\n"
+            : "\n";
+
+    internal static string NormalizeSwagger2OptionalReferencePropertyNullability(
+        OpenApiDocument document,
+        RefitGeneratorSettings settings,
+        string contracts)
+    {
+        if (document.SchemaType != NJsonSchema.SchemaType.Swagger2 ||
+            settings.CodeGeneratorSettings?.GenerateNullableReferenceTypes != true ||
+            settings.CodeGeneratorSettings.GenerateOptionalPropertiesAsNullable)
+        {
+            return contracts;
+        }
+
+        var tree = CSharpSyntaxTree.ParseText(contracts);
+        var root = tree.GetCompilationUnitRoot();
+        var rewrittenRoot = new Swagger2OptionalReferencePropertyNullabilityRewriter().Visit(root);
+        return rewrittenRoot!.ToFullString();
+    }
+
+    internal static string GenerateJsonSerializerContext(
+        OpenApiDocument document,
+        RefitGeneratorSettings settings,
+        string contracts) =>
+        settings.GenerateJsonSerializerContext && settings.GenerateContracts
+            ? JsonSerializerContextGenerator.Generate(contracts, settings, document.Info?.Title)
+            : string.Empty;
+
+    private static IReadOnlyCollection<GeneratedCode> GenerateClient(
+        OpenApiDocument document,
+        RefitGeneratorSettings settings,
+        InterfaceGenerator interfaceGenerator)
+    {
+        var code = new StringBuilder();
+        GenerateAutoGeneratedHeader(settings, code);
+
+        code.AppendLine()
+            .AppendLine(RefitInterfaceImports.GenerateNamespaceImports(settings))
+            .AppendLine();
+
+        if (settings.AdditionalNamespaces.Any())
+        {
+            foreach (var ns in settings.AdditionalNamespaces)
+            {
+                code.AppendLine($"using {ns};");
+            }
+
+            code.AppendLine();
+        }
+
+        code.AppendLine("#nullable enable annotations");
+        code.AppendLine();
+
+        var partitioning = GetInterfacePartitioning(document, settings);
+        var refitInterfaces = interfaceGenerator.Generate(partitioning);
+        var generatedCodes = refitInterfaces as GeneratedCode[] ?? refitInterfaces.ToArray();
+
+        if (settings.GenerateMultipleFiles)
+        {
+            for (int i = 0; i < generatedCodes.Length; i++)
+            {
+                generatedCodes[i] = generatedCodes[i] with
+                {
+                    Content = code +
+                              $$"""
+                                namespace {{settings.Namespace}}
+                                {
+                                {{generatedCodes[i].Content}}
+                                }
+                                """
+                };
+            }
+
+            return generatedCodes;
+        }
+
+        code.AppendLine($"namespace {settings.Namespace}");
+        code.AppendLine("{");
+
+        foreach (var generatedCode in generatedCodes)
+        {
+            code.AppendLine(generatedCode.Content);
+        }
+
+        code.Append("}");
+
+        return new[] { new GeneratedCode(generatedCodes.First().TypeName, code.ToString()) }
+            .Union(
+                generatedCodes
+                    .Skip(1)
+                    .Select(c => new GeneratedCode(c.TypeName, string.Empty)))
+            .ToArray();
+    }
+
+    private static void GenerateAutoGeneratedHeader(RefitGeneratorSettings settings, StringBuilder code)
+    {
+        if (!settings.AddAutoGeneratedHeader)
+            return;
+
+        code.AppendLine("""
+            // <auto-generated>
+            //     This code was generated by Refitter.
+            // </auto-generated>
+
+            """);
+    }
+
+    private sealed class Swagger2OptionalReferencePropertyNullabilityRewriter : CSharpSyntaxRewriter
+    {
+        public override SyntaxNode? VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            if (node.Type is NullableTypeSyntax nullableType &&
+                IsReferenceType(nullableType.ElementType))
+            {
+                node = node.WithType(nullableType.ElementType.WithTriviaFrom(node.Type));
+            }
+
+            return base.VisitPropertyDeclaration(node);
+        }
+
+        private static bool IsReferenceType(TypeSyntax typeSyntax) =>
+            typeSyntax switch
+            {
+                PredefinedTypeSyntax predefinedType => predefinedType.Keyword.Kind() is SyntaxKind.ObjectKeyword or SyntaxKind.StringKeyword,
+                ArrayTypeSyntax => true,
+                IdentifierNameSyntax => true,
+                GenericNameSyntax => true,
+                QualifiedNameSyntax => true,
+                AliasQualifiedNameSyntax => true,
+                _ => false,
+            };
+    }
+}
+
+internal record GenerationResult(
+    string Contracts,
+    IReadOnlyCollection<GeneratedCode> Interfaces,
+    string SerializerContext,
+    string DependencyInjectionCode,
+    string[] InterfaceNames);

--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -1,8 +1,5 @@
 using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NSwag;
 
 namespace Refitter.Core;
@@ -12,15 +9,7 @@ namespace Refitter.Core;
 /// </summary>
 public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument document)
 {
-    private static readonly Regex JsonStringEnumConverterAttributeRegex = new(
-        @"^\s*\[(System\.Text\.Json\.Serialization\.)?JsonConverter\(typeof\((System\.Text\.Json\.Serialization\.)?JsonStringEnumConverter(?:<[\w.]+>)?\)\)\]\s*\r?\n?",
-        RegexOptions.Compiled | RegexOptions.Multiline,
-        TimeSpan.FromSeconds(1));
-
-    private static readonly Regex EnumDeclarationRegex = new(
-        @"^(\s*)((?:public|internal)\s+(?:partial\s+)?enum\s+\w+\b)",
-        RegexOptions.Compiled | RegexOptions.Multiline,
-        TimeSpan.FromSeconds(1));
+    private readonly GeneratorPipeline pipeline = new();
 
     /// <summary>
     /// OpenAPI specifications used to generate Refit clients and interfaces.
@@ -142,302 +131,99 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
     /// Generates Refit clients and interfaces based on an OpenAPI specification and returns the generated code as a string.
     /// </summary>
     /// <returns>The generated code as a string.</returns>
-    public string Generate()
-    {
-        var factory = new CSharpClientGeneratorFactory(settings, document);
-        var generator = factory.Create();
-        var docGenerator = new XmlDocumentationGenerator(settings);
-
-        // Create the interface generator before calling GenerateFile() so that
-        // OperationNameGenerator.CheckForDuplicateOperationIds() sees the original
-        // (pre-generation) operation IDs. GenerateFile() auto-populates operation IDs
-        // with globally unique names which would prevent the switch to the path segments
-        // generator, causing unnecessary numeric suffixes in ByTag mode.
-        var interfaceGenerator = new InterfaceGenerator(settings, document, generator, docGenerator);
-
-        var contracts = generator.GenerateFile();
-        contracts = SanitizeGeneratedContracts(contracts);
-        var serializerContext = GenerateJsonSerializerContext(contracts);
-
-        if (settings.GenerateClients)
-        {
-            contracts = RefitInterfaceImports
-                .GetImportedNamespaces(settings)
-                .Aggregate(
-                    contracts,
-                    (current, import) => current.Replace($"{import}.", string.Empty));
-        }
-
-        var refitInterfaces = GenerateClient(interfaceGenerator);
-        var interfaceNames = refitInterfaces.Select(c => c.TypeName).ToArray();
-        var refitInterfacesCode = string.Join("", refitInterfaces.Select(c => c.Content));
-        var title = settings.Naming.UseOpenApiTitle && !string.IsNullOrWhiteSpace(document.Info?.Title)
-            ? document.Info!.Title.Sanitize()
-            : settings.Naming.InterfaceName;
-        var result = new StringBuilder()
-            .AppendLine(settings.GenerateClients ? refitInterfacesCode : string.Empty)
-            .AppendLine()
-            .AppendLine(settings.GenerateContracts ? contracts : string.Empty)
-            .AppendLine(serializerContext)
-            .AppendLine(
-                settings.ApizrSettings != null
-                    ? ApizrRegistrationGenerator.Generate(settings, interfaceNames, title)
-                    : DependencyInjectionGenerator.Generate(settings, interfaceNames))
-            .ToString()
-            .TrimEnd();
-
-        var contractTypeSuffix = settings.ContractTypeSuffix;
-        if (contractTypeSuffix is not null && !string.IsNullOrWhiteSpace(contractTypeSuffix))
-        {
-            result = ContractTypeSuffixApplier.ApplySuffix(result, contractTypeSuffix);
-        }
-
-        return result;
-    }
+    public string Generate() => FormatSingleFile(RunPipeline());
 
     /// <summary>
     /// Generates multiple files containing Refit interfaces and contracts.
     /// </summary>
     /// <returns>A GeneratorOutput containing all generated code files.</returns>
-    public GeneratorOutput GenerateMultipleFiles()
+    public GeneratorOutput GenerateMultipleFiles() => new(FormatMultipleFiles(RunPipeline()));
+
+    private GenerationResult RunPipeline()
     {
         var factory = new CSharpClientGeneratorFactory(settings, document);
         var generator = factory.Create();
-        var docGenerator = new XmlDocumentationGenerator(settings);
+        return pipeline.Run(document, settings, generator);
+    }
 
-        // Create the interface generator before calling GenerateFile() so that
-        // OperationNameGenerator.CheckForDuplicateOperationIds() sees the original
-        // (pre-generation) operation IDs. GenerateFile() auto-populates operation IDs
-        // with globally unique names which would prevent the switch to the path segments
-        // generator, causing unnecessary numeric suffixes in ByTag mode.
-        var interfaceGenerator = new InterfaceGenerator(settings, document, generator, docGenerator);
+    private string SanitizeGeneratedContracts(string contracts) =>
+        GeneratorPipeline.SanitizeGeneratedContracts(document, settings, contracts);
 
-        var contracts = generator.GenerateFile();
-        contracts = SanitizeGeneratedContracts(contracts);
-        var serializerContext = GenerateJsonSerializerContext(contracts);
+    private string NormalizeSwagger2OptionalReferencePropertyNullability(string contracts) =>
+        GeneratorPipeline.NormalizeSwagger2OptionalReferencePropertyNullability(document, settings, contracts);
 
-        var generatedFiles = new List<GeneratedCode>();
+    private string GenerateJsonSerializerContext(string contracts) =>
+        GeneratorPipeline.GenerateJsonSerializerContext(document, settings, contracts);
 
-        var refitInterfaces = GenerateClient(interfaceGenerator);
-        generatedFiles.AddRange(refitInterfaces);
+    private string FormatSingleFile(GenerationResult result)
+    {
+        var contracts = settings.GenerateClients
+            ? RefitInterfaceImports
+                .GetImportedNamespaces(settings)
+                .Aggregate(
+                    result.Contracts,
+                    (current, import) => current.Replace($"{import}.", string.Empty))
+            : result.Contracts;
+
+        var output = new StringBuilder()
+            .AppendLine(settings.GenerateClients ? string.Join("", result.Interfaces.Select(c => c.Content)) : string.Empty)
+            .AppendLine()
+            .AppendLine(settings.GenerateContracts ? contracts : string.Empty)
+            .AppendLine(result.SerializerContext)
+            .AppendLine(result.DependencyInjectionCode)
+            .ToString()
+            .TrimEnd();
+
+        return ApplyContractTypeSuffix(output);
+    }
+
+    private IReadOnlyList<GeneratedCode> FormatMultipleFiles(GenerationResult result)
+    {
+        var generatedFiles = new List<GeneratedCode>(result.Interfaces);
 
         if (settings.GenerateContracts)
         {
-            generatedFiles.Add(
-                new GeneratedCode(
-                    TypenameConstants.Contracts,
-                    contracts));
+            generatedFiles.Add(new GeneratedCode(TypenameConstants.Contracts, result.Contracts));
         }
 
-        if (!string.IsNullOrWhiteSpace(serializerContext))
+        if (!string.IsNullOrWhiteSpace(result.SerializerContext))
         {
             generatedFiles.Add(
                 new GeneratedCode(
                     JsonSerializerContextGenerator.GetContextTypeName(settings, document.Info?.Title),
-                    serializerContext));
+                    result.SerializerContext));
         }
 
-        if (settings.DependencyInjectionSettings is not null || settings.ApizrSettings is not null)
+        if (!string.IsNullOrWhiteSpace(result.DependencyInjectionCode))
         {
-            var title = settings.Naming.UseOpenApiTitle && !string.IsNullOrWhiteSpace(document.Info?.Title)
-                ? document.Info!.Title.Sanitize()
-                : settings.Naming.InterfaceName;
-
-            var interfaceNames = refitInterfaces.Select(c => c.TypeName).ToArray();
-            var configurationCode = settings.ApizrSettings != null
-                ? ApizrRegistrationGenerator.Generate(settings, interfaceNames, title)
-                : DependencyInjectionGenerator.Generate(settings, interfaceNames);
-
-            if (!string.IsNullOrWhiteSpace(configurationCode))
-            {
-                generatedFiles.Add(
-                    new GeneratedCode(
-                        TypenameConstants.DependencyInjection,
-                        configurationCode));
-            }
+            generatedFiles.Add(
+                new GeneratedCode(
+                    TypenameConstants.DependencyInjection,
+                    result.DependencyInjectionCode));
         }
 
+        return ApplyContractTypeSuffix(generatedFiles);
+    }
+
+    private string ApplyContractTypeSuffix(string content)
+    {
         var contractTypeSuffix = settings.ContractTypeSuffix;
-        if (contractTypeSuffix is not null && !string.IsNullOrWhiteSpace(contractTypeSuffix))
-        {
-            generatedFiles = generatedFiles
+        return contractTypeSuffix is not null && !string.IsNullOrWhiteSpace(contractTypeSuffix)
+            ? ContractTypeSuffixApplier.ApplySuffix(content, contractTypeSuffix)
+            : content;
+    }
+
+    private IReadOnlyList<GeneratedCode> ApplyContractTypeSuffix(IReadOnlyList<GeneratedCode> generatedFiles)
+    {
+        var contractTypeSuffix = settings.ContractTypeSuffix;
+        return contractTypeSuffix is not null && !string.IsNullOrWhiteSpace(contractTypeSuffix)
+            ? generatedFiles
                 .Select(f => f with
                 {
                     Content = ContractTypeSuffixApplier.ApplySuffix(f.Content, contractTypeSuffix)
                 })
-                .ToList();
-        }
-
-        return new GeneratorOutput(generatedFiles);
+                .ToList()
+            : generatedFiles;
     }
 
-    private IInterfacePartitioning GetInterfacePartitioning()
-    {
-        return settings.MultipleInterfaces switch
-        {
-            MultipleInterfaces.ByEndpoint => new ByEndpointInterfacePartitioning(settings),
-            MultipleInterfaces.ByTag => new ByTagInterfacePartitioning(settings, document),
-            _ => new SingleInterfacePartitioning(settings),
-        };
-    }
-
-    private string SanitizeGeneratedContracts(string contracts)
-    {
-        contracts = NormalizeSwagger2OptionalReferencePropertyNullability(contracts);
-
-        if (settings.CodeGeneratorSettings is not { InlineJsonConverters: false })
-        {
-            // InlineJsonConverters = true (default): move [JsonConverter] from enum properties to enum type declarations.
-            // This allows users to override the converter via JsonSerializerOptions.Converters (e.g. to use
-            // JsonStringEnumMemberConverter for enums with [EnumMember] values containing special characters).
-            contracts = JsonStringEnumConverterAttributeRegex.Replace(contracts, string.Empty);
-            var newLine = GetPreferredNewLine(contracts);
-            return EnumDeclarationRegex
-                .Replace(
-                    contracts,
-                    match =>
-                        $"{match.Groups[1].Value}[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]{newLine}{match.Groups[1].Value}{match.Groups[2].Value}")
-                .TrimEnd();
-        }
-
-        // InlineJsonConverters = false: remove all [JsonConverter(typeof(JsonStringEnumConverter))] attributes.
-        return JsonStringEnumConverterAttributeRegex
-            .Replace(contracts, string.Empty)
-            .TrimEnd();
-    }
-
-    private static string GetPreferredNewLine(string content) =>
-        content.Contains("\r\n", StringComparison.Ordinal)
-            ? "\r\n"
-            : "\n";
-
-    private string NormalizeSwagger2OptionalReferencePropertyNullability(string contracts)
-    {
-        if (document.SchemaType != NJsonSchema.SchemaType.Swagger2 ||
-            settings.CodeGeneratorSettings?.GenerateNullableReferenceTypes != true ||
-            settings.CodeGeneratorSettings.GenerateOptionalPropertiesAsNullable)
-        {
-            return contracts;
-        }
-
-        var tree = CSharpSyntaxTree.ParseText(contracts);
-        var root = tree.GetCompilationUnitRoot();
-        var rewrittenRoot = new Swagger2OptionalReferencePropertyNullabilityRewriter().Visit(root);
-        return rewrittenRoot!.ToFullString();
-    }
-
-    private sealed class Swagger2OptionalReferencePropertyNullabilityRewriter : CSharpSyntaxRewriter
-    {
-        public override SyntaxNode? VisitPropertyDeclaration(PropertyDeclarationSyntax node)
-        {
-            if (node.Type is NullableTypeSyntax nullableType &&
-                IsReferenceType(nullableType.ElementType))
-            {
-                node = node.WithType(nullableType.ElementType.WithTriviaFrom(node.Type));
-            }
-
-            return base.VisitPropertyDeclaration(node);
-        }
-
-        private static bool IsReferenceType(TypeSyntax typeSyntax) =>
-            typeSyntax switch
-            {
-                PredefinedTypeSyntax predefinedType => predefinedType.Keyword.Kind() is SyntaxKind.ObjectKeyword or SyntaxKind.StringKeyword,
-                ArrayTypeSyntax => true,
-                IdentifierNameSyntax => true,
-                GenericNameSyntax => true,
-                QualifiedNameSyntax => true,
-                AliasQualifiedNameSyntax => true,
-                _ => false,
-            };
-    }
-
-    private string GenerateJsonSerializerContext(string contracts) =>
-        settings.GenerateJsonSerializerContext && settings.GenerateContracts
-            ? JsonSerializerContextGenerator.Generate(contracts, settings, document.Info?.Title)
-            : string.Empty;
-
-    /// <summary>
-    /// Generates the client code based on the specified interface generator.
-    /// </summary>
-    /// <param name="interfaceGenerator">The interface generator used to generate the client code.</param>
-    /// <returns>The generated client code as a string.</returns>
-    private IReadOnlyCollection<GeneratedCode> GenerateClient(InterfaceGenerator interfaceGenerator)
-    {
-        var code = new StringBuilder();
-        GenerateAutoGeneratedHeader(code);
-
-        code.AppendLine()
-            .AppendLine(RefitInterfaceImports.GenerateNamespaceImports(settings))
-            .AppendLine();
-
-        if (settings.AdditionalNamespaces.Any())
-        {
-            foreach (var ns in settings.AdditionalNamespaces)
-            {
-                code.AppendLine($"using {ns};");
-            }
-
-            code.AppendLine();
-        }
-
-        code.AppendLine("#nullable enable annotations");
-        code.AppendLine();
-
-        var partitioning = GetInterfacePartitioning();
-        var refitInterfaces = interfaceGenerator.Generate(partitioning);
-        var generatedCodes = refitInterfaces as GeneratedCode[] ?? refitInterfaces.ToArray();
-
-        if (settings.GenerateMultipleFiles)
-        {
-            for (int i = 0; i < generatedCodes.Length; i++)
-            {
-                generatedCodes[i] = generatedCodes[i] with
-                {
-                    Content = code +
-                              $$"""
-                                namespace {{settings.Namespace}}
-                                {
-                                {{generatedCodes[i].Content}}
-                                }
-                                """
-                };
-            }
-            return generatedCodes;
-        }
-
-        code.AppendLine($"namespace {settings.Namespace}");
-        code.AppendLine("{");
-
-        foreach (var generatedCode in generatedCodes)
-        {
-            code.AppendLine(generatedCode.Content);
-        }
-
-        code.Append("}");
-
-        return new[] { new GeneratedCode(generatedCodes.First().TypeName, code.ToString()) }
-            .Union(
-                generatedCodes
-                    .Skip(1)
-                    .Select(c => new GeneratedCode(c.TypeName, string.Empty)))
-            .ToArray();
-    }
-
-    /// <summary>
-    /// Generates the auto-generated header if the setting is enabled.
-    /// </summary>
-    /// <param name="code">The string builder to append the header to.</param>
-    private void GenerateAutoGeneratedHeader(StringBuilder code)
-    {
-        if (!settings.AddAutoGeneratedHeader)
-            return;
-
-        code.AppendLine("""
-            // <auto-generated>
-            //     This code was generated by Refitter.
-            // </auto-generated>
-
-            """);
-    }
 }

--- a/src/Refitter.Tests/GeneratorPipelineTests.cs
+++ b/src/Refitter.Tests/GeneratorPipelineTests.cs
@@ -1,0 +1,136 @@
+using FluentAssertions;
+using NSwag;
+using Refitter.Core;
+using TUnit.Core;
+
+namespace Refitter.Tests;
+
+public class GeneratorPipelineTests
+{
+    private const string OpenApiSpec = """
+        {
+          "openapi": "3.0.0",
+          "info": {
+            "title": "Test API",
+            "version": "1.0.0"
+          },
+          "paths": {
+            "/api/products": {
+              "get": {
+                "operationId": "getProducts",
+                "responses": {
+                  "200": {
+                    "description": "Success",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Product"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "components": {
+            "schemas": {
+              "Product": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    private const string ByTagOpenApiSpec = """
+        openapi: '3.0.0'
+        info:
+          title: 'Test API'
+          version: '1.0'
+        paths:
+          /api/manage/info:
+            get:
+              tags:
+              - 'Manage'
+              responses:
+                '200':
+                  description: 'ok'
+          /api/account/info:
+            get:
+              tags:
+              - 'Account'
+              responses:
+                '200':
+                  description: 'ok'
+          /api/user/info:
+            get:
+              tags:
+              - 'User'
+              responses:
+                '200':
+                  description: 'ok'
+        """;
+
+    [Test]
+    public async Task Run_Returns_All_Generated_Artifacts()
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            GenerateMultipleFiles = true,
+            GenerateJsonSerializerContext = true,
+            DependencyInjectionSettings = new DependencyInjectionSettings
+            {
+                BaseUrl = "https://api.example.com",
+                HttpMessageHandlers = [],
+                TransientErrorHandler = TransientErrorHandler.None,
+                MaxRetryCount = 3,
+                FirstBackoffRetryInSeconds = 0.5
+            }
+        };
+        var document = await OpenApiDocument.FromJsonAsync(OpenApiSpec);
+
+        var result = RunPipeline(document, settings);
+
+        result.Contracts.Should().Contain("public partial class Product");
+        result.Interfaces.Should().ContainSingle();
+        result.Interfaces.Single().Content.Should().Contain("partial interface");
+        result.SerializerContext.Should().Contain("JsonSerializable(typeof(Product))");
+        result.DependencyInjectionCode.Should().Contain("AddRefitClient");
+        result.InterfaceNames.Should().Equal(result.Interfaces.Select(code => code.TypeName));
+    }
+
+    [Test]
+    public async Task Run_ByTag_Preserves_PreGeneration_OperationIds_For_Interface_Naming()
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            GenerateMultipleFiles = true,
+            MultipleInterfaces = MultipleInterfaces.ByTag
+        };
+        var document = await OpenApiYamlDocument.FromYamlAsync(ByTagOpenApiSpec);
+
+        var result = RunPipeline(document, settings);
+        var combinedInterfaces = string.Join("\n", result.Interfaces.Select(code => code.Content));
+
+        result.InterfaceNames.Should().Contain(["IManageApi", "IAccountApi", "IUserApi"]);
+        combinedInterfaces.Should().NotContainAny("Info2(", "Info3(", "InfoGet2(", "InfoGet3(", "InfoGET2(", "InfoGET3(");
+    }
+
+    private static GenerationResult RunPipeline(OpenApiDocument document, RefitGeneratorSettings settings)
+    {
+        var generator = new CSharpClientGeneratorFactory(settings, document).Create();
+        return new GeneratorPipeline().Run(document, settings, generator);
+    }
+}


### PR DESCRIPTION
Closes #1116 

Refactors `RefitGenerator` so generation orchestration is defined once and reused by both single-file and multi-file output paths. The generated code shape stays the same; the change is in how artifacts are produced and packaged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved generation: Swagger2 nullable reference handling, optional JSON serializer context, configurable enum converter handling, flexible interface partitioning (single/by-endpoint/by-tag), and optional dependency-injection code output.
* **Refactor**
  * Centralized end-to-end generation pipeline and simplified output formatting for contracts, interfaces, serializers, and DI.
* **Tests**
  * Added pipeline tests covering output, interface-naming strategies, and compilability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->