### PR TITLE
Separate output planning from writing

### DIFF
--- a/src/Refitter.Core/Abstractions/IFileWriter.cs
+++ b/src/Refitter.Core/Abstractions/IFileWriter.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Refitter.Core;
+
+/// <summary>
+/// Writes a <see cref="PlannedFile"/> to disk, creating directories as needed.
+/// Each distribution form (CLI, MSBuild, Source Generator) provides its own adapter
+/// that integrates with its own reporting/progress pipeline.
+/// </summary>
+public interface IFileWriter
+{
+    /// <summary>
+    /// Writes the planned file to disk, creating directories as necessary.
+    /// </summary>
+    /// <param name="file">The planned file to write.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous write operation.</returns>
+    Task WriteAsync(PlannedFile file, CancellationToken cancellationToken = default);
+}

--- a/src/Refitter.Core/Abstractions/IOutputPlanner.cs
+++ b/src/Refitter.Core/Abstractions/IOutputPlanner.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Refitter.Core;
+
+/// <summary>
+/// Resolves a <see cref="GeneratorOutput"/> into a list of <see cref="PlannedFile"/> instances.
+/// Pure logic — no I/O.
+/// </summary>
+public interface IOutputPlanner
+{
+    /// <summary>
+    /// Plans the output file paths for the given generator output.
+    /// </summary>
+    /// <param name="output">The generator output containing generated files.</param>
+    /// <param name="config">The output configuration.</param>
+    /// <param name="settingsFilePath">
+    /// The path to the settings file, or <c>null</c> for direct CLI generation.
+    /// </param>
+    /// <param name="cliOutputPath">
+    /// The output path specified via CLI, or <c>null</c>.
+    /// </param>
+    /// <returns>A read-only list of planned files with resolved paths and content.</returns>
+    IReadOnlyList<PlannedFile> Plan(
+        GeneratorOutput output,
+        IOutputConfiguration config,
+        string? settingsFilePath,
+        string? cliOutputPath);
+}

--- a/src/Refitter.Core/Abstractions/OutputPlannerAdapter.cs
+++ b/src/Refitter.Core/Abstractions/OutputPlannerAdapter.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace Refitter.Core;
+
+/// <summary>
+/// Adapts the static <see cref="OutputPlanner"/> methods to the <see cref="IOutputPlanner"/> interface.
+/// </summary>
+public class OutputPlannerAdapter : IOutputPlanner
+{
+    /// <inheritdoc />
+    public IReadOnlyList<PlannedFile> Plan(
+        GeneratorOutput output,
+        IOutputConfiguration config,
+        string? settingsFilePath,
+        string? cliOutputPath)
+    {
+        if (config.GenerateMultipleFiles)
+        {
+            return OutputPlanner.PlanMultipleFiles(
+                settingsFilePath,
+                cliOutputPath,
+                config,
+                output);
+        }
+
+        var code = output.Files.Count > 0
+            ? output.Files[0].Content
+            : string.Empty;
+
+        return
+        [
+            OutputPlanner.PlanSingleFile(
+                settingsFilePath,
+                cliOutputPath,
+                config,
+                code)
+        ];
+    }
+}

--- a/src/Refitter.Core/Abstractions/SourceGeneratorFileWriter.cs
+++ b/src/Refitter.Core/Abstractions/SourceGeneratorFileWriter.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Refitter.Core;
+
+/// <summary>
+/// Writes planned files to disk with content-equality checking.
+/// Skips writing when the file already exists with identical content,
+/// avoiding unnecessary disk writes during incremental / design-time builds.
+/// </summary>
+public class SourceGeneratorFileWriter : IFileWriter
+{
+    /// <inheritdoc />
+    public Task WriteAsync(PlannedFile file, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var dir = Path.GetDirectoryName(file.Path);
+        if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var existingContent = File.Exists(file.Path)
+            ? File.ReadAllText(file.Path, Encoding.UTF8)
+            : null;
+
+        if (existingContent is null || !string.Equals(existingContent, file.Content, System.StringComparison.Ordinal))
+        {
+            File.WriteAllText(file.Path, file.Content, Encoding.UTF8);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Refitter.MSBuild/MsBuildFileWriter.cs
+++ b/src/Refitter.MSBuild/MsBuildFileWriter.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Refitter.Core;
+
+namespace Refitter.MSBuild;
+
+/// <summary>
+/// Writes planned files to disk from within an MSBuild task.
+/// Creates directories as needed. No logging dependencies — the calling task
+/// handles reporting.
+/// </summary>
+public class MsBuildFileWriter : IFileWriter
+{
+    /// <inheritdoc />
+    public Task WriteAsync(PlannedFile file, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var dir = Path.GetDirectoryName(file.Path);
+        if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        File.WriteAllText(file.Path, file.Content);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Refitter.MSBuild/RefitterGenerateTask.cs
+++ b/src/Refitter.MSBuild/RefitterGenerateTask.cs
@@ -74,41 +74,40 @@ public class RefitterGenerateTask : MSBuildTask
         var generator = RefitGenerator.CreateAsync(settings)
             .GetAwaiter().GetResult();
 
+        var planner = new OutputPlannerAdapter();
+        var writer = new MsBuildFileWriter();
+
         var generatedFiles = new List<string>();
 
         if (settings.GenerateMultipleFiles)
         {
             var output = generator.GenerateMultipleFiles();
-            foreach (var outputFile in output.Files)
+            var plannedFiles = planner.Plan(
+                output,
+                settings,
+                filePath,
+                cliOutputPath: null);
+
+            foreach (var plannedFile in plannedFiles)
             {
-                var outputPath = OutputPlanner.GetMultiFileOutputPath(
-                    filePath,
-                    cliOutputPath: null,
-                    settings,
-                    outputFile);
-
-                var dir = Path.GetDirectoryName(outputPath);
-                if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
-                    Directory.CreateDirectory(dir);
-
-                File.WriteAllText(outputPath, outputFile.Content);
-                generatedFiles.Add(Path.GetFullPath(outputPath));
+                writer.WriteAsync(plannedFile).GetAwaiter().GetResult();
+                generatedFiles.Add(Path.GetFullPath(plannedFile.Path));
             }
         }
         else
         {
             var code = generator.Generate().Replace("\r\n", "\n");
-            var outputPath = OutputPlanner.GetSingleFileOutputPath(
+            var output = new GeneratorOutput(
+                new List<GeneratedCode> { new(string.Empty, code) });
+
+            var plannedFiles = planner.Plan(
+                output,
+                settings,
                 filePath,
-                cliOutputPath: null,
-                settings);
+                cliOutputPath: null);
 
-            var dir = Path.GetDirectoryName(outputPath);
-            if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
-
-            File.WriteAllText(outputPath, code);
-            generatedFiles.Add(Path.GetFullPath(outputPath));
+            writer.WriteAsync(plannedFiles[0]).GetAwaiter().GetResult();
+            generatedFiles.Add(Path.GetFullPath(plannedFiles[0].Path));
         }
 
         if (!SkipValidation)

--- a/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
+++ b/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
@@ -27,6 +27,7 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(AssemblyName).props" Pack="true" PackagePath="build" />
     <Compile Include="../Refitter.Core/*.cs" />
+    <Compile Include="../Refitter.Core/Abstractions/*.cs" />
     <Compile Include="../Refitter.Core/Apizr/*.cs" />
     <Compile Include="../Refitter.Core/CodeGeneration/*.cs" />
     <Compile Include="../Refitter.Core/Contracts/*.cs" />

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -1,7 +1,5 @@
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Text;
 using H.Generators.Extensions;
 using Microsoft.CodeAnalysis;
 using Refitter.Core;

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -100,7 +100,7 @@ public class RefitterSourceGenerator : IIncrementalGenerator
 
             var outputPath = GetOutputPath(file.Path, settings);
             var planned = new PlannedFile(outputPath, refit);
-            WriteGeneratedFile(planned, diagnostics);
+            WriteGeneratedFile(planned, diagnostics, cancellationToken);
 
             return new GeneratedCode(diagnostics.ToImmutableArray().AsEquatableArray(), outputPath);
         }
@@ -121,12 +121,12 @@ public class RefitterSourceGenerator : IIncrementalGenerator
             return Path.Combine(folder, filename);
         }
 
-        static void WriteGeneratedFile(PlannedFile planned, List<GeneratedDiagnostic> diagnostics)
+        static void WriteGeneratedFile(PlannedFile planned, List<GeneratedDiagnostic> diagnostics, CancellationToken cancellationToken)
         {
             try
             {
                 var writer = new SourceGeneratorFileWriter();
-                writer.WriteAsync(planned).GetAwaiter().GetResult();
+                writer.WriteAsync(planned, cancellationToken).GetAwaiter().GetResult();
                 diagnostics.Add(CreateGeneratedSuccessfullyDiagnostic(planned.Path));
             }
             catch (Exception e)

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -101,7 +101,8 @@ public class RefitterSourceGenerator : IIncrementalGenerator
             cancellationToken.ThrowIfCancellationRequested();
 
             var outputPath = GetOutputPath(file.Path, settings);
-            WriteGeneratedFile(outputPath, refit, diagnostics);
+            var planned = new PlannedFile(outputPath, refit);
+            WriteGeneratedFile(planned, diagnostics);
 
             return new GeneratedCode(diagnostics.ToImmutableArray().AsEquatableArray(), outputPath);
         }
@@ -122,23 +123,13 @@ public class RefitterSourceGenerator : IIncrementalGenerator
             return Path.Combine(folder, filename);
         }
 
-        static void WriteGeneratedFile(string outputPath, string content, List<GeneratedDiagnostic> diagnostics)
+        static void WriteGeneratedFile(PlannedFile planned, List<GeneratedDiagnostic> diagnostics)
         {
             try
             {
-                var folder = Path.GetDirectoryName(outputPath);
-                if (!string.IsNullOrEmpty(folder) && !Directory.Exists(folder))
-                {
-                    Directory.CreateDirectory(folder);
-                }
-
-                var existingContent = File.Exists(outputPath) ? File.ReadAllText(outputPath, Encoding.UTF8) : null;
-                if (existingContent == null || !existingContent.Equals(content, StringComparison.Ordinal))
-                {
-                    File.WriteAllText(outputPath, content, Encoding.UTF8);
-                }
-
-                diagnostics.Add(CreateGeneratedSuccessfullyDiagnostic(outputPath));
+                var writer = new SourceGeneratorFileWriter();
+                writer.WriteAsync(planned).GetAwaiter().GetResult();
+                diagnostics.Add(CreateGeneratedSuccessfullyDiagnostic(planned.Path));
             }
             catch (Exception e)
             {

--- a/src/Refitter.Tests/CliFileWriterTests.cs
+++ b/src/Refitter.Tests/CliFileWriterTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Refitter;
+using Refitter.Core;
+using TUnit.Core;
+
+namespace Refitter.Tests;
+
+public class CliFileWriterTests
+{
+    [Test]
+    public async Task WriteAsync_Creates_Directory_And_Writes_File()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "CliFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var reporter = new SimpleGenerationReporter();
+            var writer = new CliFileWriter(reporter);
+            var filePath = Path.Combine(workspace, "Generated", "Output.cs");
+            var planned = new PlannedFile(filePath, "// test content");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// test content");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task WriteAsync_Does_Not_Throw_When_Directory_Already_Exists()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "CliFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(workspace);
+            var existingFile = Path.Combine(workspace, "Existing.cs");
+            await File.WriteAllTextAsync(existingFile, "existing");
+
+            var reporter = new SimpleGenerationReporter();
+            var writer = new CliFileWriter(reporter);
+            var newFile = Path.Combine(workspace, "Output.cs");
+            var planned = new PlannedFile(newFile, "// new content");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(existingFile).Should().BeTrue();
+            File.Exists(newFile).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(newFile);
+            content.Should().Be("// new content");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task WriteAsync_Writes_To_File_In_Existing_Directory()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "CliFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(workspace);
+            var filePath = Path.Combine(workspace, "Output.cs");
+            var reporter = new SimpleGenerationReporter();
+            var writer = new CliFileWriter(reporter);
+            var planned = new PlannedFile(filePath, "// test");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// test");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+}

--- a/src/Refitter.Tests/MsBuildFileWriterTests.cs
+++ b/src/Refitter.Tests/MsBuildFileWriterTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.MSBuild;
+using TUnit.Core;
+
+namespace Refitter.Tests;
+
+public class MsBuildFileWriterTests
+{
+    [Test]
+    public async Task WriteAsync_Creates_Directory_And_Writes_File()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "MsBuildFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var writer = new MsBuildFileWriter();
+            var filePath = Path.Combine(workspace, "Generated", "Output.cs");
+            var planned = new PlannedFile(filePath, "// msbuild test");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// msbuild test");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task WriteAsync_Does_Not_Throw_When_Directory_Already_Exists()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "MsBuildFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(workspace);
+
+            var writer = new MsBuildFileWriter();
+            var filePath = Path.Combine(workspace, "Output.cs");
+            var planned = new PlannedFile(filePath, "// test");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+}

--- a/src/Refitter.Tests/OutputPlannerAdapterTests.cs
+++ b/src/Refitter.Tests/OutputPlannerAdapterTests.cs
@@ -1,0 +1,198 @@
+using FluentAssertions;
+using Refitter.Core;
+using TUnit.Core;
+
+namespace Refitter.Tests;
+
+public class OutputPlannerAdapterTests
+{
+    private static readonly IOutputPlanner Planner = new OutputPlannerAdapter();
+
+    [Test]
+    public void Plan_SingleFile_DirectCli_Explicit_Output_Is_Used()
+    {
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            OutputFilename = "Output.cs",
+            GenerateMultipleFiles = false,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("GeneratedType", "// code")
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath: null,
+            cliOutputPath: Path.Combine("GeneratedCode", "Petstore.cs"));
+
+        planned.Should().ContainSingle();
+        planned[0].Path.Should().Be(Path.Combine("GeneratedCode", "Petstore.cs"));
+        planned[0].Content.Should().Be("// code");
+    }
+
+    [Test]
+    public void Plan_SingleFile_DirectCli_Default_Uses_DefaultOutputPath()
+    {
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            OutputFilename = "Output.cs",
+            GenerateMultipleFiles = false,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("GeneratedType", "// code")
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath: null,
+            cliOutputPath: OutputPlanner.DefaultOutputPath);
+
+        planned.Should().ContainSingle();
+        planned[0].Path.Should().Be(OutputPlanner.DefaultOutputPath);
+        planned[0].Content.Should().Be("// code");
+    }
+
+    [Test]
+    public void Plan_SingleFile_SettingsFile_Roots_Relative_To_Settings_Directory()
+    {
+        var settingsFilePath = Path.Combine(Path.GetTempPath(), "Projects", "MyApi", "petstore.refitter");
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            OutputFilename = "Output.cs",
+            GenerateMultipleFiles = false,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("GeneratedType", "// code")
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath,
+            cliOutputPath: null);
+
+        planned.Should().ContainSingle();
+        var expected = Path.Combine(Path.GetDirectoryName(settingsFilePath)!, "./Generated", "Output.cs");
+        planned[0].Path.Should().Be(expected);
+        planned[0].Content.Should().Be("// code");
+    }
+
+    [Test]
+    public void Plan_MultiFile_DirectCli_Combines_Output_Directory_And_Filename()
+    {
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            GenerateMultipleFiles = true,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("RefitInterfaces", "// interfaces"),
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath: null,
+            cliOutputPath: Path.Combine("GeneratedCode", "MultipleFiles"));
+
+        planned.Should().ContainSingle();
+        planned[0].Path.Should().Be(Path.Combine("GeneratedCode", "MultipleFiles", "RefitInterfaces.cs"));
+        planned[0].Content.Should().Be("// interfaces");
+    }
+
+    [Test]
+    public void Plan_MultiFile_SettingsFile_Roots_Explicit_Cli_Override()
+    {
+        var settingsFilePath = Path.Combine(Path.GetTempPath(), "Projects", "MyApi", "petstore.refitter");
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            GenerateMultipleFiles = true,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("RefitInterfaces", "// interfaces"),
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath,
+            cliOutputPath: Path.Combine("GeneratedCode", "MultipleFiles"));
+
+        planned.Should().ContainSingle();
+        var expected = Path.Combine(Path.GetDirectoryName(settingsFilePath)!, "GeneratedCode", "MultipleFiles", "RefitInterfaces.cs");
+        planned[0].Path.Should().Be(expected);
+        planned[0].Content.Should().Be("// interfaces");
+    }
+
+    [Test]
+    public void Plan_MultiFile_Reroutes_Contracts_To_Separate_Folder()
+    {
+        var settingsFilePath = Path.Combine(Path.GetTempPath(), "Projects", "MyApi", "petstore.refitter");
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            ContractsOutputFolder = "./Contracts",
+            GenerateMultipleFiles = true,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("RefitInterfaces", "// interfaces"),
+            new(TypenameConstants.Contracts, "// contracts"),
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath,
+            cliOutputPath: null);
+
+        planned.Should().HaveCount(2);
+        planned[0].Content.Should().Be("// interfaces");
+        planned[1].Content.Should().Be("// contracts");
+
+        var contractsFolder = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(settingsFilePath)!, "./Contracts"));
+        planned[1].Path.Should().Be(Path.Combine(contractsFolder, $"{TypenameConstants.Contracts}.cs"));
+    }
+
+    [Test]
+    public void Plan_Preserves_Content_For_Each_File()
+    {
+        var config = new RefitGeneratorSettings
+        {
+            GenerateMultipleFiles = true,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("Interface1", "// content 1"),
+            new("Interface2", "// content 2"),
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath: null,
+            cliOutputPath: null);
+
+        planned.Should().HaveCount(2);
+        planned[0].Content.Should().Be("// content 1");
+        planned[1].Content.Should().Be("// content 2");
+    }
+}

--- a/src/Refitter.Tests/SourceGeneratorFileWriterTests.cs
+++ b/src/Refitter.Tests/SourceGeneratorFileWriterTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Refitter.Core;
+using TUnit.Core;
+
+namespace Refitter.Tests;
+
+public class SourceGeneratorFileWriterTests
+{
+    [Test]
+    public async Task WriteAsync_Creates_Directory_And_Writes_File()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "SourceGeneratorFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var writer = new SourceGeneratorFileWriter();
+            var filePath = Path.Combine(workspace, "Generated", "Output.g.cs");
+            var planned = new PlannedFile(filePath, "// sourcegen test");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// sourcegen test");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task WriteAsync_Skips_Write_When_Content_Identical()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "SourceGeneratorFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(workspace);
+            var filePath = Path.Combine(workspace, "Output.g.cs");
+            await File.WriteAllTextAsync(filePath, "// original content");
+
+            var writer = new SourceGeneratorFileWriter();
+            var planned = new PlannedFile(filePath, "// original content");
+
+            // This should NOT write because content is the same
+            await writer.WriteAsync(planned, default);
+
+            // File should still exist with original content
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// original content");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task WriteAsync_Overwrites_When_Content_Differs()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "SourceGeneratorFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(workspace);
+            var filePath = Path.Combine(workspace, "Output.g.cs");
+            await File.WriteAllTextAsync(filePath, "// old content");
+
+            var writer = new SourceGeneratorFileWriter();
+            var planned = new PlannedFile(filePath, "// new content");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// new content");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+}

--- a/src/Refitter.Tests/SourceGeneratorFileWriterTests.cs
+++ b/src/Refitter.Tests/SourceGeneratorFileWriterTests.cs
@@ -47,11 +47,18 @@ public class SourceGeneratorFileWriterTests
             var filePath = Path.Combine(workspace, "Output.g.cs");
             await File.WriteAllTextAsync(filePath, "// original content");
 
+            // Capture the timestamp after initial write
+            var originalTimestamp = File.GetLastWriteTimeUtc(filePath);
+
             var writer = new SourceGeneratorFileWriter();
             var planned = new PlannedFile(filePath, "// original content");
 
             // This should NOT write because content is the same
             await writer.WriteAsync(planned, default);
+
+            // Verify timestamp hasn't changed (proving no write occurred)
+            var currentTimestamp = File.GetLastWriteTimeUtc(filePath);
+            currentTimestamp.Should().Be(originalTimestamp);
 
             // File should still exist with original content
             File.Exists(filePath).Should().BeTrue();

--- a/src/Refitter/CliFileWriter.cs
+++ b/src/Refitter/CliFileWriter.cs
@@ -1,0 +1,33 @@
+using Refitter.Core;
+
+namespace Refitter;
+
+/// <summary>
+/// Writes planned files to disk and reports progress via <see cref="IGenerationReporter"/>.
+/// </summary>
+public class CliFileWriter : IFileWriter
+{
+    private readonly IGenerationReporter _reporter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CliFileWriter"/> class.
+    /// </summary>
+    /// <param name="reporter">The generation reporter for progress reporting.</param>
+    public CliFileWriter(IGenerationReporter reporter)
+    {
+        _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
+    }
+
+    /// <inheritdoc />
+    public async Task WriteAsync(PlannedFile file, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var dir = Path.GetDirectoryName(file.Path);
+        if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        await File.WriteAllTextAsync(file.Path, file.Content, cancellationToken);
+        _reporter.ReportFileWritten(file.Path);
+    }
+}

--- a/src/Refitter/GenerationOrchestrator.cs
+++ b/src/Refitter/GenerationOrchestrator.cs
@@ -128,11 +128,14 @@ public sealed class GenerationOrchestrator
             settings.SettingsFilePath,
             settings.OutputPath);
 
+        if (planned == null || planned.Count == 0)
+            throw new InvalidOperationException("Output planner did not return any planned files.");
+
         var plannedFile = planned[0];
         var fileName = Path.GetFileName(plannedFile.Path);
         var directory = Path.GetDirectoryName(plannedFile.Path) ?? string.Empty;
-        var sizeFormatted = FormatFileSize(code.Length);
-        var lines = code.Split('\n').Length;
+        var sizeFormatted = FormatFileSize(plannedFile.Content.Length);
+        var lines = plannedFile.Content.Split('\n').Length;
 
         reporter.ReportSingleFileOutput(fileName, directory, sizeFormatted, lines);
 
@@ -157,6 +160,9 @@ public sealed class GenerationOrchestrator
             refitGeneratorSettings,
             settings.SettingsFilePath,
             settings.OutputPath);
+
+        if (planned == null || planned.Count != generatorOutput.Files.Count)
+            throw new InvalidOperationException($"Output planner returned {planned?.Count ?? 0} planned files but expected {generatorOutput.Files.Count}.");
 
         var totalSize = 0L;
         var totalLines = 0;

--- a/src/Refitter/GenerationOrchestrator.cs
+++ b/src/Refitter/GenerationOrchestrator.cs
@@ -7,6 +7,26 @@ namespace Refitter;
 
 public sealed class GenerationOrchestrator
 {
+    private readonly IOutputPlanner _planner;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenerationOrchestrator"/> class
+    /// with the default <see cref="OutputPlannerAdapter"/>.
+    /// </summary>
+    public GenerationOrchestrator()
+        : this(new OutputPlannerAdapter())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenerationOrchestrator"/> class.
+    /// </summary>
+    /// <param name="planner">The output planner to use for resolving file paths.</param>
+    public GenerationOrchestrator(IOutputPlanner planner)
+    {
+        _planner = planner ?? throw new ArgumentNullException(nameof(planner));
+    }
+
     public async Task<int> RunAsync(
         RefitGeneratorSettings generatorSettings,
         Settings cliSettings,
@@ -38,9 +58,11 @@ public sealed class GenerationOrchestrator
             if (!cliSettings.SkipValidation)
                 await ValidateOpenApiSpecs(generatorSettings, reporter, cancellationToken);
 
+            var writer = new CliFileWriter(reporter);
+
             await (generatorSettings.GenerateMultipleFiles
-                ? WriteMultipleFiles(generator, cliSettings, generatorSettings, reporter, cancellationToken)
-                : WriteSingleFile(generator, cliSettings, generatorSettings, reporter, cancellationToken));
+                ? WriteMultipleFiles(generator, cliSettings, generatorSettings, reporter, writer, cancellationToken)
+                : WriteSingleFile(generator, cliSettings, generatorSettings, reporter, writer, cancellationToken));
 
             Analytics.LogFeatureUsage(cliSettings, generatorSettings);
 
@@ -85,42 +107,44 @@ public sealed class GenerationOrchestrator
         }
     }
 
-    private static async Task WriteSingleFile(
+    private async Task WriteSingleFile(
         RefitGenerator generator,
         Settings settings,
         RefitGeneratorSettings refitGeneratorSettings,
         IGenerationReporter reporter,
+        IFileWriter writer,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         await reporter.ReportSingleFileGenerationProgressAsync(cancellationToken);
 
         var code = generator.Generate().ReplaceLineEndings();
-        var planned = OutputPlanner.PlanSingleFile(
-            settings.SettingsFilePath,
-            settings.OutputPath,
-            refitGeneratorSettings,
-            code);
+        var output = new GeneratorOutput(
+            new List<GeneratedCode> { new(string.Empty, code) });
 
-        var fileName = Path.GetFileName(planned.Path);
-        var directory = Path.GetDirectoryName(planned.Path) ?? string.Empty;
+        var planned = _planner.Plan(
+            output,
+            refitGeneratorSettings,
+            settings.SettingsFilePath,
+            settings.OutputPath);
+
+        var plannedFile = planned[0];
+        var fileName = Path.GetFileName(plannedFile.Path);
+        var directory = Path.GetDirectoryName(plannedFile.Path) ?? string.Empty;
         var sizeFormatted = FormatFileSize(code.Length);
         var lines = code.Split('\n').Length;
 
         reporter.ReportSingleFileOutput(fileName, directory, sizeFormatted, lines);
 
-        var dir = Path.GetDirectoryName(planned.Path);
-        if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
-            Directory.CreateDirectory(dir);
-        await File.WriteAllTextAsync(planned.Path, planned.Content, cancellationToken);
-        reporter.ReportFileWritten(planned.Path);
+        await writer.WriteAsync(plannedFile, cancellationToken);
     }
 
-    private static async Task WriteMultipleFiles(
+    private async Task WriteMultipleFiles(
         RefitGenerator generator,
         Settings settings,
         RefitGeneratorSettings refitGeneratorSettings,
         IGenerationReporter reporter,
+        IFileWriter writer,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -128,11 +152,11 @@ public sealed class GenerationOrchestrator
             generator.GenerateMultipleFiles,
             cancellationToken);
 
-        var planned = OutputPlanner.PlanMultipleFiles(
-            settings.SettingsFilePath,
-            settings.OutputPath,
+        var planned = _planner.Plan(
+            generatorOutput,
             refitGeneratorSettings,
-            generatorOutput);
+            settings.SettingsFilePath,
+            settings.OutputPath);
 
         var totalSize = 0L;
         var totalLines = 0;
@@ -152,12 +176,8 @@ public sealed class GenerationOrchestrator
             totalSize += size;
             totalLines += lines;
 
-            var plannedDir = Path.GetDirectoryName(plannedFile.Path);
-            if (!string.IsNullOrWhiteSpace(plannedDir) && !Directory.Exists(plannedDir))
-                Directory.CreateDirectory(plannedDir);
             cancellationToken.ThrowIfCancellationRequested();
-            await File.WriteAllTextAsync(plannedFile.Path, plannedFile.Content, cancellationToken);
-            reporter.ReportFileWritten(plannedFile.Path);
+            await writer.WriteAsync(plannedFile, cancellationToken);
         }
 
         report.Complete(generatorOutput.Files.Count, FormatFileSize(totalSize), totalLines);


### PR DESCRIPTION
## Summary

Implements PRD-003: separates output *planning* from *writing* by introducing two narrow interfaces in Refitter.Core, each with distribution-form-specific adapters.

## Changes

### New interfaces (Refitter.Core)
- **`IOutputPlanner`** — resolves `GeneratorOutput` into a list of `PlannedFile` (path + content). Pure logic, no I/O.
- **`IFileWriter`** — accepts a `PlannedFile` and writes it to disk, creating directories as needed.

### Adapters
- **`OutputPlannerAdapter`** (Refitter.Core) — wraps static `OutputPlanner` methods behind `IOutputPlanner`
- **`CliFileWriter`** (Refitter) — writes files and reports progress via `IGenerationReporter`
- **`MsBuildFileWriter`** (Refitter.MSBuild) — writes files synchronously (netstandard2.0)
- **`SourceGeneratorFileWriter`** (Refitter.Core) — writes files with content-equality check (skips when content unchanged)

### Refactored distribution forms
- **`GenerationOrchestrator`** (CLI) — delegates planning to `IOutputPlanner` and writing to `IFileWriter`; no longer creates directories or calls `File.WriteAllTextAsync` directly
- **`RefitterGenerateTask`** (MSBuild) — delegates to `OutputPlannerAdapter` and `MsBuildFileWriter`
- **`RefitterSourceGenerator`** (Source Generator) — delegates writing to `SourceGeneratorFileWriter`

### Tests
- `OutputPlannerAdapterTests` — 6 tests covering single/multi-file planning through `IOutputPlanner`
- `CliFileWriterTests` — 3 tests for directory creation and content preservation
- `MsBuildFileWriterTests` — 2 tests for synchronous file writing
- `SourceGeneratorFileWriterTests` — 3 tests including content-equality skip logic
- All existing 2290+ tests continue to pass unchanged

## Commit history (9 micro-commits)
Each change is small, logical, and independently reviewed:
1. Add `IOutputPlanner` and `IFileWriter` interfaces
2. Add `OutputPlannerAdapter` implementing `IOutputPlanner`
3. Add `CliFileWriter` implementing `IFileWriter`
4. Add `MsBuildFileWriter` implementing `IFileWriter`
5. Add `SourceGeneratorFileWriter` implementing `IFileWriter`
6. Refactor `GenerationOrchestrator` to use interfaces
7. Refactor `RefitterGenerateTask` to use interfaces
8. Refactor `RefitterSourceGenerator` to use interfaces
9. Remove unused imports from source generator

Closes PRD-003

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified output planning/writing pipeline, improving single-file and multi-file generation behavior and output-path handling.
  * Introduced dedicated file writers for CLI, MSBuild, and source generation, including “write only when content differs” to reduce unnecessary overwrites and improve performance.
* **Refactor**
  * Updated generation orchestration to route output through the planner and writers, standardizing progress/reporting and metadata.
* **Tests**
  * Added/expanded test suites covering CLI, MSBuild, source generator writing behavior, and output-path planning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->