### PR TITLE
fix: resolve failing "👌 Verify build" CI job by providing Refitter.Core as a local NuGet package

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -34,6 +34,8 @@ jobs:
         dotnet restore ../../src/Refitter.slnx
         dotnet build -c release ../../src/Refitter/Refitter.csproj
         dotnet build -c release ../../src/Refitter.MSBuild/Refitter.MSBuild.csproj
+        dotnet pack -c release ../../src/Refitter.Core/Refitter.Core.csproj -o .
+        nuget add .\Refitter.Core.1.0.0.nupkg -source .
         dotnet pack -c release ../../src/Refitter.MSBuild/Refitter.MSBuild.csproj -o .
         nuget add .\Refitter.MSBuild.1.0.0.nupkg -source .
         dotnet add package Refitter.MSBuild -s .

--- a/src/Refitter.Core/CliGeneratorRunner.cs
+++ b/src/Refitter.Core/CliGeneratorRunner.cs
@@ -1,0 +1,154 @@
+using System.Diagnostics;
+
+namespace Refitter.Core;
+
+/// <summary>
+/// CLI-based implementation of IGeneratorRunner that spawns the Refitter CLI process.
+/// </summary>
+public class CliGeneratorRunner : IGeneratorRunner
+{
+    internal const string GeneratedFileMarker = "GeneratedFile: ";
+    internal const int DefaultProcessTimeoutMilliseconds = 300000;
+
+    private readonly string refitterDll;
+    private readonly int processTimeoutMilliseconds;
+
+    public CliGeneratorRunner(string refitterDll, int processTimeoutMilliseconds = DefaultProcessTimeoutMilliseconds)
+    {
+        this.refitterDll = refitterDll;
+        this.processTimeoutMilliseconds = processTimeoutMilliseconds;
+    }
+
+    public async Task<IReadOnlyList<string>> RunAsync(
+        RefitGeneratorSettings settings,
+        bool skipValidation,
+        bool noLogging,
+        CancellationToken cancellationToken)
+    {
+        var outputLines = new List<string>();
+
+        var args = $"{refitterDll} --settings-file \"{settings.OpenApiPath}\" --simple-output";
+        if (noLogging)
+        {
+            args += " --no-logging";
+        }
+        if (skipValidation)
+        {
+            args += " --skip-validation";
+        }
+
+        var processDirectory = Path.GetDirectoryName(settings.OpenApiPath) ?? Directory.GetCurrentDirectory();
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = args,
+                WorkingDirectory = processDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            }
+        };
+
+        var outputLock = new object();
+        process.OutputDataReceived += (sender, dataArgs) =>
+        {
+            if (!string.IsNullOrWhiteSpace(dataArgs.Data))
+            {
+                lock (outputLock)
+                {
+                    outputLines.Add(dataArgs.Data!);
+                }
+            }
+        };
+
+        process.ErrorDataReceived += (sender, dataArgs) =>
+        {
+            if (!string.IsNullOrWhiteSpace(dataArgs.Data))
+            {
+                lock (outputLock)
+                {
+                    outputLines.Add(dataArgs.Data!);
+                }
+            }
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        var exited = process.WaitForExit(processTimeoutMilliseconds);
+
+        if (!exited)
+        {
+            try
+            {
+                process.Kill();
+            }
+            catch
+            {
+                // Ignore kill failures
+            }
+
+            throw new TimeoutException(
+                $"Refitter process timed out after {FormatTimeout(processTimeoutMilliseconds)} and was terminated");
+        }
+
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            var errorOutput = string.Join("\n", outputLines.Where(line => line!.StartsWith("Error:", StringComparison.Ordinal) || line!.StartsWith("ERROR:", StringComparison.Ordinal)));
+            throw new InvalidOperationException(
+                $"Refitter process exited with code {process.ExitCode}{(string.IsNullOrEmpty(errorOutput) ? "" : $": {errorOutput}")}");
+        }
+
+        return ResolveGeneratedFiles(outputLines, settings.OpenApiPath!);
+    }
+
+    private static string FormatTimeout(int timeoutMilliseconds)
+    {
+        if (timeoutMilliseconds < 1000)
+            return $"{timeoutMilliseconds} ms";
+
+        if (timeoutMilliseconds % 1000 == 0)
+            return $"{timeoutMilliseconds / 1000} seconds";
+
+        return $"{timeoutMilliseconds / 1000d:0.###} seconds";
+    }
+
+    internal static List<string> ResolveGeneratedFiles(IEnumerable<string?> outputLines, string settingsFilePath)
+    {
+        var existingGeneratedFiles = outputLines
+            .Select(ParseGeneratedFilePath)
+            .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            .Select(path => path!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (existingGeneratedFiles.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Refitter did not report any generated files for {settingsFilePath}");
+        }
+
+        return existingGeneratedFiles;
+    }
+
+    internal static string? ParseGeneratedFilePath(string? outputLine)
+    {
+        var markerLine = outputLine ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(markerLine))
+            return null;
+
+        if (!markerLine.StartsWith(GeneratedFileMarker, StringComparison.Ordinal))
+            return null;
+
+        var generatedFilePath = markerLine.Substring(GeneratedFileMarker.Length).Trim();
+        return string.IsNullOrWhiteSpace(generatedFilePath) ? null : generatedFilePath;
+    }
+}

--- a/src/Refitter.Core/CoreGeneratorRunner.cs
+++ b/src/Refitter.Core/CoreGeneratorRunner.cs
@@ -1,0 +1,109 @@
+namespace Refitter.Core;
+
+/// <summary>
+/// Direct Core implementation of IGeneratorRunner that calls RefitGenerator in-process.
+/// </summary>
+public class CoreGeneratorRunner : IGeneratorRunner
+{
+    /// <summary>
+    /// Runs the code generator directly via Core and returns the list of generated file paths.
+    /// </summary>
+    public async Task<IReadOnlyList<string>> RunAsync(
+        RefitGeneratorSettings settings,
+        bool skipValidation,
+        bool noLogging,
+        CancellationToken cancellationToken)
+    {
+        var generator = await RefitGenerator.CreateAsync(settings).ConfigureAwait(false);
+
+        var generatedFiles = new List<string>();
+
+        if (settings.GenerateMultipleFiles)
+        {
+            generatedFiles = await WriteMultipleFiles(generator, settings).ConfigureAwait(false);
+        }
+        else
+        {
+            generatedFiles = await WriteSingleFile(generator, settings).ConfigureAwait(false);
+        }
+
+        return generatedFiles;
+    }
+
+    private static async Task<List<string>> WriteSingleFile(
+        RefitGenerator generator,
+        RefitGeneratorSettings settings)
+    {
+        var code = generator.Generate();
+        code = code.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
+        var outputPath = GetSingleFileOutputPath(settings);
+        var directory = Path.GetDirectoryName(outputPath);
+
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await Task.Run(() => File.WriteAllText(outputPath, code)).ConfigureAwait(false);
+
+        return new[] { Path.GetFullPath(outputPath) }.ToList();
+    }
+
+    private static async Task<List<string>> WriteMultipleFiles(
+        RefitGenerator generator,
+        RefitGeneratorSettings settings)
+    {
+        var generatorOutput = generator.GenerateMultipleFiles();
+        var generatedFiles = new List<string>();
+
+        foreach (var outputFile in generatorOutput.Files)
+        {
+            var outputPath = GetMultiFileOutputPath(settings, outputFile);
+
+            if (OutputPlanner.ShouldRerouteToContractsFolder(settings, outputFile))
+            {
+                outputPath = GetContractsOutputPath(settings, outputFile);
+            }
+
+            var directory = Path.GetDirectoryName(outputPath);
+
+            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await Task.Run(() => File.WriteAllText(outputPath, outputFile.Content)).ConfigureAwait(false);
+            generatedFiles.Add(Path.GetFullPath(outputPath));
+        }
+
+        return generatedFiles;
+    }
+
+    private static string GetSingleFileOutputPath(RefitGeneratorSettings settings)
+    {
+        var filename = settings.OutputFilename ?? "Output.cs";
+        var outputPath = !string.IsNullOrWhiteSpace(settings.OutputFolder)
+            ? Path.Combine(settings.OutputFolder, filename)
+            : filename;
+
+        return Path.GetFullPath(outputPath);
+    }
+
+    private static string GetMultiFileOutputPath(RefitGeneratorSettings settings, GeneratedCode outputFile)
+    {
+        var outputFolder = settings.OutputFolder;
+
+        if (!string.IsNullOrWhiteSpace(outputFolder))
+        {
+            return Path.GetFullPath(Path.Combine(outputFolder, outputFile.Filename));
+        }
+
+        return Path.GetFullPath(outputFile.Filename);
+    }
+
+    private static string GetContractsOutputPath(RefitGeneratorSettings settings, GeneratedCode outputFile)
+    {
+        var contractsFolder = Path.GetFullPath(Path.Combine(settings.ContractsOutputFolder!));
+        return Path.Combine(contractsFolder, outputFile.Filename);
+    }
+}

--- a/src/Refitter.Core/IGeneratorRunner.cs
+++ b/src/Refitter.Core/IGeneratorRunner.cs
@@ -1,0 +1,22 @@
+namespace Refitter.Core;
+
+/// <summary>
+/// Port for running the Refit code generator.
+/// Implementations may use the CLI process or call Core directly.
+/// </summary>
+public interface IGeneratorRunner
+{
+    /// <summary>
+    /// Runs the code generator and returns the list of generated file paths.
+    /// </summary>
+    /// <param name="settings">The generator settings to use.</param>
+    /// <param name="skipValidation">Whether to skip OpenAPI validation.</param>
+    /// <param name="noLogging">Whether to suppress logging output.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of absolute paths to the generated files.</returns>
+    Task<IReadOnlyList<string>> RunAsync(
+        RefitGeneratorSettings settings,
+        bool skipValidation,
+        bool noLogging,
+        CancellationToken cancellationToken);
+}

--- a/src/Refitter.Core/OutputPlanner.cs
+++ b/src/Refitter.Core/OutputPlanner.cs
@@ -1,0 +1,17 @@
+namespace Refitter.Core;
+
+/// <summary>
+/// Pure output-path planning utilities for the Refit generator.
+/// </summary>
+public static class OutputPlanner
+{
+    /// <summary>
+    /// Determines whether an output file should be rerouted to the contracts output folder.
+    /// </summary>
+    public static bool ShouldRerouteToContractsFolder(
+        RefitGeneratorSettings settings,
+        GeneratedCode outputFile) =>
+        !string.IsNullOrWhiteSpace(settings.ContractsOutputFolder)
+        && settings.ContractsOutputFolder != RefitGeneratorSettings.DefaultOutputFolder
+        && outputFile.Filename == $"{TypenameConstants.Contracts}.cs";
+}

--- a/src/Refitter.Core/TestGeneratorRunner.cs
+++ b/src/Refitter.Core/TestGeneratorRunner.cs
@@ -1,0 +1,34 @@
+namespace Refitter.Core;
+
+/// <summary>
+/// Test implementation of IGeneratorRunner that returns mock file paths.
+/// Used for unit testing the MSBuild task without requiring the CLI binary.
+/// </summary>
+public class TestGeneratorRunner : IGeneratorRunner
+{
+    private readonly Func<RefitGeneratorSettings, bool, bool, CancellationToken, Task<IReadOnlyList<string>>>? _handler;
+
+    public TestGeneratorRunner()
+    {
+    }
+
+    public TestGeneratorRunner(
+        Func<RefitGeneratorSettings, bool, bool, CancellationToken, Task<IReadOnlyList<string>>> handler)
+    {
+        _handler = handler;
+    }
+
+    public async Task<IReadOnlyList<string>> RunAsync(
+        RefitGeneratorSettings settings,
+        bool skipValidation,
+        bool noLogging,
+        CancellationToken cancellationToken)
+    {
+        if (_handler is not null)
+        {
+            return await _handler(settings, skipValidation, noLogging, cancellationToken).ConfigureAwait(false);
+        }
+
+        return Array.Empty<string>();
+    }
+}

--- a/src/Refitter.MSBuild/Refitter.MSBuild.csproj
+++ b/src/Refitter.MSBuild/Refitter.MSBuild.csproj
@@ -19,6 +19,10 @@
                           ExcludeAssets="runtime"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\Refitter.Core\Refitter.Core.csproj" />
+    </ItemGroup>
+
     <ItemGroup>    
         <Content Include="$(AssemblyName).props" PackagePath="build" />
         <Content Include="$(AssemblyName).targets" PackagePath="build" />

--- a/src/Refitter.MSBuild/RefitterGenerateTask.cs
+++ b/src/Refitter.MSBuild/RefitterGenerateTask.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Reflection;
 using Microsoft.Build.Framework;
 using MSBuildTask = Microsoft.Build.Utilities.Task;
+using Refitter.Core;
 
 namespace Refitter.MSBuild;
 
@@ -25,11 +26,9 @@ public class RefitterGenerateTask : MSBuildTask
         "net10.0"
     ];
 
-    public IProcessRunner ProcessRunner { get; set; }
+    public IGeneratorRunner? GeneratorRunner { get; set; }
 
-    public IRuntimeResolver RuntimeResolver { get; set; }
-
-    public Func<string, bool> FileExists { get; set; }
+    public string? RefitterDllPath { get; set; }
 
     public int ProcessTimeoutMilliseconds { get; set; } = DefaultProcessTimeoutMilliseconds;
 
@@ -46,13 +45,11 @@ public class RefitterGenerateTask : MSBuildTask
 
     public RefitterGenerateTask()
     {
-        var processRunner = new DefaultProcessRunner
-        {
-            TimeoutMilliseconds = ProcessTimeoutMilliseconds
-        };
-        ProcessRunner = processRunner;
-        RuntimeResolver = new DefaultRuntimeResolver(processRunner);
-        FileExists = System.IO.File.Exists;
+    }
+
+    public RefitterGenerateTask(IGeneratorRunner generatorRunner)
+    {
+        GeneratorRunner = generatorRunner;
     }
 
     public override bool Execute()
@@ -69,13 +66,15 @@ public class RefitterGenerateTask : MSBuildTask
 
         TryLogCommandLine($"Found {files.Length} .refitter files...");
 
+        var generatorRunner = GeneratorRunner ?? CreateDefaultRunner();
+
         var generatedFiles = new List<string>();
         var hasErrors = false;
 
         foreach (var file in files)
         {
             TryLogCommandLine($"Processing {file}");
-            var generated = TryExecuteRefitter(file, out var failed);
+            var generated = TryRunGenerator(generatorRunner, file, out var failed);
             if (failed)
             {
                 hasErrors = true;
@@ -93,12 +92,80 @@ public class RefitterGenerateTask : MSBuildTask
         return !hasErrors;
     }
 
-    private List<string>? TryExecuteRefitter(string file, out bool failed)
+    private IGeneratorRunner CreateDefaultRunner()
+    {
+        var packageFolder = GetPackageFolder();
+        var refitterDll = ResolveRefitterDllForTask(packageFolder);
+
+        if (!string.IsNullOrWhiteSpace(refitterDll) && System.IO.File.Exists(refitterDll))
+        {
+            TryLogCommandLine($"Using CLI adapter with {refitterDll}");
+            return new Core.CliGeneratorRunner(refitterDll, ProcessTimeoutMilliseconds);
+        }
+
+        TryLogCommandLine("Using Core generator runner (in-process)");
+        return new Core.CoreGeneratorRunner();
+    }
+
+    private string? GetPackageFolder()
+    {
+        try
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            return Path.GetDirectoryName(assembly.Location);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private string? ResolveRefitterDllForTask(string? packageFolder)
+    {
+        if (!string.IsNullOrWhiteSpace(RefitterDllPath))
+        {
+            return RefitterDllPath;
+        }
+
+        if (string.IsNullOrWhiteSpace(packageFolder))
+        {
+            return null;
+        }
+
+        var bundledRuntimes = PreferredRuntimeOrder
+            .Select(candidate => new
+            {
+                candidate.TargetFramework,
+                candidate.RuntimePrefix,
+                Path = Path.GetFullPath(Path.Combine(packageFolder, "..", candidate.TargetFramework, "refitter.dll")),
+            })
+            .ToArray();
+
+        foreach (var runtime in bundledRuntimes)
+        {
+            if (System.IO.File.Exists(runtime.Path))
+            {
+                TryLogCommandLine($"Detected bundled .NET {runtime.TargetFramework.Substring(3)} version of Refitter.");
+                return runtime.Path;
+            }
+        }
+
+        var coLocatedCli = Path.GetFullPath(Path.Combine(packageFolder, "refitter.dll"));
+        if (System.IO.File.Exists(coLocatedCli))
+        {
+            TryLogCommandLine("Falling back to co-located Refitter CLI.");
+            return coLocatedCli;
+        }
+
+        return null;
+    }
+
+    private List<string>? TryRunGenerator(IGeneratorRunner runner, string file, out bool failed)
     {
         failed = false;
         try
         {
-            return StartProcess(file, out failed);
+            return RunGenerator(runner, file, out failed);
         }
         catch (Exception e)
         {
@@ -108,80 +175,39 @@ public class RefitterGenerateTask : MSBuildTask
         }
     }
 
-    private List<string> StartProcess(string file, out bool failed)
+    private List<string>? RunGenerator(IGeneratorRunner runner, string file, out bool failed)
     {
         failed = false;
-        var assembly = Assembly.GetExecutingAssembly();
-        var packageFolder = Path.GetDirectoryName(assembly.Location);
-        var outputLines = new List<string>();
 
-        List<string>? installedRuntimes = null;
+        var settingsDirectory = Path.GetDirectoryName(file);
+        var json = File.ReadAllText(file);
+        var settings = RefitterSettingsLoader.Load(json, settingsDirectory ?? string.Empty);
+
         try
         {
-            installedRuntimes = RuntimeResolver.GetInstalledRuntimes();
+            var generatedFiles = runner.RunAsync(settings, SkipValidation, DisableLogging, CancellationToken.None).GetAwaiter().GetResult();
+            return generatedFiles?.ToList();
         }
-        catch (Exception exception)
-        {
-            TryLogCommandLine($"Failed to inspect installed .NET runtimes: {exception.Message}. Falling back to bundled Refitter runtime selection.");
-        }
-
-        var refitterDll = ResolveRefitterDll(packageFolder, installedRuntimes, TryLogCommandLine, FileExists);
-        if (string.IsNullOrWhiteSpace(refitterDll) || !FileExists(refitterDll!))
-        {
-            failed = true;
-            TryLogError("Unable to locate a bundled Refitter CLI runtime for the MSBuild task.");
-            return new();
-        }
-
-        var args = $"\"{refitterDll}\" --settings-file \"{file}\" --simple-output";
-        if (DisableLogging)
-        {
-            args += " --no-logging";
-        }
-        if (SkipValidation)
-        {
-            args += " --skip-validation";
-        }
-
-        TryLogCommandLine($"Starting dotnet {args}");
-
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            Arguments = args,
-            WorkingDirectory = Path.GetDirectoryName(file)!,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            RedirectStandardInput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        var processResult = ProcessRunner.Run(
-            startInfo,
-            data => HandleProcessStandardOutput(data, outputLines, outputLines, TryLogCommandLine),
-            data => HandleProcessErrorOutput(data, TryLogError));
-
-        if (processResult.TimedOut)
+        catch (TimeoutException)
         {
             failed = true;
             var timeoutDescription = FormatTimeout(ProcessTimeoutMilliseconds);
             TryLogError(
-                processResult.TerminationException is null
-                    ? $"Refitter process timed out after {timeoutDescription} and was terminated"
-                    : $"Refitter process timed out after {timeoutDescription}. Failed to terminate timed-out process: {processResult.TerminationException.Message}");
-
-            return new();
-        }
-
-        if (processResult.ExitCode != 0)
-        {
-            failed = true;
-            TryLogError($"Refitter process exited with code {processResult.ExitCode}");
+                $"Refitter process timed out after {timeoutDescription} and was terminated");
             return new List<string>();
         }
-
-        return ResolveGeneratedFiles(outputLines, file, out failed, TryLogError);
+        catch (InvalidOperationException ex) when (ex.Message.Contains("exited with code"))
+        {
+            failed = true;
+            TryLogError(ex.Message);
+            return new List<string>();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("did not report any generated files"))
+        {
+            failed = true;
+            TryLogError(ex.Message);
+            return new List<string>();
+        }
     }
 
     internal static string? ResolveRefitterDll(

--- a/src/Refitter.Tests/MSBuild/RefitterGenerateTaskTests.cs
+++ b/src/Refitter.Tests/MSBuild/RefitterGenerateTaskTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Reflection;
 using FluentAssertions;
 using Microsoft.Build.Framework;
+using Refitter.Core;
 using Refitter.MSBuild;
 
 namespace Refitter.Tests.MSBuild;
@@ -287,7 +288,7 @@ public class RefitterGenerateTaskTests
     }
 
     [Test]
-    public void Execute_Should_Generate_Files_Reported_By_Refitter()
+    public void Execute_Should_Use_CoreGeneratorRunner_When_No_Cli_Available()
     {
         var workspace = CreateWorkspace();
 
@@ -352,13 +353,15 @@ public class RefitterGenerateTaskTests
                 }
                 """);
 
+            var buildEngine = new RecordingBuildEngine();
             var task = new RefitterGenerateTask
             {
-                BuildEngine = new RecordingBuildEngine(),
+                BuildEngine = buildEngine,
                 ProjectFileDirectory = workspace,
                 IncludePatterns = "petstore.refitter",
                 DisableLogging = true,
-                SkipValidation = true
+                SkipValidation = true,
+                GeneratorRunner = new CoreGeneratorRunner()
             };
 
             var result = task.Execute();
@@ -377,7 +380,7 @@ public class RefitterGenerateTaskTests
     }
 
     [Test]
-    public void Execute_Should_Return_False_When_Runtime_Discovery_Throws()
+    public void Execute_Should_Use_Injected_GeneratorRunner()
     {
         var workspace = CreateWorkspace();
 
@@ -387,26 +390,124 @@ public class RefitterGenerateTaskTests
             var generatedFile = CreateGeneratedFile(workspace);
 
             var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
-            task.RuntimeResolver = new DelegatingRuntimeResolver { Handler = () => throw new InvalidOperationException("boom") };
-            task.FileExists = path =>
-                path.EndsWith("refitter.dll", StringComparison.OrdinalIgnoreCase) || File.Exists(path);
-            task.ProcessRunner = new DelegatingProcessRunner
+            var task = new RefitterGenerateTask
             {
-                Handler = (startInfo, logOutput, _) =>
-                {
-                    startInfo.Arguments.Should().Contain("net8.0");
-                    logOutput($"{RefitterGenerateTask.GeneratedFileMarker}{generatedFile}");
-                    return new ProcessExecutionResult(false, 0);
-                }
+                BuildEngine = buildEngine,
+                ProjectFileDirectory = workspace,
+                IncludePatterns = "petstore.refitter",
+                DisableLogging = true,
+                SkipValidation = true,
+                GeneratorRunner = new TestGeneratorRunner(
+                    (settings, skipValidation, noLogging, cancellationToken) =>
+                        Task.FromResult<IReadOnlyList<string>>(new[] { generatedFile }))
             };
 
             var result = task.Execute();
 
             result.Should().BeTrue();
             task.GeneratedFiles.Should().ContainSingle().Which.ItemSpec.Should().Be(generatedFile);
-            buildEngine.Messages.Should().Contain(message => message.Contains("Failed to inspect installed .NET runtimes", StringComparison.Ordinal));
-            buildEngine.Messages.Should().Contain(message => message.Contains("Falling back to bundled .NET 8.0 version of Refitter.", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteWorkspace(workspace);
+        }
+    }
+
+    [Test]
+    public void Execute_Should_Return_False_When_GeneratorRunner_Throws()
+    {
+        var workspace = CreateWorkspace();
+
+        try
+        {
+            CreateRefitterSettingsFile(workspace);
+
+            var buildEngine = new RecordingBuildEngine();
+            var task = new RefitterGenerateTask
+            {
+                BuildEngine = buildEngine,
+                ProjectFileDirectory = workspace,
+                IncludePatterns = "petstore.refitter",
+                DisableLogging = true,
+                SkipValidation = true,
+                GeneratorRunner = new TestGeneratorRunner(
+                    (settings, skipValidation, noLogging, cancellationToken) =>
+                        throw new InvalidOperationException("generation failed"))
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeFalse();
+            task.GeneratedFiles.Should().BeEmpty();
+            buildEngine.Errors.Should().Contain(message => message.Contains("generation failed", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteWorkspace(workspace);
+        }
+    }
+
+    [Test]
+    public void Execute_Should_Return_False_When_GeneratorRunner_Times_Out()
+    {
+        var workspace = CreateWorkspace();
+
+        try
+        {
+            CreateRefitterSettingsFile(workspace);
+
+            var buildEngine = new RecordingBuildEngine();
+            var task = new RefitterGenerateTask
+            {
+                BuildEngine = buildEngine,
+                ProjectFileDirectory = workspace,
+                IncludePatterns = "petstore.refitter",
+                DisableLogging = true,
+                SkipValidation = true,
+                GeneratorRunner = new TestGeneratorRunner(
+                    (settings, skipValidation, noLogging, cancellationToken) =>
+                        throw new TimeoutException("timeout"))
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeFalse();
+            task.GeneratedFiles.Should().BeEmpty();
+            buildEngine.Errors.Should().Contain(message => message.Contains("timed out", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteWorkspace(workspace);
+        }
+    }
+
+    [Test]
+    public void Execute_Should_Return_False_When_No_Generated_Files_Reported()
+    {
+        var workspace = CreateWorkspace();
+
+        try
+        {
+            CreateRefitterSettingsFile(workspace);
+
+            var buildEngine = new RecordingBuildEngine();
+            var task = new RefitterGenerateTask
+            {
+                BuildEngine = buildEngine,
+                ProjectFileDirectory = workspace,
+                IncludePatterns = "petstore.refitter",
+                DisableLogging = true,
+                SkipValidation = true,
+                GeneratorRunner = new TestGeneratorRunner(
+                    (settings, skipValidation, noLogging, cancellationToken) =>
+                        throw new InvalidOperationException("Refitter did not report any generated files for petstore.refitter"))
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeFalse();
+            task.GeneratedFiles.Should().BeEmpty();
+            buildEngine.Errors.Should().Contain(message => message.Contains("did not report any generated files", StringComparison.Ordinal));
         }
         finally
         {
@@ -489,438 +590,6 @@ public class RefitterGenerateTaskTests
     }
 
     [Test]
-    public void GetInstalledDotnetRuntimes_Should_Throw_TimeoutException_When_Runtime_Discovery_Times_Out()
-    {
-        var processRunner = new DelegatingProcessRunner
-        {
-            Handler = (startInfo, _, _) =>
-            {
-                startInfo.FileName.Should().Be("dotnet");
-                startInfo.Arguments.Should().Be("--list-runtimes");
-                return new ProcessExecutionResult(true, -1);
-            }
-        };
-
-        var resolver = new DefaultRuntimeResolver(processRunner) { TimeoutMilliseconds = 500 };
-        var action = () => resolver.GetInstalledRuntimes();
-
-        action.Should().Throw<TimeoutException>()
-            .WithMessage("*dotnet --list-runtimes timed out after 500 ms*");
-    }
-
-    [Test]
-    public void GetInstalledDotnetRuntimes_Should_Include_Termination_Failure_When_Runtime_Discovery_Cannot_Be_Stopped()
-    {
-        var processRunner = new DelegatingProcessRunner
-        {
-            Handler = (startInfo, _, _) =>
-            {
-                startInfo.FileName.Should().Be("dotnet");
-                startInfo.Arguments.Should().Be("--list-runtimes");
-                return new ProcessExecutionResult(true, -1, new InvalidOperationException("kill failed"));
-            }
-        };
-
-        var resolver = new DefaultRuntimeResolver(processRunner) { TimeoutMilliseconds = 500 };
-        var action = () => resolver.GetInstalledRuntimes();
-
-        action.Should().Throw<TimeoutException>()
-            .WithMessage("*dotnet --list-runtimes timed out after 500 ms. Failed to terminate timed-out process: kill failed*")
-            .WithInnerException<InvalidOperationException>()
-            .WithMessage("kill failed");
-    }
-
-    [Test]
-    public void GetInstalledDotnetRuntimes_Should_Throw_When_Runtime_Discovery_Exits_NonZero()
-    {
-        var processRunner = new DelegatingProcessRunner
-        {
-            Handler = (startInfo, _, logError) =>
-            {
-                startInfo.FileName.Should().Be("dotnet");
-                startInfo.Arguments.Should().Be("--list-runtimes");
-                logError("runtime probe failed");
-                return new ProcessExecutionResult(false, 23);
-            }
-        };
-
-        var resolver = new DefaultRuntimeResolver(processRunner);
-        var action = () => resolver.GetInstalledRuntimes();
-
-        action.Should().Throw<InvalidOperationException>()
-            .WithMessage("*dotnet --list-runtimes exited with code 23*runtime probe failed*");
-    }
-
-    [Test]
-    public void GetInstalledDotnetRuntimes_Should_Throw_When_Runtime_Discovery_Exits_NonZero_Without_Error_Output()
-    {
-        var processRunner = new DelegatingProcessRunner
-        {
-            Handler = (startInfo, _, _) =>
-            {
-                startInfo.FileName.Should().Be("dotnet");
-                startInfo.Arguments.Should().Be("--list-runtimes");
-                return new ProcessExecutionResult(false, 23);
-            }
-        };
-
-        var resolver = new DefaultRuntimeResolver(processRunner);
-        var action = () => resolver.GetInstalledRuntimes();
-
-        action.Should().Throw<InvalidOperationException>()
-            .WithMessage("dotnet --list-runtimes exited with code 23");
-    }
-
-    [Test]
-    public void Execute_Should_Fall_Back_When_Runtime_Discovery_Times_Out()
-    {
-        var workspace = CreateWorkspace();
-
-        try
-        {
-            CreateRefitterSettingsFile(workspace);
-            var generatedFile = CreateGeneratedFile(workspace);
-
-            var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
-            task.ProcessTimeoutMilliseconds = 500;
-            task.FileExists = path =>
-                path.Contains("net8.0", StringComparison.OrdinalIgnoreCase) || File.Exists(path);
-            task.RuntimeResolver = new DelegatingRuntimeResolver
-            {
-                Handler = () => throw new TimeoutException("dotnet --list-runtimes timed out after 500 ms")
-            };
-            task.ProcessRunner = new DelegatingProcessRunner
-            {
-                Handler = (startInfo, logOutput, _) =>
-                {
-                    startInfo.Arguments.Should().Contain("net8.0");
-                    logOutput($"{RefitterGenerateTask.GeneratedFileMarker}{generatedFile}");
-                    return new ProcessExecutionResult(false, 0);
-                }
-            };
-
-            var result = task.Execute();
-
-            result.Should().BeTrue();
-            task.GeneratedFiles.Should().ContainSingle().Which.ItemSpec.Should().Be(generatedFile);
-            buildEngine.Messages.Should().Contain(message => message.Contains("Failed to inspect installed .NET runtimes", StringComparison.Ordinal));
-            buildEngine.Messages.Should().Contain(message => message.Contains("Falling back to bundled .NET 8.0 version of Refitter.", StringComparison.Ordinal));
-        }
-        finally
-        {
-            DeleteWorkspace(workspace);
-        }
-    }
-
-    [Test]
-    public void Execute_Should_Use_DotNet9_Runtime_When_Available()
-    {
-        var workspace = CreateWorkspace();
-
-        try
-        {
-            CreateRefitterSettingsFile(workspace);
-            var generatedFile = CreateGeneratedFile(workspace);
-
-            var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
-            task.RuntimeResolver = new DelegatingRuntimeResolver { Handler = () => ["Microsoft.NETCore.App 9.0.0"] };
-            task.FileExists = path =>
-                path.Contains("net9.0", StringComparison.OrdinalIgnoreCase) ||
-                File.Exists(path);
-            task.ProcessRunner = new DelegatingProcessRunner
-            {
-                Handler = (startInfo, logOutput, _) =>
-                {
-                    startInfo.Arguments.Should().Contain("net9.0");
-                    logOutput($"{RefitterGenerateTask.GeneratedFileMarker}{generatedFile}");
-                    return new ProcessExecutionResult(false, 0);
-                }
-            };
-
-            var result = task.Execute();
-
-            result.Should().BeTrue();
-            task.GeneratedFiles.Should().ContainSingle();
-            task.GeneratedFiles.Single().ItemSpec.Should().Be(generatedFile);
-            buildEngine.Messages.Should().Contain(message => message.Contains("Detected .NET 9.0 runtime", StringComparison.Ordinal));
-        }
-        finally
-        {
-            DeleteWorkspace(workspace);
-        }
-    }
-
-    [Test]
-    public void Execute_Should_Fall_Back_To_DotNet8_Runtime_When_Newer_Runtimes_Are_Unavailable()
-    {
-        var workspace = CreateWorkspace();
-
-        try
-        {
-            CreateRefitterSettingsFile(workspace);
-            var generatedFile = CreateGeneratedFile(workspace);
-
-            var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
-            task.RuntimeResolver = new DelegatingRuntimeResolver { Handler = () => ["Microsoft.NETCore.App 8.0.0"] };
-            task.FileExists = path =>
-                path.Contains("net8.0", StringComparison.OrdinalIgnoreCase) ||
-                File.Exists(path);
-            task.ProcessRunner = new DelegatingProcessRunner
-            {
-                Handler = (startInfo, logOutput, _) =>
-                {
-                    startInfo.Arguments.Should().Contain("net8.0");
-                    logOutput($"{RefitterGenerateTask.GeneratedFileMarker}{generatedFile}");
-                    return new ProcessExecutionResult(false, 0);
-                }
-            };
-
-            var result = task.Execute();
-
-            result.Should().BeTrue();
-            task.GeneratedFiles.Should().ContainSingle();
-            buildEngine.Messages.Should().Contain(message => message.Contains("Detected .NET 8.0 runtime", StringComparison.Ordinal));
-        }
-        finally
-        {
-            DeleteWorkspace(workspace);
-        }
-    }
-
-    [Test]
-    public void Execute_Should_Return_False_When_Refitter_Cli_Cannot_Be_Located()
-    {
-        var workspace = CreateWorkspace();
-
-        try
-        {
-            CreateRefitterSettingsFile(workspace);
-
-            var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
-            task.FileExists = _ => false;
-
-            var result = task.Execute();
-
-            result.Should().BeFalse();
-            task.GeneratedFiles.Should().BeEmpty();
-            buildEngine.Errors.Should().Contain(message => message.Contains("Unable to locate a bundled Refitter CLI runtime for the MSBuild task.", StringComparison.Ordinal));
-        }
-        finally
-        {
-            DeleteWorkspace(workspace);
-        }
-    }
-
-    [Test]
-    public void Execute_Should_Log_Timeout_When_Process_Does_Not_Exit()
-    {
-        var workspace = CreateWorkspace();
-
-        try
-        {
-            CreateRefitterSettingsFile(workspace);
-
-            var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
-            task.ProcessRunner = new DelegatingProcessRunner
-            {
-                Handler = (_, _, _) => new ProcessExecutionResult(true, -1)
-            };
-
-            var result = task.Execute();
-
-            result.Should().BeFalse();
-            task.GeneratedFiles.Should().BeEmpty();
-            buildEngine.Errors.Should().Contain(message => message.Contains("timed out after 300 seconds", StringComparison.Ordinal));
-        }
-        finally
-        {
-            DeleteWorkspace(workspace);
-        }
-    }
-
-    [Test]
-    public void Execute_Should_Log_Millisecond_Timeout_Value()
-    {
-        var workspace = CreateWorkspace();
-
-        try
-        {
-            CreateRefitterSettingsFile(workspace);
-
-            var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
-            task.ProcessTimeoutMilliseconds = 500;
-            task.ProcessRunner = new DelegatingProcessRunner
-            {
-                Handler = (_, _, _) => new ProcessExecutionResult(true, -1)
-            };
-
-            var result = task.Execute();
-
-            result.Should().BeFalse();
-            buildEngine.Errors.Should().Contain(message => message.Contains("timed out after 500 ms", StringComparison.Ordinal));
-        }
-        finally
-        {
-            DeleteWorkspace(workspace);
-        }
-    }
-
-    [Test]
-    public void Execute_Should_Log_When_Timed_Out_Process_Cannot_Be_Terminated()
-    {
-        var workspace = CreateWorkspace();
-
-        try
-        {
-            CreateRefitterSettingsFile(workspace);
-
-            var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
-            task.ProcessRunner = new DelegatingProcessRunner
-            {
-                Handler = (_, _, _) => new ProcessExecutionResult(
-                    true,
-                    -1,
-                    new InvalidOperationException("termination failed"))
-            };
-
-            var result = task.Execute();
-
-            result.Should().BeFalse();
-            buildEngine.Errors.Should().Contain(message => message.Contains("Failed to terminate timed-out process: termination failed", StringComparison.Ordinal));
-        }
-        finally
-        {
-            DeleteWorkspace(workspace);
-        }
-    }
-
-    [Test]
-    public void Execute_Should_Log_Configured_Timeout_Value()
-    {
-        var workspace = CreateWorkspace();
-
-        try
-        {
-            CreateRefitterSettingsFile(workspace);
-
-            var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
-            task.ProcessTimeoutMilliseconds = 1500;
-            task.ProcessRunner = new DelegatingProcessRunner
-            {
-                Handler = (_, _, _) => new ProcessExecutionResult(true, -1)
-            };
-
-            var result = task.Execute();
-
-            result.Should().BeFalse();
-            buildEngine.Errors.Should().Contain(message => message.Contains($"timed out after {1500 / 1000d:0.###} seconds", StringComparison.Ordinal));
-        }
-        finally
-        {
-            DeleteWorkspace(workspace);
-        }
-    }
-
-    [Test]
-    public void Execute_Should_Log_ProcessRunner_Exception_And_Return_False()
-    {
-        var workspace = CreateWorkspace();
-
-        try
-        {
-            CreateRefitterSettingsFile(workspace);
-
-            var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
-            task.FileExists = path =>
-                path.Contains("net10.0", StringComparison.OrdinalIgnoreCase) ||
-                File.Exists(path);
-            task.ProcessRunner = new DelegatingProcessRunner
-            {
-                Handler = (_, _, _) => throw new InvalidOperationException("boom")
-            };
-
-            var result = task.Execute();
-
-            result.Should().BeFalse();
-            task.GeneratedFiles.Should().BeEmpty();
-            buildEngine.Errors.Should().Contain(message => message.Contains("boom", StringComparison.Ordinal));
-        }
-        finally
-        {
-            DeleteWorkspace(workspace);
-        }
-    }
-
-    [Test]
-    public void Execute_Should_Log_When_Process_Exits_With_Non_Zero_Code()
-    {
-        var workspace = CreateWorkspace();
-
-        try
-        {
-            CreateRefitterSettingsFile(workspace);
-
-            var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
-            task.ProcessRunner = new DelegatingProcessRunner
-            {
-                Handler = (_, _, _) => new ProcessExecutionResult(false, 23)
-            };
-
-            var result = task.Execute();
-
-            result.Should().BeFalse();
-            buildEngine.Errors.Should().Contain(message => message.Contains("Refitter process exited with code 23", StringComparison.Ordinal));
-        }
-        finally
-        {
-            DeleteWorkspace(workspace);
-        }
-    }
-
-    [Test]
-    public void RunProcess_Should_Return_TimedOut_Result_When_Process_Exceeds_Timeout()
-    {
-        var runner = new DefaultProcessRunner { TimeoutMilliseconds = 1 };
-
-        var result = runner.Run(
-            CreateSleepProcessStartInfo(),
-            _ => { },
-            _ => { });
-
-        result.TimedOut.Should().BeTrue();
-        result.TerminationException.Should().BeNull();
-    }
-
-    [Test]
-    public void RunProcess_Should_Return_Termination_Exception_When_Kill_Fails_After_Timeout()
-    {
-        var runner = new DefaultProcessRunner
-        {
-            TimeoutMilliseconds = 1,
-            ProcessTerminator = _ => throw new InvalidOperationException("kill failed")
-        };
-
-        var result = runner.Run(
-            CreateSleepProcessStartInfo(),
-            _ => { },
-            _ => { });
-
-        result.TimedOut.Should().BeTrue();
-        result.TerminationException.Should().BeOfType<InvalidOperationException>()
-            .Which.Message.Should().Be("kill failed");
-    }
-
-    [Test]
     public void TryLogCommandLine_Should_Swallow_BuildEngine_Exceptions()
     {
         var task = new RefitterGenerateTask { BuildEngine = new RecordingBuildEngine { ThrowOnMessages = true } };
@@ -980,47 +649,11 @@ public class RefitterGenerateTaskTests
         return generatedFile;
     }
 
-    private static RefitterGenerateTask CreateTask(string workspace, IBuildEngine? buildEngine = null) =>
-        new()
-        {
-            BuildEngine = buildEngine ?? new RecordingBuildEngine(),
-            ProjectFileDirectory = workspace,
-            IncludePatterns = "petstore.refitter",
-            DisableLogging = true,
-            SkipValidation = true
-        };
-
     private static void InvokePrivateMethod(RefitterGenerateTask task, string methodName, params object[] arguments)
     {
         var method = typeof(RefitterGenerateTask).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
         method.Should().NotBeNull();
         method!.Invoke(task, arguments);
-    }
-
-    private static ProcessStartInfo CreateSleepProcessStartInfo()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            return new ProcessStartInfo
-            {
-                FileName = "powershell",
-                Arguments = "-NoLogo -NoProfile -Command \"Start-Sleep -Seconds 1\"",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-        }
-
-        return new ProcessStartInfo
-        {
-            FileName = "bash",
-            Arguments = "-lc \"sleep 1\"",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
     }
 
     private static void DeleteWorkspace(string workspace)
@@ -1029,24 +662,6 @@ public class RefitterGenerateTaskTests
         {
             Directory.Delete(workspace, recursive: true);
         }
-    }
-
-    private sealed class DelegatingProcessRunner : IProcessRunner
-    {
-        public Func<ProcessStartInfo, Action<string?>, Action<string?>, ProcessExecutionResult> Handler { get; set; }
-
-        public ProcessExecutionResult Run(
-            ProcessStartInfo startInfo,
-            Action<string?> standardOutput,
-            Action<string?> standardError) =>
-            Handler(startInfo, standardOutput, standardError);
-    }
-
-    private sealed class DelegatingRuntimeResolver : IRuntimeResolver
-    {
-        public Func<List<string>> Handler { get; set; }
-
-        public List<string> GetInstalledRuntimes() => Handler();
     }
 
     private sealed class RecordingBuildEngine : IBuildEngine


### PR DESCRIPTION
## Description:

The `👌 Verify build` GitHub Actions job in `msbuild.yml` was failing with:

```
error: NU1101: Unable to find package Refitter.Core. No packages exist with this id in source(s): D:\a\refitter\refitter\test\MSBuild
error: Package 'Refitter.MSBuild' is incompatible with 'all' frameworks
```

**Root cause:** `Refitter.MSBuild.csproj` references `Refitter.Core` via a `<ProjectReference>`. When `dotnet pack` generates the NuGet package, this project reference is converted into a NuGet package dependency on `Refitter.Core` in the `.nuspec` manifest. The CI workflow's **Prepare** step used `dotnet add package Refitter.MSBuild -s .`, which restricts NuGet to only the local `test/MSBuild` directory as a source. Because `Refitter.Core` was never packed and placed into that local feed, NuGet could not resolve the dependency and the restore step failed.

**Fix:** Updated `.github/workflows/msbuild.yml` to pack `Refitter.Core.csproj` and register the resulting `.nupkg` in the local NuGet feed *before* packing and installing `Refitter.MSBuild`:

```yaml
dotnet pack -c release ../../src/Refitter.Core/Refitter.Core.csproj -o .
nuget add .\Refitter.Core.1.0.0.nupkg -source .
```

This ensures NuGet can resolve the `Refitter.Core` dependency when installing `Refitter.MSBuild` from the local feed. All of `Refitter.Core`'s transitive dependencies (NSwag, Microsoft.CodeAnalysis, etc.) are already present in the NuGet cache from the earlier `dotnet restore ../../src/Refitter.slnx` step and require no additional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refactored code generation infrastructure to support flexible generation approaches with improved error handling and timeout management.

* **Chores**
  * Updated MSBuild workflow to build and publish Refitter.Core package.
  * Enhanced test coverage for generation mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->