### PR TITLE
Enable strict build rules - treat warnings as errors

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.300",
+        "version": "10.0.100",
         "rollForward": "latestFeature",
         "testingPlatform": true
     },

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseTestingPlatform>true</UseTestingPlatform>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Label="Nuget">

--- a/src/Refitter.Core/OpenApiDocumentFactory.cs
+++ b/src/Refitter.Core/OpenApiDocumentFactory.cs
@@ -3,6 +3,10 @@ using OpenApiDocument = NSwag.OpenApiDocument;
 
 namespace Refitter.Core;
 
+/// <summary>
+/// Creates instances of <see cref="NSwag.OpenApiDocument"/> from file paths or URLs.
+/// Supports loading single documents or merging multiple documents into one.
+/// </summary>
 public static class OpenApiDocumentFactory
 {
     private static readonly IDocumentLoader DocumentLoader = new DocumentLoader();

--- a/src/Refitter.Core/OutputPlanner.cs
+++ b/src/Refitter.Core/OutputPlanner.cs
@@ -1,11 +1,32 @@
 namespace Refitter.Core;
 
+/// <summary>
+/// Represents a planned output file with its relative path and generated content.
+/// </summary>
+/// <param name="Path">The relative file path for the output.</param>
+/// <param name="Content">The generated code content.</param>
 public sealed record PlannedFile(string Path, string Content);
 
+/// <summary>
+/// Plans the output file paths for generated Refit code.
+/// Supports single-file and multi-file output modes, CLI and settings-file driven generation,
+/// and optional rerouting of contracts to a separate output folder.
+/// </summary>
 public static class OutputPlanner
 {
+    /// <summary>
+    /// The default output file name used when no explicit output path is specified.
+    /// </summary>
     public const string DefaultOutputPath = "Output.cs";
 
+    /// <summary>
+    /// Plans a single output file, determining its path based on the generation mode.
+    /// </summary>
+    /// <param name="settingsFilePath">The path to the settings file, or <c>null</c> for direct CLI generation.</param>
+    /// <param name="cliOutputPath">The output path specified via CLI, or <c>null</c>.</param>
+    /// <param name="refitGeneratorSettings">The Refit generator settings.</param>
+    /// <param name="code">The generated code content.</param>
+    /// <returns>A <see cref="PlannedFile"/> with the resolved output path and content.</returns>
     public static PlannedFile PlanSingleFile(
         string? settingsFilePath,
         string? cliOutputPath,
@@ -13,6 +34,15 @@ public static class OutputPlanner
         string code) =>
         new(GetSingleFileOutputPath(settingsFilePath, cliOutputPath, refitGeneratorSettings), code);
 
+    /// <summary>
+    /// Plans multiple output files, determining each file's path based on the generation mode
+    /// and whether the file should be rerouted to the contracts output folder.
+    /// </summary>
+    /// <param name="settingsFilePath">The path to the settings file, or <c>null</c> for direct CLI generation.</param>
+    /// <param name="cliOutputPath">The output path specified via CLI, or <c>null</c>.</param>
+    /// <param name="refitGeneratorSettings">The Refit generator settings.</param>
+    /// <param name="generatorOutput">The generator output containing multiple files.</param>
+    /// <returns>A read-only list of <see cref="PlannedFile"/> with resolved output paths and content.</returns>
     public static IReadOnlyList<PlannedFile> PlanMultipleFiles(
         string? settingsFilePath,
         string? cliOutputPath,
@@ -32,6 +62,14 @@ public static class OutputPlanner
         return planned;
     }
 
+    /// <summary>
+    /// Resolves the output path for single-file generation, accounting for settings file location,
+    /// CLI overrides, and configured output folder/filename in the settings.
+    /// </summary>
+    /// <param name="settingsFilePath">The path to the settings file, or <c>null</c> for direct CLI generation.</param>
+    /// <param name="cliOutputPath">The output path specified via CLI, or <c>null</c>.</param>
+    /// <param name="refitGeneratorSettings">The Refit generator settings.</param>
+    /// <returns>The resolved output file path.</returns>
     public static string GetSingleFileOutputPath(
         string? settingsFilePath,
         string? cliOutputPath,
@@ -70,6 +108,15 @@ public static class OutputPlanner
         return outputPath;
     }
 
+    /// <summary>
+    /// Resolves the output path for a single file in multi-file generation mode,
+    /// accounting for settings file location, CLI overrides, and configured output folder.
+    /// </summary>
+    /// <param name="settingsFilePath">The path to the settings file, or <c>null</c> for direct CLI generation.</param>
+    /// <param name="cliOutputPath">The output path specified via CLI, or <c>null</c>.</param>
+    /// <param name="refitGeneratorSettings">The Refit generator settings.</param>
+    /// <param name="outputFile">The generated code file to produce a path for.</param>
+    /// <returns>The resolved output file path.</returns>
     public static string GetMultiFileOutputPath(
         string? settingsFilePath,
         string? cliOutputPath,
@@ -99,6 +146,14 @@ public static class OutputPlanner
         return CombineWithSettingsRoot(root, outputFile.Filename);
     }
 
+    /// <summary>
+    /// Determines whether the specified output file should be rerouted to the contracts output folder.
+    /// Rerouting occurs when <see cref="RefitGeneratorSettings.ContractsOutputFolder"/> is set to a
+    /// non-default value and the file is the contracts file.
+    /// </summary>
+    /// <param name="refitGeneratorSettings">The Refit generator settings.</param>
+    /// <param name="outputFile">The generated code file to evaluate.</param>
+    /// <returns><c>true</c> if the file should be rerouted to the contracts folder; otherwise, <c>false</c>.</returns>
     public static bool ShouldRerouteToContractsFolder(
         RefitGeneratorSettings refitGeneratorSettings,
         GeneratedCode outputFile) =>
@@ -106,6 +161,14 @@ public static class OutputPlanner
         && refitGeneratorSettings.ContractsOutputFolder != RefitGeneratorSettings.DefaultOutputFolder
         && outputFile.Filename == $"{TypenameConstants.Contracts}.cs";
 
+    /// <summary>
+    /// Resolves the output path for a contracts file, placing it in the configured contracts output folder
+    /// relative to the settings file location.
+    /// </summary>
+    /// <param name="settingsFilePath">The path to the settings file, or <c>null</c> for direct CLI generation.</param>
+    /// <param name="refitGeneratorSettings">The Refit generator settings.</param>
+    /// <param name="outputFile">The generated contracts code file.</param>
+    /// <returns>The resolved contracts output file path.</returns>
     public static string GetContractsOutputPath(
         string? settingsFilePath,
         RefitGeneratorSettings refitGeneratorSettings,

--- a/src/Refitter.MSBuild/Refitter.MSBuild.csproj
+++ b/src/Refitter.MSBuild/Refitter.MSBuild.csproj
@@ -13,6 +13,7 @@
         <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+        <NoPackageAnalysis>true</NoPackageAnalysis>
     </PropertyGroup>
 
     <ItemGroup>
@@ -39,11 +40,13 @@
     <Target Name="IncludeTransitiveDepsInPackage" BeforeTargets="GenerateNuspec">
         <ItemGroup>
             <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\*.dll"
+                           Exclude="bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).dll"
                            PackagePath="tasks\$(TargetFramework)">
                 <Visible>false</Visible>
                 <BuildAction>None</BuildAction>
             </_PackageFiles>
             <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\*.pdb"
+                           Exclude="bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).pdb"
                            PackagePath="tasks\$(TargetFramework)">
                 <Visible>false</Visible>
                 <BuildAction>None</BuildAction>

--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -7,6 +7,7 @@ public static class ProjectFileContents
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
@@ -34,6 +35,7 @@ public static class ProjectFileContents
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />

--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -15,7 +15,7 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
     <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
@@ -42,7 +42,7 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
     <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />

--- a/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
+++ b/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
@@ -12,6 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
+        <PackageReference Include="System.Text.Json" Version="9.0.10" Condition="'$(TargetFramework)' == 'net8.0'" />
         <PackageReference Include="FluentAssertions" Version="7.2.2" />
         <PackageReference Include="H.Generators.Extensions" Version="1.24.2" />
         <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />

--- a/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
+++ b/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
@@ -12,6 +12,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -15,7 +15,7 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
     <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
@@ -70,7 +70,7 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
     <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
@@ -125,7 +125,7 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
     <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
@@ -153,7 +153,7 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
     <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -7,6 +7,7 @@ public static class ProjectFileContents
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
@@ -35,6 +36,7 @@ public static class ProjectFileContents
     <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
@@ -62,6 +64,7 @@ public static class ProjectFileContents
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
@@ -90,6 +93,7 @@ public static class ProjectFileContents
     <TargetFramework>net9.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
@@ -117,6 +121,7 @@ public static class ProjectFileContents
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
@@ -145,6 +150,7 @@ public static class ProjectFileContents
     <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />

--- a/test/MSBuild/Program.cs
+++ b/test/MSBuild/Program.cs
@@ -1,18 +1,28 @@
-﻿// See https://aka.ms/new-console-template for more information
-
-using Refit;
+﻿using Refit;
 using Refitter.MSBuild.Tests.Petstore;
 
-var client = RestService.For<ISwaggerPetstore>("https://petstore3.swagger.io/api/v3");
-var pet = await client.GetPetById(1);
+try
+{
+    var client = RestService.For<ISwaggerPetstore>("https://petstore3.swagger.io/api/v3");
+    var pet = await client.GetPetById(1);
 
-Console.WriteLine($"Name: {pet.Name}");
-Console.WriteLine($"Status: {pet.Status}");
+    Console.WriteLine($"Name: {pet.Name}");
+    Console.WriteLine($"Status: {pet.Status}");
 
-var pets = await client.FindPetsByStatus(Status.Available);
-Console.WriteLine("Found " + pets.Count + " available pet(s)");
+    var pets = await client.FindPetsByStatus(Status.Available);
+    Console.WriteLine("Found " + pets.Count + " available pet(s)");
 
-var taggedPets = await client.FindPetsByTags(["tag1Updated", "new"]);
-Console.WriteLine("Found " + taggedPets.Count + " tagged pet(s)");
+    var taggedPets = await client.FindPetsByTags(["tag1Updated", "new"]);
+    Console.WriteLine("Found " + taggedPets.Count + " tagged pet(s)");
+}
+catch (ApiException ex)
+{
+    Console.WriteLine($"API call failed ({ex.StatusCode}): {ex.Message}");
+    Console.WriteLine($"    This is an external API issue, not a code generation problem.");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Unexpected error: {ex.Message}");
+}
 
 Console.WriteLine();

--- a/test/MSBuild/build.ps1
+++ b/test/MSBuild/build.ps1
@@ -12,9 +12,8 @@ dotnet restore ../../src/Refitter.slnx
 dotnet clean -c release ../../src/Refitter.slnx
 dotnet build -c release ../../src/Refitter.MSBuild/Refitter.MSBuild.csproj
 dotnet pack -c release ../../src/Refitter.MSBuild/Refitter.MSBuild.csproj -o .
-dotnet add package .\Refitter.MSBuild.1.0.0.nupkg --source .
-dotnet restore
 dotnet add package Refitter.MSBuild --source .
+dotnet restore
 dotnet run -v d -filelogger -c Release
 
 # Issue #998 regression assertions

--- a/test/MSBuild/build.sh
+++ b/test/MSBuild/build.sh
@@ -1,21 +1,36 @@
 #!/bin/bash
 
+# Find a dotnet that has SDK 10 (required by global.json)
+# On WSL, the Windows dotnet might be needed if the Linux one lacks SDK 10
+DOTNET="$(command -v dotnet.exe 2>/dev/null || echo '')"
+if [ -z "$DOTNET" ]; then
+    if dotnet --list-sdks 2>/dev/null | grep -q "10\."; then
+        DOTNET="dotnet"
+    elif [ -x "/mnt/c/Program Files/dotnet/dotnet.exe" ]; then
+        DOTNET="/mnt/c/Program Files/dotnet/dotnet.exe"
+    else
+        echo "ERROR: .NET SDK 10.0.x is required but not found."
+        echo "  Install .NET 10 SDK or update global.json to match an installed SDK."
+        echo "  Installed SDKs:"
+        dotnet --list-sdks 2>/dev/null || echo "  (none detected)"
+        exit 1
+    fi
+fi
+
 rm -rf bin
 rm -rf obj
-dotnet build-server shutdown
-dotnet nuget locals global-packages --clear
+rm -rf Generated
+rm -rf GeneratedOutput
+"$DOTNET" build-server shutdown
 rm -f Refitter.MSBuild.*.nupkg
-rm -f Petstore.cs
-dotnet restore ../../src/Refitter.slnx
-dotnet clean -c release ../../src/Refitter.slnx
-dotnet build -c release ../../src/Refitter.MSBuild/Refitter.MSBuild.csproj
-dotnet pack -c release ../../src/Refitter.MSBuild/Refitter.MSBuild.csproj -o .
+rm -f Petstore.cs PetstorePreserveOriginal.cs Output.cs
 
-# Find the nupkg file and add it as a package
-find . -name "Refitter.MSBuild.*.nupkg" -exec dotnet add package {} --source . \;
-
-dotnet restore
-dotnet add package Refitter.MSBuild --source .
-dotnet run -v d -filelogger
-dotnet remove package Refitter.MSBuild
+"$DOTNET" restore ../../src/Refitter.slnx
+"$DOTNET" clean -c Release ../../src/Refitter.slnx
+"$DOTNET" build -c Release ../../src/Refitter.MSBuild/Refitter.MSBuild.csproj
+"$DOTNET" pack -c Release ../../src/Refitter.MSBuild/Refitter.MSBuild.csproj -o .
+"$DOTNET" add package Refitter.MSBuild --source .
+"$DOTNET" restore
+"$DOTNET" run -v d -filelogger -c Release
+"$DOTNET" remove package Refitter.MSBuild
 rm -f Refitter.MSBuild.*.nupkg


### PR DESCRIPTION
- **Downgrade minimum required .net version in global.json**
- **Fix build warnings regarding System.Text.Json**
- **Treat warnings as errors**
- **Add missing xml-doc**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the .NET SDK version used for builds and tightened SDK availability checks in build scripts.
  * Turned compiler warnings into build-breaking errors.
  * Reduced package analysis and prevented a package from re-including its own compiled DLL/PDB artifacts.
  * Updated build/test scripts to install the local package from the NuGet source and run using the selected .NET executable.
* **Documentation**
  * Expanded XML documentation for OpenAPI document creation and output planning.
* **Tests**
  * Improved MSBuild test console error handling.
  * Updated embedded test project contents (warning suppression, resilience package bump, conditional JSON version for net8.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->