### PR TITLE
Propagate CancellationToken through all upstream dependencies

### DIFF
--- a/src/Refitter.Core/DocumentLoader.cs
+++ b/src/Refitter.Core/DocumentLoader.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Threading;
 using Microsoft.OpenApi;
 using Microsoft.OpenApi.Reader;
 using NSwag;
@@ -25,16 +26,22 @@ internal sealed class DocumentLoader : IDocumentLoader
             $"refitter/{typeof(DocumentLoader).Assembly.GetName().Version}");
     }
 
-    public async Task<OpenApiDocument> LoadAsync(string openApiPath)
+    public async Task<OpenApiDocument> LoadAsync(
+        string openApiPath,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(openApiPath))
             throw new ArgumentException("The openApiPath parameter cannot be null, empty, or contain only whitespace.", nameof(openApiPath));
 
         try
         {
-            var readResult = await OpenApiMultiFileReader.Read(openApiPath).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            var readResult = await OpenApiMultiFileReader
+                .Read(openApiPath, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
             if (!readResult.ContainedExternalReferences)
-                return await CreateUsingNSwagAsync(openApiPath).ConfigureAwait(false);
+                return await CreateUsingNSwagAsync(openApiPath, cancellationToken).ConfigureAwait(false);
 
             var specificationVersion = readResult.OpenApiDiagnostic.SpecificationVersion;
             PopulateMissingRequiredFields(openApiPath, readResult);
@@ -50,15 +57,17 @@ internal sealed class DocumentLoader : IDocumentLoader
         }
         catch (Exception ex) when (ex is not OperationCanceledException && ex is not TaskCanceledException)
         {
-            return await CreateUsingNSwagAsync(openApiPath).ConfigureAwait(false);
+            return await CreateUsingNSwagAsync(openApiPath, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private static async Task<OpenApiDocument> CreateUsingNSwagAsync(string openApiPath)
+    private static async Task<OpenApiDocument> CreateUsingNSwagAsync(
+        string openApiPath,
+        CancellationToken cancellationToken = default)
     {
         if (IsHttp(openApiPath))
         {
-            var content = await GetHttpContent(openApiPath).ConfigureAwait(false);
+            var content = await GetHttpContent(openApiPath, cancellationToken).ConfigureAwait(false);
             return IsYaml(openApiPath)
                 ? await OpenApiYamlDocument.FromYamlAsync(content).ConfigureAwait(false)
                 : await OpenApiDocument.FromJsonAsync(content).ConfigureAwait(false);
@@ -96,8 +105,14 @@ internal sealed class DocumentLoader : IDocumentLoader
                path.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static Task<string> GetHttpContent(string openApiPath)
-        => HttpClient.GetStringAsync(openApiPath);
+    private static async Task<string> GetHttpContent(
+        string openApiPath,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await HttpClient.GetAsync(openApiPath, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+    }
 
     private static bool IsYaml(string path)
     {

--- a/src/Refitter.Core/IDocumentLoader.cs
+++ b/src/Refitter.Core/IDocumentLoader.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using NSwag;
 using OpenApiDocument = NSwag.OpenApiDocument;
 
@@ -5,5 +6,5 @@ namespace Refitter.Core;
 
 internal interface IDocumentLoader
 {
-    Task<OpenApiDocument> LoadAsync(string path);
+    Task<OpenApiDocument> LoadAsync(string path, CancellationToken cancellationToken = default);
 }

--- a/src/Refitter.Core/OpenApiDocumentFactory.cs
+++ b/src/Refitter.Core/OpenApiDocumentFactory.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using NSwag;
 using OpenApiDocument = NSwag.OpenApiDocument;
 
@@ -17,10 +18,13 @@ public static class OpenApiDocumentFactory
     /// The first document serves as the base; paths and schemas from subsequent documents are merged in.
     /// </summary>
     /// <param name="openApiPaths">The paths or URLs to the OpenAPI specifications.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A merged <see cref="NSwag.OpenApiDocument"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="openApiPaths"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="openApiPaths"/> is empty.</exception>
-    public static async Task<OpenApiDocument> CreateAsync(IEnumerable<string> openApiPaths)
+    public static async Task<OpenApiDocument> CreateAsync(
+        IEnumerable<string> openApiPaths,
+        CancellationToken cancellationToken = default)
     {
         if (openApiPaths == null)
             throw new ArgumentNullException(nameof(openApiPaths));
@@ -30,11 +34,14 @@ public static class OpenApiDocumentFactory
             throw new ArgumentException("At least one OpenAPI path must be specified.", nameof(openApiPaths));
 
         if (paths.Length == 1)
-            return await CreateAsync(paths[0]).ConfigureAwait(false);
+            return await CreateAsync(paths[0], cancellationToken).ConfigureAwait(false);
 
         var documents = new OpenApiDocument[paths.Length];
         for (var i = 0; i < paths.Length; i++)
-            documents[i] = await DocumentLoader.LoadAsync(paths[i]).ConfigureAwait(false);
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            documents[i] = await DocumentLoader.LoadAsync(paths[i], cancellationToken).ConfigureAwait(false);
+        }
 
         return DocumentMerger.Merge(documents);
     }
@@ -43,9 +50,12 @@ public static class OpenApiDocumentFactory
     /// Creates a new instance of the <see cref="NSwag.OpenApiDocument"/> class asynchronously.
     /// </summary>
     /// <param name="openApiPath">The path or URL to the OpenAPI specification.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A new instance of the <see cref="NSwag.OpenApiDocument"/> class.</returns>
-    public static async Task<OpenApiDocument> CreateAsync(string openApiPath)
+    public static async Task<OpenApiDocument> CreateAsync(
+        string openApiPath,
+        CancellationToken cancellationToken = default)
     {
-        return await DocumentLoader.LoadAsync(openApiPath).ConfigureAwait(false);
+        return await DocumentLoader.LoadAsync(openApiPath, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Refitter.Core/RefitGenerator.cs
+++ b/src/Refitter.Core/RefitGenerator.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using NSwag;
 
 namespace Refitter.Core;
@@ -19,11 +20,13 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
     /// Creates a new instance of the <see cref="RefitGenerator"/> class asynchronously
     /// by loading the document from settings, then filtering and cleaning it.
     /// </summary>
-    public static async Task<RefitGenerator> CreateAsync(RefitGeneratorSettings settings)
+    public static async Task<RefitGenerator> CreateAsync(
+        RefitGeneratorSettings settings,
+        CancellationToken cancellationToken = default)
     {
         if (settings == null) throw new ArgumentNullException(nameof(settings));
 
-        var openApiDocument = await GetOpenApiDocument(settings).ConfigureAwait(false);
+        var openApiDocument = await GetOpenApiDocument(settings, cancellationToken).ConfigureAwait(false);
         var processed = RefitDocumentFilter.FilterByTags(openApiDocument, settings.IncludeTags);
         processed = RefitDocumentFilter.FilterByPath(processed, settings.IncludePathMatches);
         processed = await CleanSchemaAsync(
@@ -35,10 +38,12 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
         return new RefitGenerator(settings, processed);
     }
 
-    private static async Task<OpenApiDocument> GetOpenApiDocument(RefitGeneratorSettings settings)
+    private static async Task<OpenApiDocument> GetOpenApiDocument(
+        RefitGeneratorSettings settings,
+        CancellationToken cancellationToken = default)
     {
         if (settings.OpenApiPaths is { Length: > 0 })
-            return await OpenApiDocumentFactory.CreateAsync(settings.OpenApiPaths).ConfigureAwait(false);
+            return await OpenApiDocumentFactory.CreateAsync(settings.OpenApiPaths, cancellationToken).ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(settings.OpenApiPath))
         {
@@ -47,7 +52,7 @@ public class RefitGenerator(RefitGeneratorSettings settings, OpenApiDocument doc
                 nameof(settings));
         }
 
-        return await OpenApiDocumentFactory.CreateAsync(settings.OpenApiPath!).ConfigureAwait(false);
+        return await OpenApiDocumentFactory.CreateAsync(settings.OpenApiPath!, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<OpenApiDocument> CleanSchemaAsync(

--- a/src/Refitter.Core/RefitterSettingsLoader.cs
+++ b/src/Refitter.Core/RefitterSettingsLoader.cs
@@ -44,15 +44,15 @@ public static class RefitterSettingsLoader
             settings.OpenApiPath = Path.GetFullPath(Path.Combine(baseDirectory, settings.OpenApiPath!));
         }
 
-        if (settings.OpenApiPaths is { Length: > 0 })
+        if (settings.OpenApiPaths is not { Length: > 0 })
+            return;
+
+        for (var i = 0; i < settings.OpenApiPaths.Length; i++)
         {
-            for (var i = 0; i < settings.OpenApiPaths.Length; i++)
+            var path = settings.OpenApiPaths[i];
+            if (!IsUrl(path) && !Path.IsPathRooted(path))
             {
-                var path = settings.OpenApiPaths[i];
-                if (!IsUrl(path) && !Path.IsPathRooted(path))
-                {
-                    settings.OpenApiPaths[i] = Path.GetFullPath(Path.Combine(baseDirectory, path));
-                }
+                settings.OpenApiPaths[i] = Path.GetFullPath(Path.Combine(baseDirectory, path));
             }
         }
     }
@@ -70,13 +70,13 @@ public static class RefitterSettingsLoader
         if (string.IsNullOrWhiteSpace(refitGeneratorSettings.OutputFolder))
             refitGeneratorSettings.OutputFolder = RefitGeneratorSettings.DefaultOutputFolder;
 
-        if (string.IsNullOrWhiteSpace(refitGeneratorSettings.OutputFilename))
-        {
-            var refitterFileName = Path.GetFileNameWithoutExtension(settingsFilePath);
-            if (string.IsNullOrEmpty(refitterFileName))
-                refitterFileName = "Output";
-            refitGeneratorSettings.OutputFilename = $"{refitterFileName}.cs";
-        }
+        if (!string.IsNullOrWhiteSpace(refitGeneratorSettings.OutputFilename))
+            return;
+
+        var refitterFileName = Path.GetFileNameWithoutExtension(settingsFilePath);
+        if (string.IsNullOrEmpty(refitterFileName))
+            refitterFileName = "Output";
+        refitGeneratorSettings.OutputFilename = $"{refitterFileName}.cs";
     }
 
     /// <summary>

--- a/src/Refitter.Core/Validation/OpenApiValidator.cs
+++ b/src/Refitter.Core/Validation/OpenApiValidator.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Microsoft.OpenApi;
 using Microsoft.OpenApi.Reader;
 
@@ -5,9 +6,13 @@ namespace Refitter.Core.Validation;
 
 public static class OpenApiValidator
 {
-    public static async Task<OpenApiValidationResult> Validate(string openApiFile)
+    public static async Task<OpenApiValidationResult> Validate(
+        string openApiFile,
+        CancellationToken cancellationToken = default)
     {
-        var result = await OpenApiMultiFileReader.Read(openApiFile);
+        var result = await OpenApiMultiFileReader.Read(
+            openApiFile,
+            cancellationToken: cancellationToken);
 
         var statsVisitor = new OpenApiStats();
         var walker = new OpenApiWalker(statsVisitor);

--- a/src/Refitter.Tests/GenerateCommandTests.cs
+++ b/src/Refitter.Tests/GenerateCommandTests.cs
@@ -111,17 +111,7 @@ public class GenerateCommandTests
             PropertyNamingPolicy = PropertyNamingPolicy.PreserveOriginal
         };
 
-        var method = typeof(GenerateCommand).GetMethod(
-            "CreateRefitGeneratorSettings",
-            BindingFlags.NonPublic | BindingFlags.Static);
-
-        method.Should().NotBeNull();
-
-        var refitSettings = method!
-            .Invoke(null, [settings])
-            .Should()
-            .BeOfType<RefitGeneratorSettings>()
-            .Subject;
+        var refitSettings = SettingsMapper.Map(settings);
 
         refitSettings.PropertyNamingPolicy.Should().Be(PropertyNamingPolicy.PreserveOriginal);
     }
@@ -135,17 +125,7 @@ public class GenerateCommandTests
             JsonLibraryVersion = 9.0m
         };
 
-        var method = typeof(GenerateCommand).GetMethod(
-            "CreateRefitGeneratorSettings",
-            BindingFlags.NonPublic | BindingFlags.Static);
-
-        method.Should().NotBeNull();
-
-        var refitSettings = method!
-            .Invoke(null, [settings])
-            .Should()
-            .BeOfType<RefitGeneratorSettings>()
-            .Subject;
+        var refitSettings = SettingsMapper.Map(settings);
 
         refitSettings.CodeGeneratorSettings!.JsonLibraryVersion.Should().Be(9.0m);
     }
@@ -159,17 +139,7 @@ public class GenerateCommandTests
             JsonLibraryVersion = null
         };
 
-        var method = typeof(GenerateCommand).GetMethod(
-            "CreateRefitGeneratorSettings",
-            BindingFlags.NonPublic | BindingFlags.Static);
-
-        method.Should().NotBeNull();
-
-        var refitSettings = method!
-            .Invoke(null, [settings])
-            .Should()
-            .BeOfType<RefitGeneratorSettings>()
-            .Subject;
+        var refitSettings = SettingsMapper.Map(settings);
 
         refitSettings.CodeGeneratorSettings!.JsonLibraryVersion.Should().Be(8.0m);
     }
@@ -214,13 +184,10 @@ public class GenerateCommandTests
             OutputFilename = "Output.cs"
         };
 
-        var method = typeof(GenerateCommand).GetMethod(
-            "GetOutputPath",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            [typeof(Settings), typeof(RefitGeneratorSettings)]);
-
-        method.Should().NotBeNull();
-        var result = method!.Invoke(null, [settings, refitSettings]) as string;
+        var result = OutputPlanner.GetSingleFileOutputPath(
+            settings.SettingsFilePath,
+            settings.OutputPath,
+            refitSettings);
 
         var expectedPath = Path.Combine(Path.GetDirectoryName(settingsFilePath)!, "./Generated", "Output.cs");
         result.Should().Be(expectedPath);
@@ -240,13 +207,10 @@ public class GenerateCommandTests
             OutputFilename = "Output.cs"
         };
 
-        var method = typeof(GenerateCommand).GetMethod(
-            "GetOutputPath",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            [typeof(Settings), typeof(RefitGeneratorSettings)]);
-
-        method.Should().NotBeNull();
-        var result = method!.Invoke(null, [settings, refitSettings]) as string;
+        var result = OutputPlanner.GetSingleFileOutputPath(
+            settings.SettingsFilePath,
+            settings.OutputPath,
+            refitSettings);
 
         result.Should().Be(Path.Combine("GeneratedCode", "Petstore.cs"));
     }
@@ -265,13 +229,10 @@ public class GenerateCommandTests
             OutputFilename = "Output.cs"
         };
 
-        var method = typeof(GenerateCommand).GetMethod(
-            "GetOutputPath",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            [typeof(Settings), typeof(RefitGeneratorSettings)]);
-
-        method.Should().NotBeNull();
-        var result = method!.Invoke(null, [settings, refitSettings]) as string;
+        var result = OutputPlanner.GetSingleFileOutputPath(
+            settings.SettingsFilePath,
+            settings.OutputPath,
+            refitSettings);
 
         result.Should().Be(Settings.DefaultOutputPath);
     }
@@ -292,12 +253,10 @@ public class GenerateCommandTests
             OutputFilename = "PetStore.cs"
         };
 
-        var method = typeof(GenerateCommand).GetMethod(
-            "GetOutputPath",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            [typeof(Settings), typeof(RefitGeneratorSettings)]);
-
-        var result = method!.Invoke(null, [settings, refitSettings]) as string;
+        var result = OutputPlanner.GetSingleFileOutputPath(
+            settings.SettingsFilePath,
+            settings.OutputPath,
+            refitSettings);
 
         var expectedPath = Path.Combine(Path.GetDirectoryName(settingsFilePath)!, "./CustomOutput", "PetStore.cs");
         result.Should().Be(expectedPath);
@@ -323,12 +282,10 @@ public class GenerateCommandTests
         // Apply defaults first (simulates what GenerateCommand does)
         RefitterSettingsLoader.ApplyDefaults(settingsFilePath, refitSettings);
 
-        var method = typeof(GenerateCommand).GetMethod(
-            "GetOutputPath",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            [typeof(Settings), typeof(RefitGeneratorSettings)]);
-
-        var result = method!.Invoke(null, [settings, refitSettings]) as string;
+        var result = OutputPlanner.GetSingleFileOutputPath(
+            settings.SettingsFilePath,
+            settings.OutputPath,
+            refitSettings);
 
         // Should use settings file base name
         var expectedFilename = Path.GetFileNameWithoutExtension(settingsFilePath) + ".cs";
@@ -351,15 +308,11 @@ public class GenerateCommandTests
             OutputFolder = "./Generated"
         };
 
-        var command = new GenerateCommand();
-        var method = typeof(GenerateCommand).GetMethod(
-            "GetOutputPath",
-            BindingFlags.NonPublic | BindingFlags.Instance,
-            [typeof(Settings), typeof(RefitGeneratorSettings), typeof(GeneratedCode)]);
-
-        method.Should().NotBeNull();
-
-        var result = method!.Invoke(command, [settings, refitSettings, new GeneratedCode("RefitInterfaces", "// code")]) as string;
+        var result = OutputPlanner.GetMultiFileOutputPath(
+            settings.SettingsFilePath,
+            settings.OutputPath,
+            refitSettings,
+            new GeneratedCode("RefitInterfaces", "// code"));
 
         result.Should().Be(Path.Combine("GeneratedCode", "MultipleFiles", "RefitInterfaces.cs"));
     }
@@ -381,15 +334,11 @@ public class GenerateCommandTests
             OutputFolder = "./Generated"
         };
 
-        var command = new GenerateCommand();
-        var method = typeof(GenerateCommand).GetMethod(
-            "GetOutputPath",
-            BindingFlags.NonPublic | BindingFlags.Instance,
-            [typeof(Settings), typeof(RefitGeneratorSettings), typeof(GeneratedCode)]);
-
-        method.Should().NotBeNull();
-
-        var result = method!.Invoke(command, [settings, refitSettings, new GeneratedCode("RefitInterfaces", "// code")]) as string;
+        var result = OutputPlanner.GetMultiFileOutputPath(
+            settings.SettingsFilePath,
+            settings.OutputPath,
+            refitSettings,
+            new GeneratedCode("RefitInterfaces", "// code"));
 
         result.Should().Be(Path.Combine(Path.GetDirectoryName(settingsFilePath)!, "GeneratedCode", "MultipleFiles", "RefitInterfaces.cs"));
     }

--- a/src/Refitter.Tests/GenerationOrchestratorTests.cs
+++ b/src/Refitter.Tests/GenerationOrchestratorTests.cs
@@ -836,12 +836,12 @@ public class GenerationOrchestratorTests
 
         public void ReportHeader(string version) { }
         public void ReportSupportKey(string supportKey) { }
-        public Task ReportSingleFileGenerationProgressAsync() => Task.CompletedTask;
+        public Task ReportSingleFileGenerationProgressAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public void ReportSingleFileOutput(string fileName, string directory, string sizeFormatted, int lines) { }
-        public Task<GeneratorOutput> GenerateMultipleFilesWithProgressAsync(Func<GeneratorOutput> generate) => Task.FromResult(generate());
+        public Task<GeneratorOutput> GenerateMultipleFilesWithProgressAsync(Func<GeneratorOutput> generate, CancellationToken cancellationToken = default) => Task.FromResult(generate());
         public IMultiFileOutputReport BeginMultiFileOutput() => new TestMultiFileOutputReport();
         public void ReportFileWritten(string outputPath) { }
-        public async Task<OpenApiValidationResult> ValidateWithProgressAsync(Func<Task<OpenApiValidationResult>> validate) => await validate();
+        public async Task<OpenApiValidationResult> ValidateWithProgressAsync(Func<Task<OpenApiValidationResult>> validate, CancellationToken cancellationToken = default) => await validate();
         public void ReportValidationFailed() { }
         public void ReportValidationDiagnostic(OpenApiError error, bool isError) { }
         public void ReportValidationStatistics(OpenApiValidationResult validationResult) { }
@@ -890,17 +890,18 @@ public class GenerationOrchestratorTests
 
         public void ReportHeader(string version) { }
         public void ReportSupportKey(string supportKey) => SupportKey = supportKey;
-        public Task ReportSingleFileGenerationProgressAsync() => Task.CompletedTask;
+        public Task ReportSingleFileGenerationProgressAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public void ReportSingleFileOutput(string fileName, string directory, string sizeFormatted, int lines) { }
 
-        public Task<GeneratorOutput> GenerateMultipleFilesWithProgressAsync(Func<GeneratorOutput> generate) =>
+        public Task<GeneratorOutput> GenerateMultipleFilesWithProgressAsync(Func<GeneratorOutput> generate, CancellationToken cancellationToken = default) =>
             Task.FromResult(generate());
 
         public IMultiFileOutputReport BeginMultiFileOutput() => new TestMultiFileOutputReport();
         public void ReportFileWritten(string outputPath) { }
 
         public async Task<OpenApiValidationResult> ValidateWithProgressAsync(
-            Func<Task<OpenApiValidationResult>> validate) => await validate();
+            Func<Task<OpenApiValidationResult>> validate,
+            CancellationToken cancellationToken = default) => await validate();
 
         public void ReportValidationFailed() => ValidationFailedCalled = true;
 

--- a/src/Refitter.Tests/Regression/SettingsCliRegressionTests.cs
+++ b/src/Refitter.Tests/Regression/SettingsCliRegressionTests.cs
@@ -303,13 +303,10 @@ public class SettingsCliRegressionTests
             OutputFilename = "Output.cs"
         };
 
-        var method = typeof(GenerateCommand).GetMethod(
-            "GetOutputPath",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static,
-            new[] { typeof(Settings), typeof(RefitGeneratorSettings) });
-
-        method.Should().NotBeNull();
-        var result = method!.Invoke(null, new object[] { settings, refitSettings }) as string;
+        var result = OutputPlanner.GetSingleFileOutputPath(
+            settings.SettingsFilePath,
+            settings.OutputPath,
+            refitSettings);
 
         // CLI output should override settings file
         // Normalize path separators for cross-platform compatibility
@@ -334,13 +331,10 @@ public class SettingsCliRegressionTests
             OutputFilename = "CustomApi.cs"
         };
 
-        var method = typeof(GenerateCommand).GetMethod(
-            "GetOutputPath",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static,
-            new[] { typeof(Settings), typeof(RefitGeneratorSettings) });
-
-        method.Should().NotBeNull();
-        var result = method!.Invoke(null, new object[] { settings, refitSettings }) as string;
+        var result = OutputPlanner.GetSingleFileOutputPath(
+            settings.SettingsFilePath,
+            settings.OutputPath,
+            refitSettings);
 
         // Should use settings file output
         result.Should().Contain("CustomFolder");

--- a/src/Refitter.Tests/Scenarios/SettingsFileOutputPathTests.cs
+++ b/src/Refitter.Tests/Scenarios/SettingsFileOutputPathTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using FluentAssertions;
 using Refitter.Core;
 using Refitter.Tests.Build;
@@ -149,16 +148,10 @@ public class SettingsFileOutputPathTests
 
     private static string GetOutputPath(Settings settings, RefitGeneratorSettings refitGeneratorSettings)
     {
-        var method = typeof(GenerateCommand).GetMethod(
-            "GetOutputPath",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            null,
-            [typeof(Settings), typeof(RefitGeneratorSettings)],
-            null);
-
-        method.Should().NotBeNull();
-
-        return (string)method!.Invoke(null, [settings, refitGeneratorSettings])!;
+        return OutputPlanner.GetSingleFileOutputPath(
+            settings.SettingsFilePath,
+            settings.OutputPath,
+            refitGeneratorSettings);
     }
 
     private static void ApplySettingsFileDefaults(string settingsFilePath, RefitGeneratorSettings refitGeneratorSettings)

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -55,7 +55,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         }
         else if (!string.IsNullOrWhiteSpace(settings.SettingsFilePath))
         {
-            var json = await File.ReadAllTextAsync(settings.SettingsFilePath);
+            var json = await File.ReadAllTextAsync(settings.SettingsFilePath, cancellationToken);
             refitGeneratorSettings = Serializer.Deserialize<RefitGeneratorSettings>(json);
 
             if (!string.IsNullOrWhiteSpace(settings.OpenApiPath))

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -79,7 +79,9 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
     internal static string FormatGeneratedFileMarker(string outputPath) =>
         $"{GeneratedFileMarker}{Path.GetFullPath(outputPath)}";
 
-    internal static async Task WriteRefitterSettingsFile(Settings settings, RefitGeneratorSettings refitGeneratorSettings)
+    internal static async Task WriteRefitterSettingsFile(
+        Settings settings,
+        RefitGeneratorSettings refitGeneratorSettings)
     {
         var settingsFilePath = DetermineSettingsFilePath(settings);
         var settingsDirectory = Path.GetDirectoryName(settingsFilePath);
@@ -95,18 +97,20 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
 
     internal static string DetermineSettingsFilePath(Settings settings)
     {
-        if (!string.IsNullOrWhiteSpace(settings.OutputPath) &&
-            settings.OutputPath != Settings.DefaultOutputPath)
+        if (string.IsNullOrWhiteSpace(settings.OutputPath) ||
+            settings.OutputPath == Settings.DefaultOutputPath)
         {
-            var outputDir = settings.GenerateMultipleFiles || !string.IsNullOrWhiteSpace(settings.ContractsOutputPath)
-                ? settings.OutputPath
-                : Path.GetDirectoryName(settings.OutputPath);
-
-            if (!string.IsNullOrWhiteSpace(outputDir))
-                return Path.Combine(outputDir, FileExtensionConstants.Refitter);
+            return FileExtensionConstants.Refitter;
         }
 
-        return FileExtensionConstants.Refitter;
+        var specifyOutputPath = !string.IsNullOrWhiteSpace(settings.ContractsOutputPath);
+        var outputDir = settings.GenerateMultipleFiles || specifyOutputPath
+            ? settings.OutputPath
+            : Path.GetDirectoryName(settings.OutputPath);
+
+        return !string.IsNullOrWhiteSpace(outputDir)
+            ? Path.Combine(outputDir, FileExtensionConstants.Refitter)
+            : FileExtensionConstants.Refitter;
     }
 
 }

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -30,15 +30,6 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         if (refitSettings != null)
             cachedSettings = refitSettings;
 
-        if (settings.JsonLibraryVersion is { } cliValue &&
-            cliValue != 8.0m &&
-            refitSettings?.CodeGeneratorSettings?.JsonLibraryVersion is { } fileValue &&
-            fileValue != 8.0m)
-        {
-            return ValidationResult.Error(
-                "Cannot specify --json-library-version via CLI when the settings file also specifies a non-default value. Use only one source.");
-        }
-
         return validationResult;
     }
 
@@ -85,26 +76,6 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             cancellationToken);
     }
 
-    [Obsolete("Use SettingsMapper.Map instead")]
-    private static RefitGeneratorSettings CreateRefitGeneratorSettings(Settings settings) =>
-        SettingsMapper.Map(settings);
-
-    private static string GetOutputPath(Settings settings, RefitGeneratorSettings refitGeneratorSettings) =>
-        OutputPlanner.GetSingleFileOutputPath(
-            settings.SettingsFilePath,
-            settings.OutputPath,
-            refitGeneratorSettings);
-
-    private string GetOutputPath(
-        Settings settings,
-        RefitGeneratorSettings refitGeneratorSettings,
-        GeneratedCode outputFile) =>
-        OutputPlanner.GetMultiFileOutputPath(
-            settings.SettingsFilePath,
-            settings.OutputPath,
-            refitGeneratorSettings,
-            outputFile);
-
     internal static string FormatGeneratedFileMarker(string outputPath) =>
         $"{GeneratedFileMarker}{Path.GetFullPath(outputPath)}";
 
@@ -138,12 +109,4 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         return FileExtensionConstants.Refitter;
     }
 
-    internal static void ResolveRelativeSpecPaths(string settingsFilePath, RefitGeneratorSettings refitGeneratorSettings)
-    {
-        var settingsFileDirectory = Path.GetDirectoryName(Path.GetFullPath(settingsFilePath)) ?? string.Empty;
-        RefitterSettingsLoader.ResolveRelativeSpecPaths(refitGeneratorSettings, settingsFileDirectory);
-    }
-
-    internal static bool IsUrl(string path) =>
-        RefitterSettingsLoader.IsUrl(path);
 }

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -8,7 +8,7 @@ namespace Refitter;
 [ExcludeFromCodeCoverage]
 public sealed class GenerateCommand : AsyncCommand<Settings>
 {
-    internal const string GeneratedFileMarker = "GeneratedFile: ";
+    private const string GeneratedFileMarker = "GeneratedFile: ";
 
     private RefitGeneratorSettings? cachedSettings;
 

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Refitter.Core;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -81,7 +82,8 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
 
     internal static async Task WriteRefitterSettingsFile(
         Settings settings,
-        RefitGeneratorSettings refitGeneratorSettings)
+        RefitGeneratorSettings refitGeneratorSettings,
+        CancellationToken cancellationToken = default)
     {
         var settingsFilePath = DetermineSettingsFilePath(settings);
         var settingsDirectory = Path.GetDirectoryName(settingsFilePath);
@@ -90,7 +92,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             Directory.CreateDirectory(settingsDirectory);
 
         var json = Serializer.Serialize(refitGeneratorSettings);
-        await File.WriteAllTextAsync(settingsFilePath, json);
+        await File.WriteAllTextAsync(settingsFilePath, json, cancellationToken);
 
         CreateReporter(settings).ReportSettingsFileGenerated(settingsFilePath);
     }

--- a/src/Refitter/GenerationOrchestrator.cs
+++ b/src/Refitter/GenerationOrchestrator.cs
@@ -29,9 +29,10 @@ public sealed class GenerationOrchestrator
             reporter.ReportSupportKey(supportKey);
 
             if (!string.IsNullOrWhiteSpace(cliSettings.SettingsFilePath))
-                GenerateCommand.ResolveRelativeSpecPaths(
-                    cliSettings.SettingsFilePath,
-                    refitGeneratorSettings);
+            {
+                var settingsFileDirectory = Path.GetDirectoryName(Path.GetFullPath(cliSettings.SettingsFilePath!)) ?? string.Empty;
+                RefitterSettingsLoader.ResolveRelativeSpecPaths(refitGeneratorSettings, settingsFileDirectory);
+            }
 
             var generator = await RefitGenerator.CreateAsync(refitGeneratorSettings);
 

--- a/src/Refitter/GenerationOrchestrator.cs
+++ b/src/Refitter/GenerationOrchestrator.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Threading;
 using Microsoft.OpenApi;
 using Refitter.Core;
 using Refitter.Core.Validation;
@@ -34,19 +35,21 @@ public sealed class GenerationOrchestrator
                 RefitterSettingsLoader.ResolveRelativeSpecPaths(refitGeneratorSettings, settingsFileDirectory);
             }
 
-            var generator = await RefitGenerator.CreateAsync(refitGeneratorSettings);
+            var generator = await RefitGenerator.CreateAsync(
+                refitGeneratorSettings,
+                cancellationToken);
 
             if (!cliSettings.SkipValidation)
-                await ValidateOpenApiSpecs(refitGeneratorSettings, reporter);
+                await ValidateOpenApiSpecs(refitGeneratorSettings, reporter, cancellationToken);
 
             await (refitGeneratorSettings.GenerateMultipleFiles
-                ? WriteMultipleFiles(generator, cliSettings, refitGeneratorSettings, reporter)
-                : WriteSingleFile(generator, cliSettings, refitGeneratorSettings, reporter));
+                ? WriteMultipleFiles(generator, cliSettings, refitGeneratorSettings, reporter, cancellationToken)
+                : WriteSingleFile(generator, cliSettings, refitGeneratorSettings, reporter, cancellationToken));
 
             Analytics.LogFeatureUsage(cliSettings, refitGeneratorSettings);
 
             if (string.IsNullOrWhiteSpace(cliSettings.SettingsFilePath))
-                await GenerateCommand.WriteRefitterSettingsFile(cliSettings, refitGeneratorSettings);
+                await GenerateCommand.WriteRefitterSettingsFile(cliSettings, refitGeneratorSettings, cancellationToken);
 
             if (refitGeneratorSettings.IncludePathMatches.Length > 0 &&
                 generator.OpenApiDocument.Paths.Count == 0)
@@ -87,9 +90,11 @@ public sealed class GenerationOrchestrator
         RefitGenerator generator,
         Settings settings,
         RefitGeneratorSettings refitGeneratorSettings,
-        IGenerationReporter reporter)
+        IGenerationReporter reporter,
+        CancellationToken cancellationToken)
     {
-        await reporter.ReportSingleFileGenerationProgressAsync();
+        cancellationToken.ThrowIfCancellationRequested();
+        await reporter.ReportSingleFileGenerationProgressAsync(cancellationToken);
 
         var code = generator.Generate().ReplaceLineEndings();
         var planned = OutputPlanner.PlanSingleFile(
@@ -108,7 +113,7 @@ public sealed class GenerationOrchestrator
         var dir = Path.GetDirectoryName(planned.Path);
         if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
-        await File.WriteAllTextAsync(planned.Path, planned.Content);
+        await File.WriteAllTextAsync(planned.Path, planned.Content, cancellationToken);
         reporter.ReportFileWritten(planned.Path);
     }
 
@@ -116,10 +121,13 @@ public sealed class GenerationOrchestrator
         RefitGenerator generator,
         Settings settings,
         RefitGeneratorSettings refitGeneratorSettings,
-        IGenerationReporter reporter)
+        IGenerationReporter reporter,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var generatorOutput = await reporter.GenerateMultipleFilesWithProgressAsync(
-            generator.GenerateMultipleFiles);
+            generator.GenerateMultipleFiles,
+            cancellationToken);
 
         var planned = OutputPlanner.PlanMultipleFiles(
             settings.SettingsFilePath,
@@ -148,7 +156,8 @@ public sealed class GenerationOrchestrator
             var plannedDir = Path.GetDirectoryName(plannedFile.Path);
             if (!string.IsNullOrWhiteSpace(plannedDir) && !Directory.Exists(plannedDir))
                 Directory.CreateDirectory(plannedDir);
-            await File.WriteAllTextAsync(plannedFile.Path, plannedFile.Content);
+            cancellationToken.ThrowIfCancellationRequested();
+            await File.WriteAllTextAsync(plannedFile.Path, plannedFile.Content, cancellationToken);
             reporter.ReportFileWritten(plannedFile.Path);
         }
 
@@ -172,23 +181,29 @@ public sealed class GenerationOrchestrator
 
     private static async Task ValidateOpenApiSpecs(
         RefitGeneratorSettings refitGeneratorSettings,
-        IGenerationReporter reporter)
+        IGenerationReporter reporter,
+        CancellationToken cancellationToken)
     {
         if (refitGeneratorSettings.OpenApiPaths is { Length: > 0 })
         {
             foreach (var specPath in refitGeneratorSettings.OpenApiPaths)
-                await ValidateOpenApiSpec(specPath, reporter);
+                await ValidateOpenApiSpec(specPath, reporter, cancellationToken);
         }
         else if (refitGeneratorSettings.OpenApiPath is not null)
         {
-            await ValidateOpenApiSpec(refitGeneratorSettings.OpenApiPath, reporter);
+            await ValidateOpenApiSpec(refitGeneratorSettings.OpenApiPath, reporter, cancellationToken);
         }
     }
 
-    private static async Task ValidateOpenApiSpec(string openApiPath, IGenerationReporter reporter)
+    private static async Task ValidateOpenApiSpec(
+        string openApiPath,
+        IGenerationReporter reporter,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var validationResult = await reporter.ValidateWithProgressAsync(
-            () => Refitter.Core.Validation.OpenApiValidator.Validate(openApiPath));
+            () => Refitter.Core.Validation.OpenApiValidator.Validate(openApiPath, cancellationToken),
+            cancellationToken);
 
         if (!validationResult.IsValid)
         {

--- a/src/Refitter/IGenerationReporter.cs
+++ b/src/Refitter/IGenerationReporter.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Microsoft.OpenApi;
 using Refitter.Core;
 using Refitter.Core.Validation;
@@ -17,11 +18,11 @@ public interface IGenerationReporter
 
     void ReportSupportKey(string supportKey);
 
-    Task ReportSingleFileGenerationProgressAsync();
+    Task ReportSingleFileGenerationProgressAsync(CancellationToken cancellationToken = default);
 
     void ReportSingleFileOutput(string fileName, string directory, string sizeFormatted, int lines);
 
-    Task<GeneratorOutput> GenerateMultipleFilesWithProgressAsync(Func<GeneratorOutput> generate);
+    Task<GeneratorOutput> GenerateMultipleFilesWithProgressAsync(Func<GeneratorOutput> generate, CancellationToken cancellationToken = default);
 
     IMultiFileOutputReport BeginMultiFileOutput();
 
@@ -31,7 +32,7 @@ public interface IGenerationReporter
     /// </summary>
     void ReportFileWritten(string outputPath);
 
-    Task<OpenApiValidationResult> ValidateWithProgressAsync(Func<Task<OpenApiValidationResult>> validate);
+    Task<OpenApiValidationResult> ValidateWithProgressAsync(Func<Task<OpenApiValidationResult>> validate, CancellationToken cancellationToken = default);
 
     void ReportValidationFailed();
 

--- a/src/Refitter/RichGenerationReporter.cs
+++ b/src/Refitter/RichGenerationReporter.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Microsoft.OpenApi;
 using Refitter.Core;
 using Refitter.Core.Validation;
@@ -41,14 +42,14 @@ internal sealed class RichGenerationReporter : IGenerationReporter
         AnsiConsole.WriteLine();
     }
 
-    public async Task ReportSingleFileGenerationProgressAsync()
+    public async Task ReportSingleFileGenerationProgressAsync(CancellationToken cancellationToken = default)
     {
         await AnsiConsole.Status()
             .Spinner(Spinner.Known.Dots)
             .SpinnerStyle(Style.Parse("green bold"))
             .StartAsync("[yellow]🔧 Generating code...[/]", async _ =>
             {
-                await Task.Delay(100); // Brief delay to show spinner
+                await Task.Delay(100, cancellationToken); // Brief delay to show spinner
             });
     }
 
@@ -68,14 +69,17 @@ internal sealed class RichGenerationReporter : IGenerationReporter
         AnsiConsole.WriteLine();
     }
 
-    public async Task<GeneratorOutput> GenerateMultipleFilesWithProgressAsync(Func<GeneratorOutput> generate)
+    public async Task<GeneratorOutput> GenerateMultipleFilesWithProgressAsync(
+        Func<GeneratorOutput> generate,
+        CancellationToken cancellationToken = default)
     {
         return await AnsiConsole.Status()
             .Spinner(Spinner.Known.Dots)
             .SpinnerStyle(Style.Parse("green bold"))
             .StartAsync("[yellow]🔧 Generating multiple files...[/]", async _ =>
             {
-                await Task.Delay(100); // Brief delay to show spinner
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Delay(100, cancellationToken); // Brief delay to show spinner
                 return generate();
             });
     }
@@ -87,13 +91,16 @@ internal sealed class RichGenerationReporter : IGenerationReporter
         // Rich output does not emit the machine-readable marker.
     }
 
-    public async Task<OpenApiValidationResult> ValidateWithProgressAsync(Func<Task<OpenApiValidationResult>> validate)
+    public async Task<OpenApiValidationResult> ValidateWithProgressAsync(
+        Func<Task<OpenApiValidationResult>> validate,
+        CancellationToken cancellationToken = default)
     {
         return await AnsiConsole.Status()
             .Spinner(Spinner.Known.Dots)
             .SpinnerStyle(Style.Parse("cyan bold"))
             .StartAsync("[cyan]🔍 Validating OpenAPI specification...[/]", async _ =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 return await validate();
             });
     }

--- a/src/Refitter/SettingsValidator.cs
+++ b/src/Refitter/SettingsValidator.cs
@@ -29,7 +29,10 @@ public static class SettingsValidator
 
         if (!string.IsNullOrWhiteSpace(settings.SettingsFilePath))
         {
-            return ValidateFilePath(settings, out refitSettings);
+            var fileResult = ValidateFilePath(settings, out refitSettings);
+            if (!fileResult.Successful)
+                return fileResult;
+            return ValidateJsonLibraryVersionConflict(settings, refitSettings);
         }
 
         return ValidateOperationNameAndUrl(settings);
@@ -86,7 +89,8 @@ public static class SettingsValidator
         }
 
         RefitterSettingsLoader.ApplyDefaults(settings.SettingsFilePath!, refitGeneratorSettings);
-        GenerateCommand.ResolveRelativeSpecPaths(settings.SettingsFilePath!, refitGeneratorSettings);
+        var settingsFileDirectory = Path.GetDirectoryName(Path.GetFullPath(settings.SettingsFilePath!)) ?? string.Empty;
+        RefitterSettingsLoader.ResolveRelativeSpecPaths(refitGeneratorSettings, settingsFileDirectory);
         refitSettings = refitGeneratorSettings;
 
         // Then populate settings.OpenApiPath and validate file existence
@@ -97,7 +101,7 @@ public static class SettingsValidator
             for (var i = 0; i < refitGeneratorSettings.OpenApiPaths.Length; i++)
             {
                 var path = refitGeneratorSettings.OpenApiPaths[i];
-                if (!GenerateCommand.IsUrl(path))
+                if (!IsUrl(path))
                 {
                     if (!File.Exists(path))
                     {
@@ -186,6 +190,22 @@ public static class SettingsValidator
     private static ValidationResult GetValidationErrorForOperationName()
     {
         return ValidationResult.Error("'{operationName}' placeholder must be present in operation name template");
+    }
+
+    private static ValidationResult ValidateJsonLibraryVersionConflict(
+        Settings settings,
+        RefitGeneratorSettings? refitSettings)
+    {
+        if (settings.JsonLibraryVersion is { } cliValue &&
+            cliValue != 8.0m &&
+            refitSettings?.CodeGeneratorSettings?.JsonLibraryVersion is { } fileValue &&
+            fileValue != 8.0m)
+        {
+            return ValidationResult.Error(
+                "Cannot specify --json-library-version via CLI when the settings file also specifies a non-default value. Use only one source.");
+        }
+
+        return ValidationResult.Success();
     }
 
     private static ValidationResult ValidateFileExistence(Settings settings)

--- a/src/Refitter/SimpleGenerationReporter.cs
+++ b/src/Refitter/SimpleGenerationReporter.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Microsoft.OpenApi;
 using Refitter.Core;
 using Refitter.Core.Validation;
@@ -27,7 +28,7 @@ internal sealed class SimpleGenerationReporter : IGenerationReporter
         Console.WriteLine();
     }
 
-    public Task ReportSingleFileGenerationProgressAsync()
+    public Task ReportSingleFileGenerationProgressAsync(CancellationToken cancellationToken = default)
     {
         Console.WriteLine("Generating code...");
         return Task.CompletedTask;
@@ -43,7 +44,9 @@ internal sealed class SimpleGenerationReporter : IGenerationReporter
         Console.WriteLine();
     }
 
-    public Task<GeneratorOutput> GenerateMultipleFilesWithProgressAsync(Func<GeneratorOutput> generate)
+    public Task<GeneratorOutput> GenerateMultipleFilesWithProgressAsync(
+        Func<GeneratorOutput> generate,
+        CancellationToken cancellationToken = default)
     {
         Console.WriteLine("Generating multiple files...");
         return Task.FromResult(generate());
@@ -54,7 +57,9 @@ internal sealed class SimpleGenerationReporter : IGenerationReporter
     public void ReportFileWritten(string outputPath) =>
         Console.WriteLine(GenerateCommand.FormatGeneratedFileMarker(outputPath));
 
-    public async Task<OpenApiValidationResult> ValidateWithProgressAsync(Func<Task<OpenApiValidationResult>> validate)
+    public async Task<OpenApiValidationResult> ValidateWithProgressAsync(
+        Func<Task<OpenApiValidationResult>> validate,
+        CancellationToken cancellationToken = default)
     {
         Console.WriteLine("Validating OpenAPI specification...");
         return await validate();


### PR DESCRIPTION
This pull request introduces support for cancellation tokens throughout the OpenAPI document loading, validation, and generation processes. By propagating `CancellationToken` parameters through public APIs and internal methods, the codebase now allows for cooperative cancellation of long-running or I/O-bound operations, improving responsiveness and control, especially in CLI and test scenarios. Additionally, some minor code cleanups and logic improvements were made.

**Cancellation support and API changes:**

* Added `CancellationToken` parameters (defaulting to `default`) to all relevant public and internal async methods in `DocumentLoader`, `OpenApiDocumentFactory`, `RefitGenerator`, and `OpenApiValidator`, and updated their implementations to honor cancellation requests. [[1]](diffhunk://#diff-486297db65b5a559f1659ca72abd1cffade0e5e8c8e2572e87b06d3a62344312L28-R44) [[2]](diffhunk://#diff-486297db65b5a559f1659ca72abd1cffade0e5e8c8e2572e87b06d3a62344312L53-R70) [[3]](diffhunk://#diff-e074b7f9713fd1462a1fcc97fc7854f0d4b48184029b29c444b00d70debd691eR1-R9) [[4]](diffhunk://#diff-d81412fe6a672f7b09e26ce2b108a075f16f6853d73db638cb3a1f27b728ff1bR21-R27) [[5]](diffhunk://#diff-d81412fe6a672f7b09e26ce2b108a075f16f6853d73db638cb3a1f27b728ff1bL33-R44) [[6]](diffhunk://#diff-d81412fe6a672f7b09e26ce2b108a075f16f6853d73db638cb3a1f27b728ff1bR53-R59) [[7]](diffhunk://#diff-275851d6772d6a0a03b9aaf63017c87331d0334e274deeebd199fe8cd07cc521L22-R29) [[8]](diffhunk://#diff-275851d6772d6a0a03b9aaf63017c87331d0334e274deeebd199fe8cd07cc521L38-R46) [[9]](diffhunk://#diff-275851d6772d6a0a03b9aaf63017c87331d0334e274deeebd199fe8cd07cc521L50-R55) [[10]](diffhunk://#diff-497c532f96f4e9f740f13ef23719c509a511f13da403abd30935844498da844dR1-R15)

* Updated HTTP content loading in `DocumentLoader` to use `HttpClient.GetAsync` with cancellation support, and to ensure HTTP response success.

**CLI and test integration:**

* Updated `GenerateCommand` in the CLI to use cancellation tokens when reading files and writing settings, and refactored some internal methods for clarity. [[1]](diffhunk://#diff-5a3744a20d6fb16b3196ad75a6cffd5df047271cf9c9b8ca898f93784eecce31L67-R59) [[2]](diffhunk://#diff-5a3744a20d6fb16b3196ad75a6cffd5df047271cf9c9b8ca898f93784eecce31L88-R86)

* Modified test reporters in `GenerationOrchestratorTests` to accept and propagate cancellation tokens in all relevant async methods, ensuring test coverage for cancellation scenarios. [[1]](diffhunk://#diff-e776491e6c316d24396c26d87ccad9fa265b62d15692ba6f454a5582ea42ea99L839-R844) [[2]](diffhunk://#diff-e776491e6c316d24396c26d87ccad9fa265b62d15692ba6f454a5582ea42ea99L893-R904)

**Logic and code cleanup:**

* Improved logic in `RefitterSettingsLoader` for handling `OpenApiPaths` and default output filename assignment, making the code more concise and robust. [[1]](diffhunk://#diff-3bb86477a3e08f6fa591beced76795a5ec5c4c7d3ca80b8e5cdc2cccd178dcafL47-R49) [[2]](diffhunk://#diff-3bb86477a3e08f6fa591beced76795a5ec5c4c7d3ca80b8e5cdc2cccd178dcafL58) [[3]](diffhunk://#diff-3bb86477a3e08f6fa591beced76795a5ec5c4c7d3ca80b8e5cdc2cccd178dcafL73-L80)

* Minor code cleanups, such as making `GeneratedFileMarker` private and removing obsolete or redundant code in `GenerateCommand`. [[1]](diffhunk://#diff-5a3744a20d6fb16b3196ad75a6cffd5df047271cf9c9b8ca898f93784eecce31L11-R12) [[2]](diffhunk://#diff-5a3744a20d6fb16b3196ad75a6cffd5df047271cf9c9b8ca898f93784eecce31L33-L41) [[3]](diffhunk://#diff-5a3744a20d6fb16b3196ad75a6cffd5df047271cf9c9b8ca898f93784eecce31L88-R86)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long-running operations (OpenAPI spec loading, code generation, and validation) now support cancellation, enabling better control and graceful interruption of workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->