### PR TITLE
Refactor RefitGenerator to add synchronous factory method and fix RS1035

### DIFF
--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -25,6 +25,9 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
     /// <returns>A new instance of the <see cref="RefitGenerator"/> class.</returns>
     public static RefitGenerator Create(OpenApiDocument document, RefitGeneratorSettings settings)
     {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        if (settings == null) throw new ArgumentNullException(nameof(settings));
+
         ProcessTagFilters(document, settings.IncludeTags);
         ProcessPathFilters(document, settings.IncludePathMatches);
         ProcessContractFilter(document, settings.TrimUnusedSchema, settings.KeepSchemaPatterns, settings.IncludeInheritanceHierarchy);

--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -17,6 +17,22 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
     public OpenApiDocument OpenApiDocument => document;
 
     /// <summary>
+    /// Creates a new instance of the <see cref="RefitGenerator"/> class synchronously
+    /// from a pre-loaded <see cref="OpenApiDocument"/>.
+    /// </summary>
+    /// <param name="document">The pre-loaded OpenAPI document.</param>
+    /// <param name="settings">The settings used to configure the generator.</param>
+    /// <returns>A new instance of the <see cref="RefitGenerator"/> class.</returns>
+    public static RefitGenerator Create(OpenApiDocument document, RefitGeneratorSettings settings)
+    {
+        ProcessTagFilters(document, settings.IncludeTags);
+        ProcessPathFilters(document, settings.IncludePathMatches);
+        ProcessContractFilter(document, settings.TrimUnusedSchema, settings.KeepSchemaPatterns, settings.IncludeInheritanceHierarchy);
+
+        return new RefitGenerator(settings, document);
+    }
+
+    /// <summary>
     /// Creates a new instance of the <see cref="RefitGenerator"/> class asynchronously.
     /// </summary>
     /// <param name="settings">The settings used to configure the generator.</param>
@@ -24,12 +40,7 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
     public static async Task<RefitGenerator> CreateAsync(RefitGeneratorSettings settings)
     {
         var openApiDocument = await GetOpenApiDocument(settings).ConfigureAwait(false);
-
-        ProcessTagFilters(openApiDocument, settings.IncludeTags);
-        ProcessPathFilters(openApiDocument, settings.IncludePathMatches);
-        ProcessContractFilter(openApiDocument, settings.TrimUnusedSchema, settings.KeepSchemaPatterns, settings.IncludeInheritanceHierarchy);
-
-        return new RefitGenerator(settings, openApiDocument);
+        return Create(openApiDocument, settings);
     }
 
     private static async Task<OpenApiDocument> GetOpenApiDocument(RefitGeneratorSettings settings)

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -60,10 +60,6 @@ public class RefitterSourceGenerator : IIncrementalGenerator
         }
     }
 
-    [SuppressMessage(
-        "MicrosoftCodeAnalysisCorrectness",
-        "RS1035:Do not use APIs banned for analyzers",
-        Justification = "By design")]
     internal static GeneratedCode GenerateCode(
         AdditionalText file,
         CancellationToken cancellationToken = default)
@@ -105,8 +101,6 @@ public class RefitterSourceGenerator : IIncrementalGenerator
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Create unique hint name based on the full .refitter file path to avoid collisions
-            // when multiple .refitter files with the same name exist in different directories
             var hintName = CreateUniqueHintName(file.Path, settings.OutputFilename);
 
             return new GeneratedCode(diagnostics.ToImmutableArray().AsEquatableArray(), refit, hintName);
@@ -158,7 +152,8 @@ public class RefitterSourceGenerator : IIncrementalGenerator
 
     private static void ResolveRelativeSpecPaths(string settingsFilePath, RefitGeneratorSettings settings)
     {
-        var settingsFileDirectory = Path.GetDirectoryName(Path.GetFullPath(settingsFilePath)) ?? string.Empty;
+        var lastSep = settingsFilePath.LastIndexOfAny(new[] { '/', '\\' });
+        var settingsFileDirectory = lastSep >= 0 ? settingsFilePath.Substring(0, lastSep) : string.Empty;
         RefitterSettingsLoader.ResolveRelativeSpecPaths(settings, settingsFileDirectory);
     }
 
@@ -215,37 +210,33 @@ public class RefitterSourceGenerator : IIncrementalGenerator
                 diagnostic.EnabledByDefault),
             Location.None);
 
-    /// <summary>
-    /// Creates a unique hint name for AddSource that prevents collisions when multiple
-    /// .refitter files with the same name exist in different directories.
-    /// </summary>
-    /// <param name="refitterFilePath">The full path to the .refitter file</param>
-    /// <param name="outputFilename">Optional explicit output filename from settings</param>
-    /// <returns>A unique hint name safe for AddSource</returns>
     private static string CreateUniqueHintName(string refitterFilePath, string? outputFilename)
     {
-        // If an explicit output filename is set, use it as the base for the hint name
-        // but still include path disambiguation to prevent collisions
         var baseName = !string.IsNullOrWhiteSpace(outputFilename)
-            ? Path.GetFileNameWithoutExtension(outputFilename)
-            : Path.GetFileNameWithoutExtension(refitterFilePath);
+            ? GetFileNameWithoutExtension(outputFilename!)
+            : GetFileNameWithoutExtension(refitterFilePath);
 
         if (string.IsNullOrEmpty(baseName) || baseName == ".")
         {
             baseName = RefitterDiagnosticTitle;
         }
 
-        // Create a stable unique suffix from the full .refitter path so files in the same
-        // directory can still coexist even when they share the same explicit output filename.
         if (!string.IsNullOrWhiteSpace(refitterFilePath))
         {
-            var normalizedPath = Path.GetFullPath(refitterFilePath)
-                .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            var normalizedPath = refitterFilePath.Replace('/', '\\');
             var pathHash = GetStableHash(normalizedPath);
             return $"{baseName}_{pathHash}.g.cs";
         }
 
         return $"{baseName}.g.cs";
+    }
+
+    private static string GetFileNameWithoutExtension(string path)
+    {
+        var lastSep = path.LastIndexOfAny(new[] { '/', '\\' });
+        var fileName = lastSep >= 0 ? path.Substring(lastSep + 1) : path;
+        var lastDot = fileName.LastIndexOf('.');
+        return lastDot >= 0 ? fileName.Substring(0, lastDot) : fileName;
     }
 
     /// <summary>

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -153,7 +153,23 @@ public class RefitterSourceGenerator : IIncrementalGenerator
     private static void ResolveRelativeSpecPaths(string settingsFilePath, RefitGeneratorSettings settings)
     {
         var lastSep = settingsFilePath.LastIndexOfAny(new[] { '/', '\\' });
-        var settingsFileDirectory = lastSep >= 0 ? settingsFilePath.Substring(0, lastSep) : string.Empty;
+        string settingsFileDirectory;
+        if (lastSep < 0)
+        {
+            settingsFileDirectory = string.Empty;
+        }
+        else if (lastSep == 0)
+        {
+            settingsFileDirectory = settingsFilePath.Substring(0, 1);
+        }
+        else if (lastSep == 2 && settingsFilePath.Length > 1 && settingsFilePath[1] == ':')
+        {
+            settingsFileDirectory = settingsFilePath.Substring(0, lastSep + 1);
+        }
+        else
+        {
+            settingsFileDirectory = settingsFilePath.Substring(0, lastSep);
+        }
         RefitterSettingsLoader.ResolveRelativeSpecPaths(settings, settingsFileDirectory);
     }
 


### PR DESCRIPTION
Closes #1120 

Add RefitGenerator.Create(OpenApiDocument, RefitGeneratorSettings) sync factory method to provide a synchronous entry point for source generators. RefitGenerator.CreateAsync now delegates to Create after loading the document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New synchronous factory option to create the generator directly from a loaded OpenAPI document.

* **Changes**
  * Improved determinism of generated-source filenames and output paths for .refitter-driven generation.
  * Adjusted resolution of relative specification paths to change how referenced spec files are located during generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->