### PR TITLE
Strategy pattern for document loading

### DIFF
--- a/src/Refitter.Core/Abstractions/IFileWriter.cs
+++ b/src/Refitter.Core/Abstractions/IFileWriter.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Refitter.Core;
+
+/// <summary>
+/// Writes a <see cref="PlannedFile"/> to disk, creating directories as needed.
+/// Each distribution form (CLI, MSBuild, Source Generator) provides its own adapter
+/// that integrates with its own reporting/progress pipeline.
+/// </summary>
+public interface IFileWriter
+{
+    /// <summary>
+    /// Writes the planned file to disk, creating directories as necessary.
+    /// </summary>
+    /// <param name="file">The planned file to write.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous write operation.</returns>
+    Task WriteAsync(PlannedFile file, CancellationToken cancellationToken = default);
+}

--- a/src/Refitter.Core/Abstractions/IOutputPlanner.cs
+++ b/src/Refitter.Core/Abstractions/IOutputPlanner.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Refitter.Core;
+
+/// <summary>
+/// Resolves a <see cref="GeneratorOutput"/> into a list of <see cref="PlannedFile"/> instances.
+/// Pure logic — no I/O.
+/// </summary>
+public interface IOutputPlanner
+{
+    /// <summary>
+    /// Plans the output file paths for the given generator output.
+    /// </summary>
+    /// <param name="output">The generator output containing generated files.</param>
+    /// <param name="config">The output configuration.</param>
+    /// <param name="settingsFilePath">
+    /// The path to the settings file, or <c>null</c> for direct CLI generation.
+    /// </param>
+    /// <param name="cliOutputPath">
+    /// The output path specified via CLI, or <c>null</c>.
+    /// </param>
+    /// <returns>A read-only list of planned files with resolved paths and content.</returns>
+    IReadOnlyList<PlannedFile> Plan(
+        GeneratorOutput output,
+        IOutputConfiguration config,
+        string? settingsFilePath,
+        string? cliOutputPath);
+}

--- a/src/Refitter.Core/Abstractions/OutputPlannerAdapter.cs
+++ b/src/Refitter.Core/Abstractions/OutputPlannerAdapter.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace Refitter.Core;
+
+/// <summary>
+/// Adapts the static <see cref="OutputPlanner"/> methods to the <see cref="IOutputPlanner"/> interface.
+/// </summary>
+public class OutputPlannerAdapter : IOutputPlanner
+{
+    /// <inheritdoc />
+    public IReadOnlyList<PlannedFile> Plan(
+        GeneratorOutput output,
+        IOutputConfiguration config,
+        string? settingsFilePath,
+        string? cliOutputPath)
+    {
+        if (config.GenerateMultipleFiles)
+        {
+            return OutputPlanner.PlanMultipleFiles(
+                settingsFilePath,
+                cliOutputPath,
+                config,
+                output);
+        }
+
+        var code = output.Files.Count > 0
+            ? output.Files[0].Content
+            : string.Empty;
+
+        return
+        [
+            OutputPlanner.PlanSingleFile(
+                settingsFilePath,
+                cliOutputPath,
+                config,
+                code)
+        ];
+    }
+}

--- a/src/Refitter.Core/Abstractions/SourceGeneratorFileWriter.cs
+++ b/src/Refitter.Core/Abstractions/SourceGeneratorFileWriter.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Refitter.Core;
+
+/// <summary>
+/// Writes planned files to disk with content-equality checking.
+/// Skips writing when the file already exists with identical content,
+/// avoiding unnecessary disk writes during incremental / design-time builds.
+/// </summary>
+public class SourceGeneratorFileWriter : IFileWriter
+{
+    /// <inheritdoc />
+    public Task WriteAsync(PlannedFile file, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var dir = Path.GetDirectoryName(file.Path);
+        if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var existingContent = File.Exists(file.Path)
+            ? File.ReadAllText(file.Path, Encoding.UTF8)
+            : null;
+
+        if (existingContent is null || !string.Equals(existingContent, file.Content, System.StringComparison.Ordinal))
+        {
+            File.WriteAllText(file.Path, file.Content, Encoding.UTF8);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Refitter.Core/Document/DocumentLoader.cs
+++ b/src/Refitter.Core/Document/DocumentLoader.cs
@@ -13,6 +13,9 @@ internal sealed class DocumentLoader : IDocumentLoader
 
     public DocumentLoader(IEnumerable<IDocumentLoadingStrategy> strategies)
     {
+        if (strategies == null)
+            throw new ArgumentNullException(nameof(strategies), "strategies cannot be null");
+
         this.strategies = strategies.ToList();
     }
 
@@ -44,6 +47,9 @@ internal sealed class DocumentLoader : IDocumentLoader
             }
             catch (Exception ex)
             {
+                if (ex is OperationCanceledException or TaskCanceledException)
+                    throw;
+
                 errors.Add($"{strategy.GetType().Name}: {ex.Message}");
             }
         }

--- a/src/Refitter.Core/Document/DocumentLoader.cs
+++ b/src/Refitter.Core/Document/DocumentLoader.cs
@@ -1,28 +1,19 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Net;
-using Microsoft.OpenApi;
-using Microsoft.OpenApi.Reader;
-using NSwag;
 using OpenApiDocument = NSwag.OpenApiDocument;
 
 namespace Refitter.Core;
 
 internal sealed class DocumentLoader : IDocumentLoader
 {
-    private static readonly HttpClient HttpClient = new(
-        new HttpClientHandler
-        {
-            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-        })
-    {
-        Timeout = TimeSpan.FromSeconds(30)
-    };
+    private readonly IReadOnlyList<IDocumentLoadingStrategy> strategies;
 
-    static DocumentLoader()
+    public DocumentLoader()
+        : this(CreateDefaultStrategies())
     {
-        HttpClient.DefaultRequestHeaders.Add(
-            "User-Agent",
-            $"refitter/{typeof(DocumentLoader).Assembly.GetName().Version}");
+    }
+
+    public DocumentLoader(IEnumerable<IDocumentLoadingStrategy> strategies)
+    {
+        this.strategies = strategies.ToList();
     }
 
     public async Task<OpenApiDocument> LoadAsync(
@@ -34,114 +25,44 @@ internal sealed class DocumentLoader : IDocumentLoader
                 "The openApiPath parameter cannot be null, empty, or contain only whitespace.",
                 nameof(openApiPath));
 
-        try
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var errors = new List<string>();
+
+        foreach (var strategy in strategies)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var readResult = await OpenApiMultiFileReader
-                .Read(openApiPath, cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
 
-            if (!readResult.ContainedExternalReferences)
-                return await CreateUsingNSwagAsync(openApiPath, cancellationToken).ConfigureAwait(false);
-
-            var specificationVersion = readResult.OpenApiDiagnostic.SpecificationVersion;
-            PopulateMissingRequiredFields(openApiPath, readResult);
-
-            if (IsYaml(openApiPath))
+            try
             {
-                var yaml = await readResult.OpenApiDocument
-                    .SerializeAsYamlAsync(
-                        specificationVersion,
-                        cancellationToken: cancellationToken)
+                var result = await strategy
+                    .TryLoadAsync(openApiPath, cancellationToken)
                     .ConfigureAwait(false);
 
-                return await OpenApiYamlDocument
-                    .FromYamlAsync(yaml, cancellationToken)
-                    .ConfigureAwait(false);
+                if (result != null)
+                    return result;
             }
-
-            var json = await readResult.OpenApiDocument
-                .SerializeAsJsonAsync(specificationVersion, cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
-
-            return await OpenApiDocument
-                .FromJsonAsync(json, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException && ex is not TaskCanceledException)
-        {
-            return await CreateUsingNSwagAsync(openApiPath, cancellationToken)
-                .ConfigureAwait(false);
-        }
-    }
-
-    private static async Task<OpenApiDocument> CreateUsingNSwagAsync(
-        string openApiPath,
-        CancellationToken cancellationToken = default)
-    {
-        if (IsHttp(openApiPath))
-        {
-            var content = await GetHttpContent(openApiPath, cancellationToken).ConfigureAwait(false);
-            return IsYaml(openApiPath)
-                ? await OpenApiYamlDocument.FromYamlAsync(content, cancellationToken).ConfigureAwait(false)
-                : await OpenApiDocument.FromJsonAsync(content, cancellationToken).ConfigureAwait(false);
-        }
-
-        return IsYaml(openApiPath)
-            ? await OpenApiYamlDocument.FromFileAsync(openApiPath, cancellationToken).ConfigureAwait(false)
-            : await OpenApiDocument.FromFileAsync(openApiPath, cancellationToken).ConfigureAwait(false);
-    }
-
-    [ExcludeFromCodeCoverage]
-    private static void PopulateMissingRequiredFields(
-        string openApiPath,
-        Result readResult)
-    {
-        var document = readResult.OpenApiDocument;
-        if (document.Info is null)
-        {
-            document.Info = new()
+            catch (Exception ex)
             {
-                Title = Path.GetFileNameWithoutExtension(openApiPath),
-                Version = readResult.OpenApiDiagnostic.SpecificationVersion.GetDisplayName()
-            };
+                errors.Add($"{strategy.GetType().Name}: {ex.Message}");
+            }
         }
-        else
+
+        throw new InvalidOperationException(
+            $"Failed to load OpenAPI document from '{openApiPath}'. " +
+            $"All {strategies.Count} strategies failed." +
+            (errors.Count > 0
+                ? $" Errors: {string.Join("; ", errors)}"
+                : ""));
+    }
+
+    private static List<IDocumentLoadingStrategy> CreateDefaultStrategies()
+    {
+        return new List<IDocumentLoadingStrategy>
         {
-            document.Info.Title ??= Path.GetFileNameWithoutExtension(openApiPath);
-            document.Info.Version ??= readResult.OpenApiDiagnostic.SpecificationVersion.GetDisplayName();
-        }
-    }
-
-    private static bool IsHttp(string path)
-    {
-        return path.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
-               path.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static async Task<string> GetHttpContent(
-        string openApiPath,
-        CancellationToken cancellationToken = default)
-    {
-        var response = await HttpClient.GetAsync(openApiPath, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-    }
-
-    private static bool IsYaml(string path)
-    {
-        var queryIndex = path.IndexOf('?');
-        var fragmentIndex = path.IndexOf('#');
-        var endIndex = path.Length;
-
-        if (queryIndex >= 0)
-            endIndex = Math.Min(endIndex, queryIndex);
-        if (fragmentIndex >= 0)
-            endIndex = Math.Min(endIndex, fragmentIndex);
-
-        var basePath = endIndex < path.Length ? path.Substring(0, endIndex) : path;
-
-        return basePath.EndsWith("yaml", StringComparison.OrdinalIgnoreCase) ||
-               basePath.EndsWith("yml", StringComparison.OrdinalIgnoreCase);
+            new FileDocumentStrategy(),
+            new HttpDocumentStrategy(),
+            new OpenApiReaderDocumentStrategy()
+        };
     }
 }

--- a/src/Refitter.Core/Document/FileDocumentStrategy.cs
+++ b/src/Refitter.Core/Document/FileDocumentStrategy.cs
@@ -20,8 +20,11 @@ internal sealed class FileDocumentStrategy : IDocumentLoadingStrategy
                 ? await OpenApiYamlDocument.FromFileAsync(path, cancellationToken).ConfigureAwait(false)
                 : await OpenApiDocument.FromFileAsync(path, cancellationToken).ConfigureAwait(false);
         }
-        catch
+        catch (Exception ex)
         {
+            if (ex is OperationCanceledException or TaskCanceledException)
+                throw;
+
             return null;
         }
     }

--- a/src/Refitter.Core/Document/FileDocumentStrategy.cs
+++ b/src/Refitter.Core/Document/FileDocumentStrategy.cs
@@ -1,0 +1,28 @@
+using NSwag;
+using OpenApiDocument = NSwag.OpenApiDocument;
+
+namespace Refitter.Core;
+
+internal sealed class FileDocumentStrategy : IDocumentLoadingStrategy
+{
+    public async Task<OpenApiDocument?> TryLoadAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        if (PathUtilities.IsHttp(path))
+            return null;
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return PathUtilities.IsYaml(path)
+                ? await OpenApiYamlDocument.FromFileAsync(path, cancellationToken).ConfigureAwait(false)
+                : await OpenApiDocument.FromFileAsync(path, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Refitter.Core/Document/HttpDocumentStrategy.cs
+++ b/src/Refitter.Core/Document/HttpDocumentStrategy.cs
@@ -1,0 +1,69 @@
+using System.Net;
+using NSwag;
+using OpenApiDocument = NSwag.OpenApiDocument;
+
+namespace Refitter.Core;
+
+internal sealed class HttpDocumentStrategy : IDocumentLoadingStrategy
+{
+    private readonly HttpClient httpClient;
+
+    public HttpDocumentStrategy()
+        : this(CreateDefaultHttpClient())
+    {
+    }
+
+    public HttpDocumentStrategy(HttpClient httpClient)
+    {
+        this.httpClient = httpClient;
+    }
+
+    public async Task<OpenApiDocument?> TryLoadAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        if (!PathUtilities.IsHttp(path))
+            return null;
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var response = await httpClient
+                .GetAsync(path, cancellationToken)
+                .ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content
+                .ReadAsStringAsync()
+                .ConfigureAwait(false);
+
+            return PathUtilities.IsYaml(path)
+                ? await OpenApiYamlDocument.FromYamlAsync(content, cancellationToken)
+                    .ConfigureAwait(false)
+                : await OpenApiDocument.FromJsonAsync(content, cancellationToken)
+                    .ConfigureAwait(false);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static HttpClient CreateDefaultHttpClient()
+    {
+        var client = new HttpClient(
+            new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            })
+        {
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+
+        client.DefaultRequestHeaders.Add(
+            "User-Agent",
+            $"refitter/{typeof(HttpDocumentStrategy).Assembly.GetName().Version}");
+
+        return client;
+    }
+}

--- a/src/Refitter.Core/Document/HttpDocumentStrategy.cs
+++ b/src/Refitter.Core/Document/HttpDocumentStrategy.cs
@@ -29,7 +29,7 @@ internal sealed class HttpDocumentStrategy : IDocumentLoadingStrategy
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var response = await httpClient
+            using var response = await httpClient
                 .GetAsync(path, cancellationToken)
                 .ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
@@ -43,8 +43,11 @@ internal sealed class HttpDocumentStrategy : IDocumentLoadingStrategy
                 : await OpenApiDocument.FromJsonAsync(content, cancellationToken)
                     .ConfigureAwait(false);
         }
-        catch
+        catch (Exception ex)
         {
+            if (ex is OperationCanceledException or TaskCanceledException)
+                throw;
+
             return null;
         }
     }

--- a/src/Refitter.Core/Document/IDocumentLoadingStrategy.cs
+++ b/src/Refitter.Core/Document/IDocumentLoadingStrategy.cs
@@ -1,0 +1,8 @@
+using OpenApiDocument = NSwag.OpenApiDocument;
+
+namespace Refitter.Core;
+
+internal interface IDocumentLoadingStrategy
+{
+    Task<OpenApiDocument?> TryLoadAsync(string path, CancellationToken cancellationToken = default);
+}

--- a/src/Refitter.Core/Document/OpenApiReaderDocumentStrategy.cs
+++ b/src/Refitter.Core/Document/OpenApiReaderDocumentStrategy.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
+using NSwag;
+using OpenApiDocument = NSwag.OpenApiDocument;
+
+namespace Refitter.Core;
+
+internal sealed class OpenApiReaderDocumentStrategy : IDocumentLoadingStrategy
+{
+    public async Task<OpenApiDocument?> TryLoadAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var readResult = await OpenApiMultiFileReader
+                .Read(path, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!readResult.ContainedExternalReferences)
+                return null;
+
+            var specificationVersion = readResult.OpenApiDiagnostic.SpecificationVersion;
+            PopulateMissingRequiredFields(path, readResult);
+
+            return await SerializeRoundTripAsync(readResult, path, specificationVersion, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException
+                                       and not TaskCanceledException)
+        {
+            return await FallbackToNSwagAsync(path, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<OpenApiDocument> SerializeRoundTripAsync(
+        Result readResult,
+        string path,
+        OpenApiSpecVersion specificationVersion,
+        CancellationToken cancellationToken)
+    {
+        var document = readResult.OpenApiDocument;
+
+        if (PathUtilities.IsYaml(path))
+        {
+            var yaml = await document
+                .SerializeAsYamlAsync(specificationVersion, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            return await OpenApiYamlDocument
+                .FromYamlAsync(yaml, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var json = await document
+            .SerializeAsJsonAsync(specificationVersion, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        return await OpenApiDocument
+            .FromJsonAsync(json, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task<OpenApiDocument?> FallbackToNSwagAsync(
+        string path,
+        CancellationToken cancellationToken)
+    {
+        if (PathUtilities.IsHttp(path))
+            return null;
+
+        try
+        {
+            return PathUtilities.IsYaml(path)
+                ? await OpenApiYamlDocument.FromFileAsync(path, cancellationToken)
+                    .ConfigureAwait(false)
+                : await OpenApiDocument.FromFileAsync(path, cancellationToken)
+                    .ConfigureAwait(false);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    [ExcludeFromCodeCoverage]
+    private static void PopulateMissingRequiredFields(
+        string openApiPath,
+        Result readResult)
+    {
+        var document = readResult.OpenApiDocument;
+        if (document.Info is null)
+        {
+            document.Info = new()
+            {
+                Title = Path.GetFileNameWithoutExtension(openApiPath),
+                Version = readResult.OpenApiDiagnostic.SpecificationVersion.GetDisplayName()
+            };
+        }
+        else
+        {
+            document.Info.Title ??= Path.GetFileNameWithoutExtension(openApiPath);
+            document.Info.Version ??= readResult.OpenApiDiagnostic.SpecificationVersion.GetDisplayName();
+        }
+    }
+}

--- a/src/Refitter.Core/Document/OpenApiReaderDocumentStrategy.cs
+++ b/src/Refitter.Core/Document/OpenApiReaderDocumentStrategy.cs
@@ -80,8 +80,11 @@ internal sealed class OpenApiReaderDocumentStrategy : IDocumentLoadingStrategy
                 : await OpenApiDocument.FromFileAsync(path, cancellationToken)
                     .ConfigureAwait(false);
         }
-        catch
+        catch (Exception ex)
         {
+            if (ex is OperationCanceledException)
+                throw;
+
             return null;
         }
     }

--- a/src/Refitter.Core/Document/PathUtilities.cs
+++ b/src/Refitter.Core/Document/PathUtilities.cs
@@ -21,7 +21,7 @@ internal static class PathUtilities
 
         var basePath = endIndex < path.Length ? path.Substring(0, endIndex) : path;
 
-        return basePath.EndsWith("yaml", StringComparison.OrdinalIgnoreCase) ||
-               basePath.EndsWith("yml", StringComparison.OrdinalIgnoreCase);
+        return basePath.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) ||
+               basePath.EndsWith(".yml", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Refitter.Core/Document/PathUtilities.cs
+++ b/src/Refitter.Core/Document/PathUtilities.cs
@@ -1,0 +1,27 @@
+namespace Refitter.Core;
+
+internal static class PathUtilities
+{
+    public static bool IsHttp(string path)
+    {
+        return path.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+               path.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool IsYaml(string path)
+    {
+        var queryIndex = path.IndexOf('?');
+        var fragmentIndex = path.IndexOf('#');
+        var endIndex = path.Length;
+
+        if (queryIndex >= 0)
+            endIndex = Math.Min(endIndex, queryIndex);
+        if (fragmentIndex >= 0)
+            endIndex = Math.Min(endIndex, fragmentIndex);
+
+        var basePath = endIndex < path.Length ? path.Substring(0, endIndex) : path;
+
+        return basePath.EndsWith("yaml", StringComparison.OrdinalIgnoreCase) ||
+               basePath.EndsWith("yml", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Refitter.MSBuild/MsBuildFileWriter.cs
+++ b/src/Refitter.MSBuild/MsBuildFileWriter.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Refitter.Core;
+
+namespace Refitter.MSBuild;
+
+/// <summary>
+/// Writes planned files to disk from within an MSBuild task.
+/// Creates directories as needed. No logging dependencies — the calling task
+/// handles reporting.
+/// </summary>
+public class MsBuildFileWriter : IFileWriter
+{
+    /// <inheritdoc />
+    public Task WriteAsync(PlannedFile file, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var dir = Path.GetDirectoryName(file.Path);
+        if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        File.WriteAllText(file.Path, file.Content);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Refitter.MSBuild/RefitterGenerateTask.cs
+++ b/src/Refitter.MSBuild/RefitterGenerateTask.cs
@@ -74,41 +74,40 @@ public class RefitterGenerateTask : MSBuildTask
         var generator = RefitGenerator.CreateAsync(settings)
             .GetAwaiter().GetResult();
 
+        var planner = new OutputPlannerAdapter();
+        var writer = new MsBuildFileWriter();
+
         var generatedFiles = new List<string>();
 
         if (settings.GenerateMultipleFiles)
         {
             var output = generator.GenerateMultipleFiles();
-            foreach (var outputFile in output.Files)
+            var plannedFiles = planner.Plan(
+                output,
+                settings,
+                filePath,
+                cliOutputPath: null);
+
+            foreach (var plannedFile in plannedFiles)
             {
-                var outputPath = OutputPlanner.GetMultiFileOutputPath(
-                    filePath,
-                    cliOutputPath: null,
-                    settings,
-                    outputFile);
-
-                var dir = Path.GetDirectoryName(outputPath);
-                if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
-                    Directory.CreateDirectory(dir);
-
-                File.WriteAllText(outputPath, outputFile.Content);
-                generatedFiles.Add(Path.GetFullPath(outputPath));
+                writer.WriteAsync(plannedFile).GetAwaiter().GetResult();
+                generatedFiles.Add(Path.GetFullPath(plannedFile.Path));
             }
         }
         else
         {
             var code = generator.Generate().Replace("\r\n", "\n");
-            var outputPath = OutputPlanner.GetSingleFileOutputPath(
+            var output = new GeneratorOutput(
+                new List<GeneratedCode> { new(string.Empty, code) });
+
+            var plannedFiles = planner.Plan(
+                output,
+                settings,
                 filePath,
-                cliOutputPath: null,
-                settings);
+                cliOutputPath: null);
 
-            var dir = Path.GetDirectoryName(outputPath);
-            if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
-
-            File.WriteAllText(outputPath, code);
-            generatedFiles.Add(Path.GetFullPath(outputPath));
+            writer.WriteAsync(plannedFiles[0]).GetAwaiter().GetResult();
+            generatedFiles.Add(Path.GetFullPath(plannedFiles[0].Path));
         }
 
         if (!SkipValidation)

--- a/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
+++ b/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
@@ -27,6 +27,7 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(AssemblyName).props" Pack="true" PackagePath="build" />
     <Compile Include="../Refitter.Core/*.cs" />
+    <Compile Include="../Refitter.Core/Abstractions/*.cs" />
     <Compile Include="../Refitter.Core/Apizr/*.cs" />
     <Compile Include="../Refitter.Core/CodeGeneration/*.cs" />
     <Compile Include="../Refitter.Core/Contracts/*.cs" />

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -1,7 +1,5 @@
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Text;
 using H.Generators.Extensions;
 using Microsoft.CodeAnalysis;
 using Refitter.Core;

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -100,7 +100,7 @@ public class RefitterSourceGenerator : IIncrementalGenerator
 
             var outputPath = GetOutputPath(file.Path, settings);
             var planned = new PlannedFile(outputPath, refit);
-            WriteGeneratedFile(planned, diagnostics);
+            WriteGeneratedFile(planned, diagnostics, cancellationToken);
 
             return new GeneratedCode(diagnostics.ToImmutableArray().AsEquatableArray(), outputPath);
         }
@@ -121,12 +121,12 @@ public class RefitterSourceGenerator : IIncrementalGenerator
             return Path.Combine(folder, filename);
         }
 
-        static void WriteGeneratedFile(PlannedFile planned, List<GeneratedDiagnostic> diagnostics)
+        static void WriteGeneratedFile(PlannedFile planned, List<GeneratedDiagnostic> diagnostics, CancellationToken cancellationToken)
         {
             try
             {
                 var writer = new SourceGeneratorFileWriter();
-                writer.WriteAsync(planned).GetAwaiter().GetResult();
+                writer.WriteAsync(planned, cancellationToken).GetAwaiter().GetResult();
                 diagnostics.Add(CreateGeneratedSuccessfullyDiagnostic(planned.Path));
             }
             catch (Exception e)

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -101,7 +101,8 @@ public class RefitterSourceGenerator : IIncrementalGenerator
             cancellationToken.ThrowIfCancellationRequested();
 
             var outputPath = GetOutputPath(file.Path, settings);
-            WriteGeneratedFile(outputPath, refit, diagnostics);
+            var planned = new PlannedFile(outputPath, refit);
+            WriteGeneratedFile(planned, diagnostics);
 
             return new GeneratedCode(diagnostics.ToImmutableArray().AsEquatableArray(), outputPath);
         }
@@ -122,23 +123,13 @@ public class RefitterSourceGenerator : IIncrementalGenerator
             return Path.Combine(folder, filename);
         }
 
-        static void WriteGeneratedFile(string outputPath, string content, List<GeneratedDiagnostic> diagnostics)
+        static void WriteGeneratedFile(PlannedFile planned, List<GeneratedDiagnostic> diagnostics)
         {
             try
             {
-                var folder = Path.GetDirectoryName(outputPath);
-                if (!string.IsNullOrEmpty(folder) && !Directory.Exists(folder))
-                {
-                    Directory.CreateDirectory(folder);
-                }
-
-                var existingContent = File.Exists(outputPath) ? File.ReadAllText(outputPath, Encoding.UTF8) : null;
-                if (existingContent == null || !existingContent.Equals(content, StringComparison.Ordinal))
-                {
-                    File.WriteAllText(outputPath, content, Encoding.UTF8);
-                }
-
-                diagnostics.Add(CreateGeneratedSuccessfullyDiagnostic(outputPath));
+                var writer = new SourceGeneratorFileWriter();
+                writer.WriteAsync(planned).GetAwaiter().GetResult();
+                diagnostics.Add(CreateGeneratedSuccessfullyDiagnostic(planned.Path));
             }
             catch (Exception e)
             {

--- a/src/Refitter.Tests/CliFileWriterTests.cs
+++ b/src/Refitter.Tests/CliFileWriterTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Refitter;
+using Refitter.Core;
+using TUnit.Core;
+
+namespace Refitter.Tests;
+
+public class CliFileWriterTests
+{
+    [Test]
+    public async Task WriteAsync_Creates_Directory_And_Writes_File()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "CliFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var reporter = new SimpleGenerationReporter();
+            var writer = new CliFileWriter(reporter);
+            var filePath = Path.Combine(workspace, "Generated", "Output.cs");
+            var planned = new PlannedFile(filePath, "// test content");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// test content");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task WriteAsync_Does_Not_Throw_When_Directory_Already_Exists()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "CliFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(workspace);
+            var existingFile = Path.Combine(workspace, "Existing.cs");
+            await File.WriteAllTextAsync(existingFile, "existing");
+
+            var reporter = new SimpleGenerationReporter();
+            var writer = new CliFileWriter(reporter);
+            var newFile = Path.Combine(workspace, "Output.cs");
+            var planned = new PlannedFile(newFile, "// new content");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(existingFile).Should().BeTrue();
+            File.Exists(newFile).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(newFile);
+            content.Should().Be("// new content");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task WriteAsync_Writes_To_File_In_Existing_Directory()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "CliFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(workspace);
+            var filePath = Path.Combine(workspace, "Output.cs");
+            var reporter = new SimpleGenerationReporter();
+            var writer = new CliFileWriter(reporter);
+            var planned = new PlannedFile(filePath, "// test");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// test");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+}

--- a/src/Refitter.Tests/MsBuildFileWriterTests.cs
+++ b/src/Refitter.Tests/MsBuildFileWriterTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.MSBuild;
+using TUnit.Core;
+
+namespace Refitter.Tests;
+
+public class MsBuildFileWriterTests
+{
+    [Test]
+    public async Task WriteAsync_Creates_Directory_And_Writes_File()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "MsBuildFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var writer = new MsBuildFileWriter();
+            var filePath = Path.Combine(workspace, "Generated", "Output.cs");
+            var planned = new PlannedFile(filePath, "// msbuild test");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// msbuild test");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task WriteAsync_Does_Not_Throw_When_Directory_Already_Exists()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "MsBuildFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(workspace);
+
+            var writer = new MsBuildFileWriter();
+            var filePath = Path.Combine(workspace, "Output.cs");
+            var planned = new PlannedFile(filePath, "// test");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+}

--- a/src/Refitter.Tests/OpenApi/DocumentLoaderCompositorTests.cs
+++ b/src/Refitter.Tests/OpenApi/DocumentLoaderCompositorTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using NSwag;
+using Refitter.Core;
+
+namespace Refitter.Tests.OpenApi;
+
+public class DocumentLoaderCompositorTests
+{
+    [Test]
+    public async Task Throws_On_Empty_Path()
+    {
+        var loader = new DocumentLoader();
+        var act = async () => await loader.LoadAsync("");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Throws_On_Null_Path()
+    {
+        var loader = new DocumentLoader();
+        var act = async () => await loader.LoadAsync(null!);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Throws_When_All_Strategies_Fail()
+    {
+        var strategies = new IDocumentLoadingStrategy[]
+        {
+            new FailingStrategy(),
+            new FailingStrategy()
+        };
+        var loader = new DocumentLoader(strategies);
+
+        var act = async () => await loader.LoadAsync("test.json");
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Returns_First_Successful_Result()
+    {
+        var strategies = new IDocumentLoadingStrategy[]
+        {
+            new NullReturningStrategy(),
+            new SuccessStrategy("First Success"),
+            new SuccessStrategy("Second Success")
+        };
+        var loader = new DocumentLoader(strategies);
+
+        var result = await loader.LoadAsync("test.json");
+
+        result.Should().NotBeNull();
+        result.Info.Title.Should().Be("First Success");
+    }
+
+    [Test]
+    public async Task Skips_Strategies_That_Return_Null()
+    {
+        var strategies = new IDocumentLoadingStrategy[]
+        {
+            new NullReturningStrategy(),
+            new NullReturningStrategy(),
+            new SuccessStrategy("Third Time")
+        };
+        var loader = new DocumentLoader(strategies);
+
+        var result = await loader.LoadAsync("test.json");
+
+        result.Should().NotBeNull();
+        result.Info.Title.Should().Be("Third Time");
+    }
+
+    [Test]
+    public async Task Loads_Valid_File_With_Default_Strategies()
+    {
+        var spec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": { ""title"": ""Default Strategies Test"", ""version"": ""1.0.0"" },
+  ""paths"": {}
+}";
+        var swaggerFile = await TestFile.CreateSwaggerFile(spec, "default-test.json");
+        var loader = new DocumentLoader();
+
+        var result = await loader.LoadAsync(swaggerFile);
+
+        result.Should().NotBeNull();
+        result.Info.Title.Should().Be("Default Strategies Test");
+    }
+
+    private sealed class NullReturningStrategy : IDocumentLoadingStrategy
+    {
+        public Task<OpenApiDocument?> TryLoadAsync(string path, CancellationToken cancellationToken = default)
+            => Task.FromResult<OpenApiDocument?>(null);
+    }
+
+    private sealed class SuccessStrategy : IDocumentLoadingStrategy
+    {
+        private readonly string title;
+
+        public SuccessStrategy(string title)
+        {
+            this.title = title;
+        }
+
+        public Task<OpenApiDocument?> TryLoadAsync(string path, CancellationToken cancellationToken = default)
+        {
+            var doc = new OpenApiDocument
+            {
+                Info = new() { Title = title, Version = "1.0.0" }
+            };
+            return Task.FromResult<OpenApiDocument?>(doc);
+        }
+    }
+
+    private sealed class FailingStrategy : IDocumentLoadingStrategy
+    {
+        public Task<OpenApiDocument?> TryLoadAsync(string path, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Strategy failed");
+    }
+}

--- a/src/Refitter.Tests/OpenApi/FileDocumentStrategyTests.cs
+++ b/src/Refitter.Tests/OpenApi/FileDocumentStrategyTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Resources;
+
+namespace Refitter.Tests.OpenApi;
+
+public class FileDocumentStrategyTests
+{
+    [Test]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "petstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "petstore.yaml")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV2, "petstore.json")]
+    [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV2, "petstore.yaml")]
+    public async Task Loads_Valid_OpenApi_Spec_From_File(
+        SampleOpenSpecifications version,
+        string filename)
+    {
+        var swaggerFile = await TestFile.CreateSwaggerFile(
+            EmbeddedResources.GetSwaggerPetstore(version),
+            filename);
+        var strategy = new FileDocumentStrategy();
+        var result = await strategy.TryLoadAsync(swaggerFile);
+
+        result.Should().NotBeNull();
+        result!.Info.Title.Should().NotBeNullOrEmpty();
+    }
+
+    [Test]
+    [Arguments("petstore.json")]
+    [Arguments("petstore.yaml")]
+    [Arguments("petstore.yml")]
+    public async Task Returns_Null_For_Http_Uri(string filename)
+    {
+        var strategy = new FileDocumentStrategy();
+        var result = await strategy.TryLoadAsync($"https://example.com/{filename}");
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Returns_Null_For_Nonexistent_File()
+    {
+        var strategy = new FileDocumentStrategy();
+        var result = await strategy.TryLoadAsync(
+            Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "nonexistent.json"));
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Returns_Null_For_Invalid_Spec()
+    {
+        var swaggerFile = await TestFile.CreateSwaggerFile(
+            "not valid openapi content",
+            "invalid.json");
+        var strategy = new FileDocumentStrategy();
+        var result = await strategy.TryLoadAsync(swaggerFile);
+
+        result.Should().BeNull();
+    }
+}

--- a/src/Refitter.Tests/OpenApi/HttpDocumentStrategyTests.cs
+++ b/src/Refitter.Tests/OpenApi/HttpDocumentStrategyTests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using FluentAssertions;
+using Refitter.Core;
+
+namespace Refitter.Tests.OpenApi;
+
+public class HttpDocumentStrategyTests
+{
+    [Test]
+    public async Task Returns_Null_For_File_Paths()
+    {
+        var strategy = new HttpDocumentStrategy();
+        var result = await strategy.TryLoadAsync("/local/path/spec.json");
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Returns_Null_When_Http_Fails()
+    {
+        var handler = new MockHttpMessageHandler(
+            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)));
+        var httpClient = new HttpClient(handler);
+        var strategy = new HttpDocumentStrategy(httpClient);
+
+        var result = await strategy.TryLoadAsync("https://example.com/spec.json");
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Loads_Json_Spec_From_Http()
+    {
+        var spec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": { ""title"": ""Test API"", ""version"": ""1.0.0"" },
+  ""paths"": {}
+}";
+        var handler = new MockHttpMessageHandler(
+            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(spec)
+            }));
+        var httpClient = new HttpClient(handler);
+        var strategy = new HttpDocumentStrategy(httpClient);
+
+        var result = await strategy.TryLoadAsync("https://example.com/spec.json");
+
+        result.Should().NotBeNull();
+        result!.Info.Title.Should().Be("Test API");
+    }
+
+    [Test]
+    public async Task Loads_Yaml_Spec_From_Http()
+    {
+        var spec = @"openapi: 3.0.0
+info:
+  title: YAML Test API
+  version: 1.0.0
+paths: {}";
+        var handler = new MockHttpMessageHandler(
+            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(spec)
+            }));
+        var httpClient = new HttpClient(handler);
+        var strategy = new HttpDocumentStrategy(httpClient);
+
+        var result = await strategy.TryLoadAsync("https://example.com/spec.yaml");
+
+        result.Should().NotBeNull();
+        result!.Info.Title.Should().Be("YAML Test API");
+    }
+
+    [Test]
+    public async Task Returns_Null_For_Invalid_Http_Content()
+    {
+        var handler = new MockHttpMessageHandler(
+            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("not valid openapi content")
+            }));
+        var httpClient = new HttpClient(handler);
+        var strategy = new HttpDocumentStrategy(httpClient);
+
+        var result = await strategy.TryLoadAsync("https://example.com/spec.json");
+
+        result.Should().BeNull();
+    }
+
+    private sealed class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler;
+
+        public MockHttpMessageHandler(
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            this.handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return handler(request, cancellationToken);
+        }
+    }
+}

--- a/src/Refitter.Tests/OpenApi/OpenApiReaderDocumentStrategyTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiReaderDocumentStrategyTests.cs
@@ -1,0 +1,134 @@
+using FluentAssertions;
+using Microsoft.OpenApi.Reader;
+using Refitter.Core;
+
+namespace Refitter.Tests.OpenApi;
+
+public class OpenApiReaderDocumentStrategyTests
+{
+
+
+    [Test]
+    public async Task Returns_Null_When_No_External_References()
+    {
+        var spec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": { ""title"": ""Test"", ""version"": ""1.0.0"" },
+  ""paths"": {}
+}";
+        var swaggerFile = await TestFile.CreateSwaggerFile(spec, "no-refs.json");
+        var strategy = new OpenApiReaderDocumentStrategy();
+        var result = await strategy.TryLoadAsync(swaggerFile);
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Handles_Json_With_External_References()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+
+        var mainSpec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": { ""title"": ""External Ref Test"", ""version"": ""1.0.0"" },
+  ""paths"": {
+    ""/users"": {
+      ""get"": {
+        ""responses"": {
+          ""200"": {
+            ""description"": ""Success"",
+            ""content"": {
+              ""application/json"": {
+                ""schema"": {
+                  ""$ref"": ""./components.json#/components/schemas/User""
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}";
+        var componentsSpec = @"{
+  ""components"": {
+    ""schemas"": {
+      ""User"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""id"": { ""type"": ""integer"" },
+          ""name"": { ""type"": ""string"" }
+        }
+      }
+    }
+  }
+}";
+
+        var mainFile = Path.Combine(folder, "main.json");
+        var componentsFile = Path.Combine(folder, "components.json");
+        await File.WriteAllTextAsync(mainFile, mainSpec);
+        await File.WriteAllTextAsync(componentsFile, componentsSpec);
+
+        var strategy = new OpenApiReaderDocumentStrategy();
+        var result = await strategy.TryLoadAsync(mainFile);
+
+        result.Should().NotBeNull();
+        result!.Info.Title.Should().Be("External Ref Test");
+    }
+
+    [Test]
+    public async Task Handles_Yaml_With_External_References()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folder);
+
+        var mainSpec = @"openapi: 3.0.0
+info:
+  title: YAML External Ref Test
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: './components.yaml#/components/schemas/User'";
+
+        var componentsSpec = @"components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string";
+
+        var mainFile = Path.Combine(folder, "main.yaml");
+        var componentsFile = Path.Combine(folder, "components.yaml");
+        await File.WriteAllTextAsync(mainFile, mainSpec);
+        await File.WriteAllTextAsync(componentsFile, componentsSpec);
+
+        var strategy = new OpenApiReaderDocumentStrategy();
+        var result = await strategy.TryLoadAsync(mainFile);
+
+        result.Should().NotBeNull();
+        result!.Info.Title.Should().Be("YAML External Ref Test");
+    }
+
+    [Test]
+    public async Task Returns_Null_On_Invalid_Spec()
+    {
+        var swaggerFile = await TestFile.CreateSwaggerFile(
+            "not valid",
+            "invalid.json");
+        var strategy = new OpenApiReaderDocumentStrategy();
+        var result = await strategy.TryLoadAsync(swaggerFile);
+
+        result.Should().BeNull();
+    }
+}

--- a/src/Refitter.Tests/OpenApi/OpenApiReaderDocumentStrategyTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiReaderDocumentStrategyTests.cs
@@ -75,6 +75,8 @@ public class OpenApiReaderDocumentStrategyTests
 
         result.Should().NotBeNull();
         result!.Info.Title.Should().Be("External Ref Test");
+
+        Directory.Delete(folder, true);
     }
 
     [Test]
@@ -118,6 +120,8 @@ paths:
 
         result.Should().NotBeNull();
         result!.Info.Title.Should().Be("YAML External Ref Test");
+
+        Directory.Delete(folder, true);
     }
 
     [Test]

--- a/src/Refitter.Tests/OpenApi/PathUtilitiesTests.cs
+++ b/src/Refitter.Tests/OpenApi/PathUtilitiesTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Refitter.Core;
+
+namespace Refitter.Tests.OpenApi;
+
+public class PathUtilitiesTests
+{
+    [Test]
+    [Arguments("http://example.com/spec.json")]
+    [Arguments("https://example.com/spec.yaml")]
+    [Arguments("HTTP://EXAMPLE.COM/SPEC.JSON")]
+    [Arguments("https://example.com/path/to/spec.yml")]
+    public void IsHttp_Detects_Http_Paths(string path)
+    {
+        PathUtilities.IsHttp(path).Should().BeTrue();
+    }
+
+    [Test]
+    [Arguments("/local/path/spec.json")]
+    [Arguments("C:\\local\\path\\spec.yaml")]
+    [Arguments("relative/path/spec.json")]
+    [Arguments("")]
+    public void IsHttp_Returns_False_For_NonHttp_Paths(string path)
+    {
+        PathUtilities.IsHttp(path).Should().BeFalse();
+    }
+
+    [Test]
+    [Arguments("spec.yaml")]
+    [Arguments("spec.yml")]
+    [Arguments("spec.YAML")]
+    [Arguments("spec.YML")]
+    [Arguments("/path/to/spec.yaml")]
+    [Arguments("https://example.com/spec.yaml")]
+    [Arguments("https://example.com/spec.yaml?query=param")]
+    [Arguments("https://example.com/spec.yaml#fragment")]
+    [Arguments("spec.YAML")]
+    public void IsYaml_Detects_Yaml_Paths(string path)
+    {
+        PathUtilities.IsYaml(path).Should().BeTrue();
+    }
+
+    [Test]
+    [Arguments("spec.json")]
+    [Arguments("spec.xml")]
+    [Arguments("/path/to/spec.json")]
+    [Arguments("https://example.com/spec.json")]
+    [Arguments("spec")]
+    [Arguments("")]
+    public void IsYaml_Returns_False_For_NonYaml_Paths(string path)
+    {
+        PathUtilities.IsYaml(path).Should().BeFalse();
+    }
+}

--- a/src/Refitter.Tests/OutputPlannerAdapterTests.cs
+++ b/src/Refitter.Tests/OutputPlannerAdapterTests.cs
@@ -6,7 +6,7 @@ namespace Refitter.Tests;
 
 public class OutputPlannerAdapterTests
 {
-    private static readonly IOutputPlanner Planner = new OutputPlannerAdapter();
+    private static readonly IOutputPlanner planner = new OutputPlannerAdapter();
 
     [Test]
     public void Plan_SingleFile_DirectCli_Explicit_Output_Is_Used()
@@ -23,7 +23,7 @@ public class OutputPlannerAdapterTests
             new("GeneratedType", "// code")
         });
 
-        var planned = Planner.Plan(
+        var planned = planner.Plan(
             output,
             config,
             settingsFilePath: null,
@@ -49,7 +49,7 @@ public class OutputPlannerAdapterTests
             new("GeneratedType", "// code")
         });
 
-        var planned = Planner.Plan(
+        var planned = planner.Plan(
             output,
             config,
             settingsFilePath: null,
@@ -76,7 +76,7 @@ public class OutputPlannerAdapterTests
             new("GeneratedType", "// code")
         });
 
-        var planned = Planner.Plan(
+        var planned = planner.Plan(
             output,
             config,
             settingsFilePath,
@@ -102,7 +102,7 @@ public class OutputPlannerAdapterTests
             new("RefitInterfaces", "// interfaces"),
         });
 
-        var planned = Planner.Plan(
+        var planned = planner.Plan(
             output,
             config,
             settingsFilePath: null,
@@ -128,7 +128,7 @@ public class OutputPlannerAdapterTests
             new("RefitInterfaces", "// interfaces"),
         });
 
-        var planned = Planner.Plan(
+        var planned = planner.Plan(
             output,
             config,
             settingsFilePath,
@@ -157,7 +157,7 @@ public class OutputPlannerAdapterTests
             new(TypenameConstants.Contracts, "// contracts"),
         });
 
-        var planned = Planner.Plan(
+        var planned = planner.Plan(
             output,
             config,
             settingsFilePath,
@@ -185,7 +185,7 @@ public class OutputPlannerAdapterTests
             new("Interface2", "// content 2"),
         });
 
-        var planned = Planner.Plan(
+        var planned = planner.Plan(
             output,
             config,
             settingsFilePath: null,

--- a/src/Refitter.Tests/OutputPlannerAdapterTests.cs
+++ b/src/Refitter.Tests/OutputPlannerAdapterTests.cs
@@ -1,0 +1,198 @@
+using FluentAssertions;
+using Refitter.Core;
+using TUnit.Core;
+
+namespace Refitter.Tests;
+
+public class OutputPlannerAdapterTests
+{
+    private static readonly IOutputPlanner Planner = new OutputPlannerAdapter();
+
+    [Test]
+    public void Plan_SingleFile_DirectCli_Explicit_Output_Is_Used()
+    {
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            OutputFilename = "Output.cs",
+            GenerateMultipleFiles = false,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("GeneratedType", "// code")
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath: null,
+            cliOutputPath: Path.Combine("GeneratedCode", "Petstore.cs"));
+
+        planned.Should().ContainSingle();
+        planned[0].Path.Should().Be(Path.Combine("GeneratedCode", "Petstore.cs"));
+        planned[0].Content.Should().Be("// code");
+    }
+
+    [Test]
+    public void Plan_SingleFile_DirectCli_Default_Uses_DefaultOutputPath()
+    {
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            OutputFilename = "Output.cs",
+            GenerateMultipleFiles = false,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("GeneratedType", "// code")
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath: null,
+            cliOutputPath: OutputPlanner.DefaultOutputPath);
+
+        planned.Should().ContainSingle();
+        planned[0].Path.Should().Be(OutputPlanner.DefaultOutputPath);
+        planned[0].Content.Should().Be("// code");
+    }
+
+    [Test]
+    public void Plan_SingleFile_SettingsFile_Roots_Relative_To_Settings_Directory()
+    {
+        var settingsFilePath = Path.Combine(Path.GetTempPath(), "Projects", "MyApi", "petstore.refitter");
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            OutputFilename = "Output.cs",
+            GenerateMultipleFiles = false,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("GeneratedType", "// code")
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath,
+            cliOutputPath: null);
+
+        planned.Should().ContainSingle();
+        var expected = Path.Combine(Path.GetDirectoryName(settingsFilePath)!, "./Generated", "Output.cs");
+        planned[0].Path.Should().Be(expected);
+        planned[0].Content.Should().Be("// code");
+    }
+
+    [Test]
+    public void Plan_MultiFile_DirectCli_Combines_Output_Directory_And_Filename()
+    {
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            GenerateMultipleFiles = true,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("RefitInterfaces", "// interfaces"),
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath: null,
+            cliOutputPath: Path.Combine("GeneratedCode", "MultipleFiles"));
+
+        planned.Should().ContainSingle();
+        planned[0].Path.Should().Be(Path.Combine("GeneratedCode", "MultipleFiles", "RefitInterfaces.cs"));
+        planned[0].Content.Should().Be("// interfaces");
+    }
+
+    [Test]
+    public void Plan_MultiFile_SettingsFile_Roots_Explicit_Cli_Override()
+    {
+        var settingsFilePath = Path.Combine(Path.GetTempPath(), "Projects", "MyApi", "petstore.refitter");
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            GenerateMultipleFiles = true,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("RefitInterfaces", "// interfaces"),
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath,
+            cliOutputPath: Path.Combine("GeneratedCode", "MultipleFiles"));
+
+        planned.Should().ContainSingle();
+        var expected = Path.Combine(Path.GetDirectoryName(settingsFilePath)!, "GeneratedCode", "MultipleFiles", "RefitInterfaces.cs");
+        planned[0].Path.Should().Be(expected);
+        planned[0].Content.Should().Be("// interfaces");
+    }
+
+    [Test]
+    public void Plan_MultiFile_Reroutes_Contracts_To_Separate_Folder()
+    {
+        var settingsFilePath = Path.Combine(Path.GetTempPath(), "Projects", "MyApi", "petstore.refitter");
+        var config = new RefitGeneratorSettings
+        {
+            OutputFolder = "./Generated",
+            ContractsOutputFolder = "./Contracts",
+            GenerateMultipleFiles = true,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("RefitInterfaces", "// interfaces"),
+            new(TypenameConstants.Contracts, "// contracts"),
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath,
+            cliOutputPath: null);
+
+        planned.Should().HaveCount(2);
+        planned[0].Content.Should().Be("// interfaces");
+        planned[1].Content.Should().Be("// contracts");
+
+        var contractsFolder = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(settingsFilePath)!, "./Contracts"));
+        planned[1].Path.Should().Be(Path.Combine(contractsFolder, $"{TypenameConstants.Contracts}.cs"));
+    }
+
+    [Test]
+    public void Plan_Preserves_Content_For_Each_File()
+    {
+        var config = new RefitGeneratorSettings
+        {
+            GenerateMultipleFiles = true,
+        };
+
+        var output = new GeneratorOutput(new List<GeneratedCode>
+        {
+            new("Interface1", "// content 1"),
+            new("Interface2", "// content 2"),
+        });
+
+        var planned = Planner.Plan(
+            output,
+            config,
+            settingsFilePath: null,
+            cliOutputPath: null);
+
+        planned.Should().HaveCount(2);
+        planned[0].Content.Should().Be("// content 1");
+        planned[1].Content.Should().Be("// content 2");
+    }
+}

--- a/src/Refitter.Tests/SourceGeneratorFileWriterTests.cs
+++ b/src/Refitter.Tests/SourceGeneratorFileWriterTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Refitter.Core;
+using TUnit.Core;
+
+namespace Refitter.Tests;
+
+public class SourceGeneratorFileWriterTests
+{
+    [Test]
+    public async Task WriteAsync_Creates_Directory_And_Writes_File()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "SourceGeneratorFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var writer = new SourceGeneratorFileWriter();
+            var filePath = Path.Combine(workspace, "Generated", "Output.g.cs");
+            var planned = new PlannedFile(filePath, "// sourcegen test");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// sourcegen test");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task WriteAsync_Skips_Write_When_Content_Identical()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "SourceGeneratorFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(workspace);
+            var filePath = Path.Combine(workspace, "Output.g.cs");
+            await File.WriteAllTextAsync(filePath, "// original content");
+
+            var writer = new SourceGeneratorFileWriter();
+            var planned = new PlannedFile(filePath, "// original content");
+
+            // This should NOT write because content is the same
+            await writer.WriteAsync(planned, default);
+
+            // File should still exist with original content
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// original content");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task WriteAsync_Overwrites_When_Content_Differs()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "SourceGeneratorFileWriterTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(workspace);
+            var filePath = Path.Combine(workspace, "Output.g.cs");
+            await File.WriteAllTextAsync(filePath, "// old content");
+
+            var writer = new SourceGeneratorFileWriter();
+            var planned = new PlannedFile(filePath, "// new content");
+
+            await writer.WriteAsync(planned, default);
+
+            File.Exists(filePath).Should().BeTrue();
+            var content = await File.ReadAllTextAsync(filePath);
+            content.Should().Be("// new content");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+}

--- a/src/Refitter/CliFileWriter.cs
+++ b/src/Refitter/CliFileWriter.cs
@@ -1,0 +1,33 @@
+using Refitter.Core;
+
+namespace Refitter;
+
+/// <summary>
+/// Writes planned files to disk and reports progress via <see cref="IGenerationReporter"/>.
+/// </summary>
+public class CliFileWriter : IFileWriter
+{
+    private readonly IGenerationReporter _reporter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CliFileWriter"/> class.
+    /// </summary>
+    /// <param name="reporter">The generation reporter for progress reporting.</param>
+    public CliFileWriter(IGenerationReporter reporter)
+    {
+        _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
+    }
+
+    /// <inheritdoc />
+    public async Task WriteAsync(PlannedFile file, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var dir = Path.GetDirectoryName(file.Path);
+        if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        await File.WriteAllTextAsync(file.Path, file.Content, cancellationToken);
+        _reporter.ReportFileWritten(file.Path);
+    }
+}

--- a/src/Refitter/GenerationOrchestrator.cs
+++ b/src/Refitter/GenerationOrchestrator.cs
@@ -7,6 +7,26 @@ namespace Refitter;
 
 public sealed class GenerationOrchestrator
 {
+    private readonly IOutputPlanner _planner;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenerationOrchestrator"/> class
+    /// with the default <see cref="OutputPlannerAdapter"/>.
+    /// </summary>
+    public GenerationOrchestrator()
+        : this(new OutputPlannerAdapter())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenerationOrchestrator"/> class.
+    /// </summary>
+    /// <param name="planner">The output planner to use for resolving file paths.</param>
+    public GenerationOrchestrator(IOutputPlanner planner)
+    {
+        _planner = planner ?? throw new ArgumentNullException(nameof(planner));
+    }
+
     public async Task<int> RunAsync(
         RefitGeneratorSettings generatorSettings,
         Settings cliSettings,
@@ -38,9 +58,11 @@ public sealed class GenerationOrchestrator
             if (!cliSettings.SkipValidation)
                 await ValidateOpenApiSpecs(generatorSettings, reporter, cancellationToken);
 
+            var writer = new CliFileWriter(reporter);
+
             await (generatorSettings.GenerateMultipleFiles
-                ? WriteMultipleFiles(generator, cliSettings, generatorSettings, reporter, cancellationToken)
-                : WriteSingleFile(generator, cliSettings, generatorSettings, reporter, cancellationToken));
+                ? WriteMultipleFiles(generator, cliSettings, generatorSettings, reporter, writer, cancellationToken)
+                : WriteSingleFile(generator, cliSettings, generatorSettings, reporter, writer, cancellationToken));
 
             Analytics.LogFeatureUsage(cliSettings, generatorSettings);
 
@@ -85,42 +107,44 @@ public sealed class GenerationOrchestrator
         }
     }
 
-    private static async Task WriteSingleFile(
+    private async Task WriteSingleFile(
         RefitGenerator generator,
         Settings settings,
         RefitGeneratorSettings refitGeneratorSettings,
         IGenerationReporter reporter,
+        IFileWriter writer,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         await reporter.ReportSingleFileGenerationProgressAsync(cancellationToken);
 
         var code = generator.Generate().ReplaceLineEndings();
-        var planned = OutputPlanner.PlanSingleFile(
-            settings.SettingsFilePath,
-            settings.OutputPath,
-            refitGeneratorSettings,
-            code);
+        var output = new GeneratorOutput(
+            new List<GeneratedCode> { new(string.Empty, code) });
 
-        var fileName = Path.GetFileName(planned.Path);
-        var directory = Path.GetDirectoryName(planned.Path) ?? string.Empty;
+        var planned = _planner.Plan(
+            output,
+            refitGeneratorSettings,
+            settings.SettingsFilePath,
+            settings.OutputPath);
+
+        var plannedFile = planned[0];
+        var fileName = Path.GetFileName(plannedFile.Path);
+        var directory = Path.GetDirectoryName(plannedFile.Path) ?? string.Empty;
         var sizeFormatted = FormatFileSize(code.Length);
         var lines = code.Split('\n').Length;
 
         reporter.ReportSingleFileOutput(fileName, directory, sizeFormatted, lines);
 
-        var dir = Path.GetDirectoryName(planned.Path);
-        if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
-            Directory.CreateDirectory(dir);
-        await File.WriteAllTextAsync(planned.Path, planned.Content, cancellationToken);
-        reporter.ReportFileWritten(planned.Path);
+        await writer.WriteAsync(plannedFile, cancellationToken);
     }
 
-    private static async Task WriteMultipleFiles(
+    private async Task WriteMultipleFiles(
         RefitGenerator generator,
         Settings settings,
         RefitGeneratorSettings refitGeneratorSettings,
         IGenerationReporter reporter,
+        IFileWriter writer,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -128,11 +152,11 @@ public sealed class GenerationOrchestrator
             generator.GenerateMultipleFiles,
             cancellationToken);
 
-        var planned = OutputPlanner.PlanMultipleFiles(
-            settings.SettingsFilePath,
-            settings.OutputPath,
+        var planned = _planner.Plan(
+            generatorOutput,
             refitGeneratorSettings,
-            generatorOutput);
+            settings.SettingsFilePath,
+            settings.OutputPath);
 
         var totalSize = 0L;
         var totalLines = 0;
@@ -152,12 +176,8 @@ public sealed class GenerationOrchestrator
             totalSize += size;
             totalLines += lines;
 
-            var plannedDir = Path.GetDirectoryName(plannedFile.Path);
-            if (!string.IsNullOrWhiteSpace(plannedDir) && !Directory.Exists(plannedDir))
-                Directory.CreateDirectory(plannedDir);
             cancellationToken.ThrowIfCancellationRequested();
-            await File.WriteAllTextAsync(plannedFile.Path, plannedFile.Content, cancellationToken);
-            reporter.ReportFileWritten(plannedFile.Path);
+            await writer.WriteAsync(plannedFile, cancellationToken);
         }
 
         report.Complete(generatorOutput.Files.Count, FormatFileSize(totalSize), totalLines);


### PR DESCRIPTION
## Summary

Implements Strategy Pattern for Document Loading. Decomposes the monolithic \DocumentLoader\ into composable, testable strategies.

## Changes

### New interfaces and strategies
- \IDocumentLoadingStrategy\ — narrow interface for loading an OpenAPI document
- \FileDocumentStrategy\ — NSwag direct file parsing for local specs
- \HttpDocumentStrategy\ — NSwag direct HTTP parsing with injectable HttpClient
- \OpenApiReaderDocumentStrategy\ — Microsoft.OpenApi.Reader with external \\\ resolution and NSwag fallback

### Utilities
- \PathUtilities\ — extracted \IsHttp\ and \IsYaml\ helpers

### Refactored
- \DocumentLoader\ → compositor holding ordered strategies, tries each in sequence, aggregates errors
- \OpenApiDocumentFactory\ — unchanged (already a thin wrapper)

### Testing
- 46 new tests across all strategies and the compositor
- Strategy ordering verified, error aggregation verified, fallback behavior verified
- All 2349 tests pass (including source generator tests)

## Commit History

6 micro commits:
1. \eat: add IDocumentLoadingStrategy interface\
2. \eat: add PathUtilities helper (IsHttp, IsYaml)\
3. \eat: add FileDocumentStrategy for loading local OpenAPI specs\
4. \eat: add HttpDocumentStrategy for loading remote OpenAPI specs\
5. \eat: add OpenApiReaderDocumentStrategy for external \ resolution\
6. \
efactor: DocumentLoader becomes compositor using strategy pattern\

## Verification

- Build: \dotnet build -c Release\ — clean
- Tests: \dotnet test --solution src/Refitter.slnx -c Release\ — 2349/2349 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Document loading restructured to use multiple strategies, improving handling of local files, HTTP sources, and OpenAPI specs with external references.
  * Output generation now plans files and writes through a unified interface, avoiding unnecessary disk writes by updating files only when content changes.
* **Tests**
  * Added extensive test suites covering document loading strategies, output planning behavior, and file writer filesystem behavior (directory creation, overwrite/no-op rules).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->