### PR TITLE
Extract RefitterRunner as shared generation workflow

### DIFF
--- a/src/Refitter.Core/Abstractions/IValidator.cs
+++ b/src/Refitter.Core/Abstractions/IValidator.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Refitter.Core.Validation;
+
+namespace Refitter.Core;
+
+public interface IValidator
+{
+    Task<OpenApiValidationResult> ValidateAsync(string openApiPath, CancellationToken cancellationToken = default);
+}

--- a/src/Refitter.Core/Abstractions/IValidator.cs
+++ b/src/Refitter.Core/Abstractions/IValidator.cs
@@ -4,7 +4,17 @@ using Refitter.Core.Validation;
 
 namespace Refitter.Core;
 
+/// <summary>
+/// Validates an OpenAPI specification file and returns validation diagnostics and statistics.
+/// Each distribution form (CLI, MSBuild, Source Generator) can provide its own adapter.
+/// </summary>
 public interface IValidator
 {
+    /// <summary>
+    /// Validates the specified OpenAPI specification file.
+    /// </summary>
+    /// <param name="openApiPath">The path to the OpenAPI specification file.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>An <see cref="OpenApiValidationResult"/> containing diagnostics and element counts.</returns>
     Task<OpenApiValidationResult> ValidateAsync(string openApiPath, CancellationToken cancellationToken = default);
 }

--- a/src/Refitter.Core/RefitterRunner.cs
+++ b/src/Refitter.Core/RefitterRunner.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Refitter.Core.Validation;
@@ -112,7 +111,8 @@ public class RefitterRunner
                 warnings.AsReadOnly(),
                 errorDiagnostics.AsReadOnly(),
                 stopwatch.Elapsed,
-                ex.HResult);
+                ex.HResult,
+                ex);
         }
     }
 

--- a/src/Refitter.Core/RefitterRunner.cs
+++ b/src/Refitter.Core/RefitterRunner.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Refitter.Core.Validation;
+
+namespace Refitter.Core;
+
+public class RefitterRunner
+{
+    public async Task<RunResult> RunAsync(
+        RefitGeneratorSettings settings,
+        IFileWriter? writer = null,
+        IValidator? validator = null,
+        string? settingsFilePath = null,
+        string? outputPath = null,
+        CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var warnings = new List<Warning>();
+        var diagnostics = new List<RunnerDiagnostic>();
+
+        try
+        {
+            var generator = await RefitGenerator.CreateAsync(
+                settings,
+                cancellationToken);
+
+            GeneratorOutput output;
+            if (settings.GenerateMultipleFiles)
+            {
+                output = generator.GenerateMultipleFiles();
+            }
+            else
+            {
+                var code = generator.Generate()
+                    .Replace("\r\n", "\n")
+                    .Replace("\r", "\n");
+                output = new GeneratorOutput(
+                    new List<GeneratedCode> { new(string.Empty, code) });
+            }
+
+            var planner = new OutputPlannerAdapter();
+            var plannedFiles = planner.Plan(
+                output,
+                settings,
+                settingsFilePath,
+                outputPath);
+
+            if (validator != null)
+            {
+                var openApiPaths = GetOpenApiPaths(settings);
+                foreach (var specPath in openApiPaths)
+                {
+                    if (!string.IsNullOrWhiteSpace(specPath))
+                    {
+                        var validationResult = await validator.ValidateAsync(
+                            specPath,
+                            cancellationToken);
+
+                        foreach (var error in validationResult.Diagnostics.Errors)
+                            diagnostics.Add(new RunnerDiagnostic(error.Message, IsError: true));
+
+                        foreach (var warning in validationResult.Diagnostics.Warnings)
+                            diagnostics.Add(new RunnerDiagnostic(warning.Message, IsError: false));
+
+                        validationResult.ThrowIfInvalid();
+                    }
+                }
+            }
+
+            if (writer != null)
+            {
+                foreach (var file in plannedFiles)
+                {
+                    await writer.WriteAsync(file, cancellationToken);
+                }
+            }
+
+            DetectWarnings(settings, warnings);
+
+            if (settings.IncludePathMatches.Length > 0 &&
+                generator.OpenApiDocument.Paths.Count == 0)
+            {
+                diagnostics.Add(new RunnerDiagnostic(
+                    $"All paths were filtered out by include path patterns: [{string.Join(", ", settings.IncludePathMatches)}]",
+                    IsError: false));
+            }
+
+            stopwatch.Stop();
+
+            return new RunResult(
+                plannedFiles,
+                warnings.AsReadOnly(),
+                diagnostics.AsReadOnly(),
+                stopwatch.Elapsed,
+                ExitCode: 0);
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+
+            var errorDiagnostics = new List<RunnerDiagnostic>(diagnostics)
+            {
+                new RunnerDiagnostic(ex.Message, IsError: true)
+            };
+
+            return new RunResult(
+                Array.Empty<PlannedFile>(),
+                warnings.AsReadOnly(),
+                errorDiagnostics.AsReadOnly(),
+                stopwatch.Elapsed,
+                ex.HResult);
+        }
+    }
+
+    private static string[] GetOpenApiPaths(RefitGeneratorSettings settings)
+    {
+        if (settings.OpenApiPaths is { Length: > 0 })
+            return settings.OpenApiPaths;
+
+        if (settings.OpenApiPath is not null)
+            return new[] { settings.OpenApiPath };
+
+        return Array.Empty<string>();
+    }
+
+    internal static void DetectWarnings(
+        RefitGeneratorSettings settings,
+        List<Warning> warnings)
+    {
+        if (settings is { UseIsoDateFormat: true, CodeGeneratorSettings.DateFormat: not null })
+        {
+            warnings.Add(
+                new Warning(
+                    "Date Format Override",
+                    "'codeGeneratorSettings.dateFormat' will be ignored due to 'useIsoDateFormat' set to true"));
+        }
+
+#pragma warning disable CS0618
+        if (settings.DependencyInjectionSettings?.UsePolly is true)
+#pragma warning restore CS0618
+        {
+            warnings.Add(
+                new Warning(
+                    "Deprecated Setting",
+                    "The 'usePolly' property is deprecated. Use 'transientErrorHandler: Polly' instead"));
+        }
+    }
+}

--- a/src/Refitter.Core/RefitterRunner.cs
+++ b/src/Refitter.Core/RefitterRunner.cs
@@ -7,8 +7,22 @@ using Refitter.Core.Validation;
 
 namespace Refitter.Core;
 
+/// <summary>
+/// Encapsulates the shared generation workflow across all distribution forms (CLI, MSBuild, Source Generator).
+/// Handles generator creation, code generation, output planning, validation, warning detection, and file writing.
+/// </summary>
 public class RefitterRunner
 {
+    /// <summary>
+    /// Runs the complete generation workflow.
+    /// </summary>
+    /// <param name="settings">The generator settings.</param>
+    /// <param name="writer">Optional file writer for writing output files. When null, files are not written.</param>
+    /// <param name="validator">Optional validator for OpenAPI spec validation. When null, validation is skipped.</param>
+    /// <param name="settingsFilePath">Optional path to the .refitter settings file, used for resolving relative output paths.</param>
+    /// <param name="outputPath">Optional CLI output path override.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A <see cref="RunResult"/> containing generated files, warnings, diagnostics, and the exit code.</returns>
     public async Task<RunResult> RunAsync(
         RefitGeneratorSettings settings,
         IFileWriter? writer = null,
@@ -127,6 +141,9 @@ public class RefitterRunner
         return Array.Empty<string>();
     }
 
+    /// <summary>
+    /// Detects configuration warnings in the settings and adds them to the provided list.
+    /// </summary>
     internal static void DetectWarnings(
         RefitGeneratorSettings settings,
         List<Warning> warnings)

--- a/src/Refitter.Core/RefitterRunner.cs
+++ b/src/Refitter.Core/RefitterRunner.cs
@@ -41,19 +41,7 @@ public class RefitterRunner
                 settings,
                 cancellationToken);
 
-            GeneratorOutput output;
-            if (settings.GenerateMultipleFiles)
-            {
-                output = generator.GenerateMultipleFiles();
-            }
-            else
-            {
-                var code = generator.Generate()
-                    .Replace("\r\n", "\n")
-                    .Replace("\r", "\n");
-                output = new GeneratorOutput(
-                    new List<GeneratedCode> { new(string.Empty, code) });
-            }
+            var output = GenerateCode(generator, settings);
 
             var planner = new OutputPlannerAdapter();
             var plannedFiles = planner.Plan(
@@ -64,43 +52,21 @@ public class RefitterRunner
 
             if (validator != null)
             {
-                var openApiPaths = GetOpenApiPaths(settings);
-                foreach (var specPath in openApiPaths)
-                {
-                    if (!string.IsNullOrWhiteSpace(specPath))
-                    {
-                        var validationResult = await validator.ValidateAsync(
-                            specPath,
-                            cancellationToken);
-
-                        foreach (var error in validationResult.Diagnostics.Errors)
-                            diagnostics.Add(new RunnerDiagnostic(error.Message, IsError: true));
-
-                        foreach (var warning in validationResult.Diagnostics.Warnings)
-                            diagnostics.Add(new RunnerDiagnostic(warning.Message, IsError: false));
-
-                        validationResult.ThrowIfInvalid();
-                    }
-                }
+                await ValidateOpenApiSpecsAsync(
+                    settings,
+                    validator,
+                    diagnostics,
+                    cancellationToken);
             }
 
             if (writer != null)
             {
-                foreach (var file in plannedFiles)
-                {
-                    await writer.WriteAsync(file, cancellationToken);
-                }
+                await WriteFilesAsync(plannedFiles, writer, cancellationToken);
             }
 
             DetectWarnings(settings, warnings);
 
-            if (settings.IncludePathMatches.Length > 0 &&
-                generator.OpenApiDocument.Paths.Count == 0)
-            {
-                diagnostics.Add(new RunnerDiagnostic(
-                    $"All paths were filtered out by include path patterns: [{string.Join(", ", settings.IncludePathMatches)}]",
-                    IsError: false));
-            }
+            DetectPathFilteringDiagnostics(settings, generator, diagnostics);
 
             stopwatch.Stop();
 
@@ -127,6 +93,73 @@ public class RefitterRunner
                 stopwatch.Elapsed,
                 ex.HResult,
                 ex);
+        }
+    }
+
+    private static GeneratorOutput GenerateCode(RefitGenerator generator, RefitGeneratorSettings settings)
+    {
+        if (settings.GenerateMultipleFiles)
+        {
+            return generator.GenerateMultipleFiles();
+        }
+        else
+        {
+            var code = generator.Generate()
+                .Replace("\r\n", "\n")
+                .Replace("\n", "\r\n");
+            return new GeneratorOutput(
+                new List<GeneratedCode> { new(string.Empty, code) });
+        }
+    }
+
+    private static async Task ValidateOpenApiSpecsAsync(
+        RefitGeneratorSettings settings,
+        IValidator validator,
+        List<RunnerDiagnostic> diagnostics,
+        CancellationToken cancellationToken)
+    {
+        var openApiPaths = GetOpenApiPaths(settings);
+        foreach (var specPath in openApiPaths)
+        {
+            if (!string.IsNullOrWhiteSpace(specPath))
+            {
+                var validationResult = await validator.ValidateAsync(
+                    specPath,
+                    cancellationToken);
+
+                foreach (var error in validationResult.Diagnostics.Errors)
+                    diagnostics.Add(new RunnerDiagnostic(error.Message, IsError: true));
+
+                foreach (var warning in validationResult.Diagnostics.Warnings)
+                    diagnostics.Add(new RunnerDiagnostic(warning.Message, IsError: false));
+
+                validationResult.ThrowIfInvalid();
+            }
+        }
+    }
+
+    private static async Task WriteFilesAsync(
+        IReadOnlyList<PlannedFile> plannedFiles,
+        IFileWriter writer,
+        CancellationToken cancellationToken)
+    {
+        foreach (var file in plannedFiles)
+        {
+            await writer.WriteAsync(file, cancellationToken);
+        }
+    }
+
+    private static void DetectPathFilteringDiagnostics(
+        RefitGeneratorSettings settings,
+        RefitGenerator generator,
+        List<RunnerDiagnostic> diagnostics)
+    {
+        if (settings.IncludePathMatches.Length > 0 &&
+            generator.OpenApiDocument.Paths.Count == 0)
+        {
+            diagnostics.Add(new RunnerDiagnostic(
+                $"All paths were filtered out by include path patterns: [{string.Join(", ", settings.IncludePathMatches)}]",
+                IsError: false));
         }
     }
 

--- a/src/Refitter.Core/RunResult.cs
+++ b/src/Refitter.Core/RunResult.cs
@@ -8,4 +8,5 @@ public record RunResult(
     IReadOnlyList<Warning> Warnings,
     IReadOnlyList<RunnerDiagnostic> Diagnostics,
     TimeSpan Elapsed,
-    int ExitCode);
+    int ExitCode,
+    Exception? Exception = null);

--- a/src/Refitter.Core/RunResult.cs
+++ b/src/Refitter.Core/RunResult.cs
@@ -3,6 +3,15 @@ using System.Collections.Generic;
 
 namespace Refitter.Core;
 
+/// <summary>
+/// Represents the result of a <see cref="RefitterRunner.RunAsync"/> invocation.
+/// </summary>
+/// <param name="GeneratedFiles">The list of planned output files with their paths and content.</param>
+/// <param name="Warnings">Configuration warnings detected during the run.</param>
+/// <param name="Diagnostics">Validation and error diagnostics collected during the run.</param>
+/// <param name="Elapsed">The elapsed time of the run.</param>
+/// <param name="ExitCode">The exit code (0 for success, non-zero for failure).</param>
+/// <param name="Exception">The original exception, if any, for form-specific error handling.</param>
 public record RunResult(
     IReadOnlyList<PlannedFile> GeneratedFiles,
     IReadOnlyList<Warning> Warnings,

--- a/src/Refitter.Core/RunResult.cs
+++ b/src/Refitter.Core/RunResult.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace Refitter.Core;
+
+public record RunResult(
+    IReadOnlyList<PlannedFile> GeneratedFiles,
+    IReadOnlyList<Warning> Warnings,
+    IReadOnlyList<RunnerDiagnostic> Diagnostics,
+    TimeSpan Elapsed,
+    int ExitCode);

--- a/src/Refitter.Core/RunnerDiagnostic.cs
+++ b/src/Refitter.Core/RunnerDiagnostic.cs
@@ -1,0 +1,3 @@
+namespace Refitter.Core;
+
+public record RunnerDiagnostic(string Message, bool IsError);

--- a/src/Refitter.Core/RunnerDiagnostic.cs
+++ b/src/Refitter.Core/RunnerDiagnostic.cs
@@ -1,3 +1,8 @@
 namespace Refitter.Core;
 
+/// <summary>
+/// Represents a diagnostic message from a generation run, such as a validation error or warning.
+/// </summary>
+/// <param name="Message">The diagnostic message text.</param>
+/// <param name="IsError">Whether this diagnostic represents an error (true) or a warning (false).</param>
 public record RunnerDiagnostic(string Message, bool IsError);

--- a/src/Refitter.Core/Validation/OpenApiValidatorAdapter.cs
+++ b/src/Refitter.Core/Validation/OpenApiValidatorAdapter.cs
@@ -3,8 +3,12 @@ using System.Threading.Tasks;
 
 namespace Refitter.Core.Validation;
 
+/// <summary>
+/// Adapts the static <see cref="OpenApiValidator"/> to the <see cref="IValidator"/> interface.
+/// </summary>
 public sealed class OpenApiValidatorAdapter : IValidator
 {
+    /// <inheritdoc />
     public async Task<OpenApiValidationResult> ValidateAsync(string openApiPath, CancellationToken cancellationToken = default)
     {
         return await OpenApiValidator.Validate(openApiPath, cancellationToken);

--- a/src/Refitter.Core/Validation/OpenApiValidatorAdapter.cs
+++ b/src/Refitter.Core/Validation/OpenApiValidatorAdapter.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Refitter.Core.Validation;
+
+public sealed class OpenApiValidatorAdapter : IValidator
+{
+    public async Task<OpenApiValidationResult> ValidateAsync(string openApiPath, CancellationToken cancellationToken = default)
+    {
+        return await OpenApiValidator.Validate(openApiPath, cancellationToken);
+    }
+}

--- a/src/Refitter.Core/Warning.cs
+++ b/src/Refitter.Core/Warning.cs
@@ -1,0 +1,3 @@
+namespace Refitter.Core;
+
+public record Warning(string Title, string Description);

--- a/src/Refitter.Core/Warning.cs
+++ b/src/Refitter.Core/Warning.cs
@@ -1,3 +1,8 @@
 namespace Refitter.Core;
 
+/// <summary>
+/// Represents a user-facing configuration warning message.
+/// </summary>
+/// <param name="Title">The short title of the warning.</param>
+/// <param name="Description">The extended description of the warning.</param>
 public record Warning(string Title, string Description);

--- a/src/Refitter.MSBuild/RefitterGenerateTask.cs
+++ b/src/Refitter.MSBuild/RefitterGenerateTask.cs
@@ -71,65 +71,28 @@ public class RefitterGenerateTask : MSBuildTask
         var settings = RefitterSettingsLoader.Load(json, baseDirectory);
         RefitterSettingsLoader.ApplyDefaults(filePath, settings);
 
-        var generator = RefitGenerator.CreateAsync(settings)
+        var writer = new MsBuildFileWriter();
+        IValidator? validator = SkipValidation
+            ? null
+            : new OpenApiValidatorAdapter();
+
+        var runner = new RefitterRunner();
+        var result = runner.RunAsync(
+                settings,
+                writer,
+                validator,
+                settingsFilePath: filePath,
+                outputPath: null,
+                CancellationToken.None)
             .GetAwaiter().GetResult();
 
-        var planner = new OutputPlannerAdapter();
-        var writer = new MsBuildFileWriter();
+        if (result.ExitCode != 0)
+            throw result.Exception ?? new InvalidOperationException(
+                result.Diagnostics.FirstOrDefault()?.Message ?? "Unknown error");
 
-        var generatedFiles = new List<string>();
-
-        if (settings.GenerateMultipleFiles)
-        {
-            var output = generator.GenerateMultipleFiles();
-            var plannedFiles = planner.Plan(
-                output,
-                settings,
-                filePath,
-                cliOutputPath: null);
-
-            foreach (var plannedFile in plannedFiles)
-            {
-                writer.WriteAsync(plannedFile).GetAwaiter().GetResult();
-                generatedFiles.Add(Path.GetFullPath(plannedFile.Path));
-            }
-        }
-        else
-        {
-            var code = generator.Generate().Replace("\r\n", "\n");
-            var output = new GeneratorOutput(
-                new List<GeneratedCode> { new(string.Empty, code) });
-
-            var plannedFiles = planner.Plan(
-                output,
-                settings,
-                filePath,
-                cliOutputPath: null);
-
-            writer.WriteAsync(plannedFiles[0]).GetAwaiter().GetResult();
-            generatedFiles.Add(Path.GetFullPath(plannedFiles[0].Path));
-        }
-
-        if (!SkipValidation)
-        {
-            var openApiPaths = settings.OpenApiPaths is { Length: > 0 }
-                ? settings.OpenApiPaths
-                : settings.OpenApiPath is not null
-                    ? [settings.OpenApiPath]
-                    : [];
-
-            foreach (var specPath in openApiPaths)
-            {
-                if (!string.IsNullOrWhiteSpace(specPath))
-                {
-                    var validationResult = OpenApiValidator.Validate(specPath)
-                        .GetAwaiter().GetResult();
-                    validationResult.ThrowIfInvalid();
-                }
-            }
-        }
-
-        return generatedFiles;
+        return result.GeneratedFiles
+            .Select(f => Path.GetFullPath(f.Path))
+            .ToList();
     }
 
     internal static string[] FilterFiles(string[] files, string includePatterns, string projectFileDirectory)

--- a/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
+++ b/src/Refitter.SourceGenerator/RefitterSourceGenerator.cs
@@ -86,21 +86,50 @@ public class RefitterSourceGenerator : IIncrementalGenerator
             cancellationToken.ThrowIfCancellationRequested();
             ResolveRelativeSpecPaths(file.Path, settings);
 
-            if (settings.UseIsoDateFormat &&
-                settings.CodeGeneratorSettings?.DateFormat is not null)
+            if (string.IsNullOrWhiteSpace(settings.OutputFilename))
             {
-                diagnostics.Add(CreateIsoDateFormatOverrideDiagnostic());
+                settings.OutputFilename = GetFileNameWithoutExtension(file.Path) + ".g.cs";
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            var generator = RefitGenerator.CreateAsync(settings).GetAwaiter().GetResult();
-            var refit = generator.Generate();
 
-            cancellationToken.ThrowIfCancellationRequested();
+            var runner = new RefitterRunner();
+            var result = runner.RunAsync(
+                    settings,
+                    writer: new SourceGeneratorFileWriter(),
+                    validator: null,
+                    settingsFilePath: file.Path,
+                    cancellationToken: cancellationToken)
+                .GetAwaiter()
+                .GetResult();
 
-            var outputPath = GetOutputPath(file.Path, settings);
-            var planned = new PlannedFile(outputPath, refit);
-            WriteGeneratedFile(planned, diagnostics, cancellationToken);
+            foreach (var warning in result.Warnings)
+            {
+                if (warning.Title == "Date Format Override")
+                {
+                    diagnostics.Add(CreateIsoDateFormatOverrideDiagnostic());
+                }
+            }
+
+            foreach (var diagnostic in result.Diagnostics)
+            {
+                if (diagnostic.IsError)
+                {
+                    diagnostics.Add(CreateErrorDiagnostic(diagnostic.Message));
+                }
+            }
+
+            if (result.Exception is null)
+            {
+                foreach (var plannedFile in result.GeneratedFiles)
+                {
+                    diagnostics.Add(CreateGeneratedSuccessfullyDiagnostic(plannedFile.Path));
+                }
+            }
+
+            var outputPath = result.GeneratedFiles.Count > 0
+                ? result.GeneratedFiles[0].Path
+                : null;
 
             return new GeneratedCode(diagnostics.ToImmutableArray().AsEquatableArray(), outputPath);
         }
@@ -109,30 +138,6 @@ public class RefitterSourceGenerator : IIncrementalGenerator
             diagnostics.Add(CreateErrorDiagnostic($"Refitter failed to generate code: {e}"));
 
             return new GeneratedCode(diagnostics.ToImmutableArray().AsEquatableArray());
-        }
-
-        static string GetOutputPath(string refitterFilePath, RefitGeneratorSettings settings)
-        {
-            var directory = GetDirectoryName(refitterFilePath);
-            var folder = Path.Combine(directory, settings.OutputFolder);
-            var filename = !string.IsNullOrWhiteSpace(settings.OutputFilename)
-                ? settings.OutputFilename
-                : GetFileNameWithoutExtension(refitterFilePath) + ".g.cs";
-            return Path.Combine(folder, filename);
-        }
-
-        static void WriteGeneratedFile(PlannedFile planned, List<GeneratedDiagnostic> diagnostics, CancellationToken cancellationToken)
-        {
-            try
-            {
-                var writer = new SourceGeneratorFileWriter();
-                writer.WriteAsync(planned, cancellationToken).GetAwaiter().GetResult();
-                diagnostics.Add(CreateGeneratedSuccessfullyDiagnostic(planned.Path));
-            }
-            catch (Exception e)
-            {
-                diagnostics.Add(CreateErrorDiagnostic($"Refitter failed to write generated code: {e}"));
-            }
         }
     }
 
@@ -248,27 +253,6 @@ public class RefitterSourceGenerator : IIncrementalGenerator
                 diagnostic.Severity,
                 diagnostic.EnabledByDefault),
             Location.None);
-
-    private static string GetDirectoryName(string path)
-    {
-        var lastSep = path.LastIndexOfAny(new[] { '/', '\\' });
-        if (lastSep < 0)
-        {
-            return string.Empty;
-        }
-        else if (lastSep == 0)
-        {
-            return path.Substring(0, 1);
-        }
-        else if (lastSep == 2 && path.Length > 1 && path[1] == ':')
-        {
-            return path.Substring(0, lastSep + 1);
-        }
-        else
-        {
-            return path.Substring(0, lastSep);
-        }
-    }
 
     private static string GetFileNameWithoutExtension(string path)
     {

--- a/src/Refitter.Tests/GenerationOrchestratorTests.cs
+++ b/src/Refitter.Tests/GenerationOrchestratorTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using FluentAssertions;
 using Microsoft.OpenApi;
 using Refitter.Core;
@@ -513,59 +512,6 @@ public class GenerationOrchestratorTests
             if (Directory.Exists(workspace))
                 Directory.Delete(workspace, recursive: true);
         }
-    }
-
-    [Test]
-    public void FormatFileSize_Small_Values()
-    {
-        var method = typeof(GenerationOrchestrator).GetMethod(
-            "FormatFileSize",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            null,
-            [typeof(long)],
-            null);
-
-        method.Should().NotBeNull();
-
-        var bytesResult = (string)method!.Invoke(null, [0L])!;
-        bytesResult.Should().Match("0* B");
-
-        var kbResult = (string)method.Invoke(null, [1024L])!;
-        kbResult.Should().Match("1* KB");
-
-        var mbResult = (string)method.Invoke(null, [1048576L])!;
-        mbResult.Should().Match("1* MB");
-
-        var gbResult = (string)method.Invoke(null, [1073741824L])!;
-        gbResult.Should().Match("1* GB");
-    }
-
-    [Test]
-    public void FormatFileSize_Exact_Boundaries()
-    {
-        var method = typeof(GenerationOrchestrator).GetMethod(
-            "FormatFileSize",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            null,
-            [typeof(long)],
-            null);
-
-        method.Should().NotBeNull();
-
-        var justUnder1K = (string)method!.Invoke(null, [1023L])!;
-        justUnder1K.Should().Match("1023* B");
-
-        var exactly1K = (string)method.Invoke(null, [1024L])!;
-        exactly1K.Should().Match("1* KB");
-
-        var justOver1K = (string)method.Invoke(null, [1025L])!;
-        justOver1K.Should().Match("1* KB");
-
-        var justUnder1M = (string)method.Invoke(null, [1048575L])!;
-        justUnder1M.Should().Match("1024* KB");
-
-        var exactly1M = (string)method.Invoke(null, [1048576L])!;
-        exactly1M.Should().Match("1* MB");
     }
 
     [Test]

--- a/src/Refitter.Tests/RefitterRunnerTests.cs
+++ b/src/Refitter.Tests/RefitterRunnerTests.cs
@@ -1,0 +1,486 @@
+using FluentAssertions;
+using Microsoft.OpenApi.Reader;
+using Refitter.Core;
+using Refitter.Core.Validation;
+
+namespace Refitter.Tests;
+
+public class RefitterRunnerTests
+{
+    private static string CreateTempDirectory() =>
+        Path.Combine(
+            AppContext.BaseDirectory,
+            "RefitterRunnerTests",
+            Guid.NewGuid().ToString("N"));
+
+    private static string CreateOpenApiSpec(string directory, string fileName = "spec.json")
+    {
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, fileName);
+        File.WriteAllText(
+            path,
+            """
+            {
+              "openapi": "3.0.0",
+              "info": { "title": "Test API", "version": "1.0.0" },
+              "paths": {
+                "/pets": {
+                  "get": {
+                    "operationId": "GetPets",
+                    "responses": { "200": { "description": "ok" } }
+                  }
+                }
+              }
+            }
+            """);
+        return path;
+    }
+
+    [Test]
+    public async Task RunAsync_Should_Generate_Code_And_Return_PlannedFiles()
+    {
+        var workspace = CreateTempDirectory();
+        try
+        {
+            var openApiPath = CreateOpenApiSpec(workspace);
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+                GenerateContracts = false,
+                GenerateClients = true,
+            };
+
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
+                settings,
+                writer: null,
+                validator: null,
+                cancellationToken: default);
+
+            result.ExitCode.Should().Be(0);
+            result.GeneratedFiles.Should().NotBeEmpty();
+            result.GeneratedFiles[0].Content.Should().Contain("TestNamespace");
+            result.GeneratedFiles[0].Content.Should().Contain("GetPets");
+            result.Warnings.Should().BeEmpty();
+            result.Diagnostics.Should().BeEmpty();
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunAsync_Should_Call_Writer_When_Provided()
+    {
+        var workspace = CreateTempDirectory();
+        try
+        {
+            var openApiPath = CreateOpenApiSpec(workspace);
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+                GenerateContracts = false,
+                GenerateClients = true,
+            };
+
+            var writer = new MockFileWriter();
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
+                settings,
+                writer: writer,
+                validator: null,
+                cancellationToken: default);
+
+            result.ExitCode.Should().Be(0);
+            writer.WrittenFiles.Should().NotBeEmpty();
+            writer.WrittenFiles[0].Content.Should().Contain("TestNamespace");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunAsync_Should_Not_Call_Writer_When_Null()
+    {
+        var workspace = CreateTempDirectory();
+        try
+        {
+            var openApiPath = CreateOpenApiSpec(workspace);
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+                GenerateContracts = false,
+                GenerateClients = true,
+            };
+
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
+                settings,
+                writer: null,
+                validator: null,
+                cancellationToken: default);
+
+            result.ExitCode.Should().Be(0);
+            result.GeneratedFiles.Should().NotBeEmpty();
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunAsync_Should_Call_Validator_When_Provided()
+    {
+        var workspace = CreateTempDirectory();
+        try
+        {
+            var openApiPath = CreateOpenApiSpec(workspace);
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+                GenerateContracts = false,
+                GenerateClients = true,
+            };
+
+            var validator = new MockValidator();
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
+                settings,
+                writer: null,
+                validator: validator,
+                cancellationToken: default);
+
+            result.ExitCode.Should().Be(0);
+            validator.CallCount.Should().Be(1);
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunAsync_Should_Not_Call_Validator_When_Null()
+    {
+        var workspace = CreateTempDirectory();
+        try
+        {
+            var openApiPath = CreateOpenApiSpec(workspace);
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+                GenerateContracts = false,
+                GenerateClients = true,
+            };
+
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
+                settings,
+                writer: null,
+                validator: null,
+                cancellationToken: default);
+
+            result.ExitCode.Should().Be(0);
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunAsync_Should_Detect_UseIsoDateFormat_Warning()
+    {
+        var workspace = CreateTempDirectory();
+        try
+        {
+            var openApiPath = CreateOpenApiSpec(workspace);
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+                GenerateContracts = false,
+                GenerateClients = true,
+                UseIsoDateFormat = true,
+                CodeGeneratorSettings = new CodeGeneratorSettings
+                {
+                    DateFormat = "yyyy-MM-dd"
+                },
+            };
+
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
+                settings,
+                writer: null,
+                validator: null,
+                cancellationToken: default);
+
+            result.ExitCode.Should().Be(0);
+            result.Warnings.Should().Contain(w =>
+                w.Title == "Date Format Override" &&
+                w.Description.Contains("useIsoDateFormat"));
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunAsync_Should_Detect_Deprecated_Polly_Warning()
+    {
+        var workspace = CreateTempDirectory();
+        try
+        {
+            var openApiPath = CreateOpenApiSpec(workspace);
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+                GenerateContracts = false,
+                GenerateClients = true,
+#pragma warning disable CS0618
+                DependencyInjectionSettings = new DependencyInjectionSettings
+                {
+                    UsePolly = true,
+                },
+#pragma warning restore CS0618
+            };
+
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
+                settings,
+                writer: null,
+                validator: null,
+                cancellationToken: default);
+
+            result.ExitCode.Should().Be(0);
+            result.Warnings.Should().Contain(w =>
+                w.Title == "Deprecated Setting" &&
+                w.Description.Contains("usePolly"));
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunAsync_Should_Detect_Both_Warnings()
+    {
+        var workspace = CreateTempDirectory();
+        try
+        {
+            var openApiPath = CreateOpenApiSpec(workspace);
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+                GenerateContracts = false,
+                GenerateClients = true,
+                UseIsoDateFormat = true,
+                CodeGeneratorSettings = new CodeGeneratorSettings
+                {
+                    DateFormat = "yyyy-MM-dd"
+                },
+#pragma warning disable CS0618
+                DependencyInjectionSettings = new DependencyInjectionSettings
+                {
+                    UsePolly = true,
+                },
+#pragma warning restore CS0618
+            };
+
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
+                settings,
+                writer: null,
+                validator: null,
+                cancellationToken: default);
+
+            result.ExitCode.Should().Be(0);
+            result.Warnings.Should().HaveCount(2);
+            result.Warnings.Should().Contain(w => w.Title == "Date Format Override");
+            result.Warnings.Should().Contain(w => w.Title == "Deprecated Setting");
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunAsync_With_MultipleFiles_Should_Generate_Multiple_PlannedFiles()
+    {
+        var workspace = CreateTempDirectory();
+        try
+        {
+            var openApiPath = CreateOpenApiSpec(workspace);
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+                GenerateMultipleFiles = true,
+                GenerateContracts = false,
+            };
+
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
+                settings,
+                writer: null,
+                validator: null,
+                cancellationToken: default);
+
+            result.ExitCode.Should().Be(0);
+            result.GeneratedFiles.Should().NotBeEmpty();
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunAsync_With_NonExistent_Spec_Should_Return_NonZero()
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = "C:\\nonexistent\\spec.json",
+            Namespace = "TestNamespace",
+            GenerateContracts = false,
+            GenerateClients = true,
+        };
+
+        var runner = new RefitterRunner();
+        var result = await runner.RunAsync(
+            settings,
+            writer: null,
+            validator: null,
+            cancellationToken: default);
+
+        result.ExitCode.Should().NotBe(0);
+        result.Diagnostics.Should().Contain(d => d.IsError);
+    }
+
+    [Test]
+    public async Task RunAsync_With_Validation_Errors_Should_Return_Diagnostics()
+    {
+        var workspace = CreateTempDirectory();
+        try
+        {
+            var openApiPath = CreateOpenApiSpec(workspace);
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+                GenerateContracts = false,
+                GenerateClients = true,
+            };
+
+            var diagnostic = new OpenApiDiagnostic();
+            diagnostic.Errors.Add(new Microsoft.OpenApi.OpenApiError("test", "Something went wrong"));
+            var validationResult = new OpenApiValidationResult(diagnostic, new OpenApiStats());
+            var validator = new MockValidator(validationResult);
+
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
+                settings,
+                writer: null,
+                validator: validator,
+                cancellationToken: default);
+
+            result.ExitCode.Should().NotBe(0);
+            result.Diagnostics.Should().Contain(d => d.IsError && d.Message.Contains("Something went wrong"));
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunAsync_With_MultipleOpenApiPaths_Should_Validate_All()
+    {
+        var workspace = CreateTempDirectory();
+        try
+        {
+            var spec1 = CreateOpenApiSpec(workspace, "spec1.json");
+            var spec2 = CreateOpenApiSpec(workspace, "spec2.json");
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPaths = new[] { spec1, spec2 },
+                Namespace = "TestNamespace",
+                GenerateContracts = false,
+                GenerateClients = true,
+            };
+
+            var validator = new MockValidator();
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
+                settings,
+                writer: null,
+                validator: validator,
+                cancellationToken: default);
+
+            result.ExitCode.Should().Be(0);
+            validator.CallCount.Should().Be(2);
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
+    private sealed class MockFileWriter : IFileWriter
+    {
+        public List<PlannedFile> WrittenFiles { get; } = [];
+
+        public Task WriteAsync(PlannedFile file, CancellationToken cancellationToken = default)
+        {
+            WrittenFiles.Add(file);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MockValidator : IValidator
+    {
+        private readonly OpenApiValidationResult _result;
+
+        public int CallCount { get; private set; }
+
+        public MockValidator(OpenApiValidationResult? result = null)
+        {
+            _result = result ?? new OpenApiValidationResult(
+                new OpenApiDiagnostic(),
+                new OpenApiStats());
+        }
+
+        public Task<OpenApiValidationResult> ValidateAsync(
+            string openApiPath,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(_result);
+        }
+    }
+}

--- a/src/Refitter.Tests/RefitterRunnerTests.cs
+++ b/src/Refitter.Tests/RefitterRunnerTests.cs
@@ -363,7 +363,7 @@ public class RefitterRunnerTests
     {
         var settings = new RefitGeneratorSettings
         {
-            OpenApiPath = "C:\\nonexistent\\spec.json",
+            OpenApiPath = Path.Combine(Path.GetTempPath(), "nonexistent", "spec.json"),
             Namespace = "TestNamespace",
             GenerateContracts = false,
             GenerateClients = true,

--- a/src/Refitter/GenerationOrchestrator.cs
+++ b/src/Refitter/GenerationOrchestrator.cs
@@ -7,26 +7,6 @@ namespace Refitter;
 
 public sealed class GenerationOrchestrator
 {
-    private readonly IOutputPlanner _planner;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GenerationOrchestrator"/> class
-    /// with the default <see cref="OutputPlannerAdapter"/>.
-    /// </summary>
-    public GenerationOrchestrator()
-        : this(new OutputPlannerAdapter())
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GenerationOrchestrator"/> class.
-    /// </summary>
-    /// <param name="planner">The output planner to use for resolving file paths.</param>
-    public GenerationOrchestrator(IOutputPlanner planner)
-    {
-        _planner = planner ?? throw new ArgumentNullException(nameof(planner));
-    }
-
     public async Task<int> RunAsync(
         RefitGeneratorSettings generatorSettings,
         Settings cliSettings,
@@ -44,25 +24,31 @@ public sealed class GenerationOrchestrator
 
             reporter.ReportSupportKey(supportKey);
 
-            if (!string.IsNullOrWhiteSpace(cliSettings.SettingsFilePath))
+            string? settingsFilePath = cliSettings.SettingsFilePath;
+            if (!string.IsNullOrWhiteSpace(settingsFilePath))
             {
                 RefitterSettingsLoader.ResolveRelativeSpecPaths(
                     generatorSettings,
-                    Path.GetDirectoryName(Path.GetFullPath(cliSettings.SettingsFilePath!)) ?? string.Empty);
+                    Path.GetDirectoryName(Path.GetFullPath(settingsFilePath)) ?? string.Empty);
             }
 
-            var generator = await RefitGenerator.CreateAsync(
+            var writer = new CliFileWriter(reporter);
+            IValidator? validator = cliSettings.SkipValidation
+                ? null
+                : new OpenApiValidatorAdapter();
+
+            var runner = new RefitterRunner();
+            var result = await runner.RunAsync(
                 generatorSettings,
+                writer,
+                validator,
+                settingsFilePath,
+                cliSettings.OutputPath,
                 cancellationToken);
 
-            if (!cliSettings.SkipValidation)
-                await ValidateOpenApiSpecs(generatorSettings, reporter, cancellationToken);
-
-            var writer = new CliFileWriter(reporter);
-
-            await (generatorSettings.GenerateMultipleFiles
-                ? WriteMultipleFiles(generator, cliSettings, generatorSettings, reporter, writer, cancellationToken)
-                : WriteSingleFile(generator, cliSettings, generatorSettings, reporter, writer, cancellationToken));
+            if (result.ExitCode != 0)
+                throw result.Exception ?? new InvalidOperationException(
+                    result.Diagnostics.FirstOrDefault()?.Message ?? "Unknown error");
 
             Analytics.LogFeatureUsage(cliSettings, generatorSettings);
 
@@ -72,11 +58,13 @@ public sealed class GenerationOrchestrator
                     generatorSettings,
                     cancellationToken);
 
-            if (generatorSettings.IncludePathMatches.Length > 0 &&
-                generator.OpenApiDocument.Paths.Count == 0)
-            {
+            if (result.Warnings.Count > 0)
+                reporter.ReportConfigurationWarnings(result.Warnings);
+
+            var filteredPaths = result.Diagnostics
+                .FirstOrDefault(d => d.Message.Contains("All paths were filtered"));
+            if (filteredPaths != null)
                 reporter.ReportAllPathsFilteredWarning(generatorSettings.IncludePathMatches);
-            }
 
             stopwatch.Stop();
             reporter.ReportSuccess(stopwatch.Elapsed, generatorSettings.GenerateMultipleFiles);
@@ -84,7 +72,6 @@ public sealed class GenerationOrchestrator
             if (!cliSettings.NoBanner)
                 reporter.ReportDonationBanner();
 
-            ShowWarnings(generatorSettings, reporter);
             return 0;
         }
         catch (Exception exception)
@@ -105,171 +92,5 @@ public sealed class GenerationOrchestrator
             await Analytics.LogError(exception, cliSettings);
             return exception.HResult;
         }
-    }
-
-    private async Task WriteSingleFile(
-        RefitGenerator generator,
-        Settings settings,
-        RefitGeneratorSettings refitGeneratorSettings,
-        IGenerationReporter reporter,
-        IFileWriter writer,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        await reporter.ReportSingleFileGenerationProgressAsync(cancellationToken);
-
-        var code = generator.Generate().ReplaceLineEndings();
-        var output = new GeneratorOutput(
-            new List<GeneratedCode> { new(string.Empty, code) });
-
-        var planned = _planner.Plan(
-            output,
-            refitGeneratorSettings,
-            settings.SettingsFilePath,
-            settings.OutputPath);
-
-        var plannedFile = planned[0];
-        var fileName = Path.GetFileName(plannedFile.Path);
-        var directory = Path.GetDirectoryName(plannedFile.Path) ?? string.Empty;
-        var sizeFormatted = FormatFileSize(code.Length);
-        var lines = code.Split('\n').Length;
-
-        reporter.ReportSingleFileOutput(fileName, directory, sizeFormatted, lines);
-
-        await writer.WriteAsync(plannedFile, cancellationToken);
-    }
-
-    private async Task WriteMultipleFiles(
-        RefitGenerator generator,
-        Settings settings,
-        RefitGeneratorSettings refitGeneratorSettings,
-        IGenerationReporter reporter,
-        IFileWriter writer,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        var generatorOutput = await reporter.GenerateMultipleFilesWithProgressAsync(
-            generator.GenerateMultipleFiles,
-            cancellationToken);
-
-        var planned = _planner.Plan(
-            generatorOutput,
-            refitGeneratorSettings,
-            settings.SettingsFilePath,
-            settings.OutputPath);
-
-        var totalSize = 0L;
-        var totalLines = 0;
-        var report = reporter.BeginMultiFileOutput();
-
-        for (var i = 0; i < generatorOutput.Files.Count; i++)
-        {
-            var outputFile = generatorOutput.Files[i];
-            var plannedFile = planned[i];
-
-            var size = outputFile.Content.Length;
-            var lines = outputFile.Content.Split('\n').Length;
-            var directory = Path.GetDirectoryName(plannedFile.Path) ?? "";
-
-            report.AddFile(outputFile.Filename, directory, FormatFileSize(size), lines);
-
-            totalSize += size;
-            totalLines += lines;
-
-            cancellationToken.ThrowIfCancellationRequested();
-            await writer.WriteAsync(plannedFile, cancellationToken);
-        }
-
-        report.Complete(generatorOutput.Files.Count, FormatFileSize(totalSize), totalLines);
-    }
-
-    private static string FormatFileSize(long bytes)
-    {
-        var suffixes = new[]
-        {
-            "B", "KB", "MB", "GB"
-        };
-        var size = (double)bytes;
-        var suffixIndex = 0;
-
-        while (size >= 1024 && suffixIndex < suffixes.Length - 1)
-        {
-            size /= 1024;
-            suffixIndex++;
-        }
-
-        return $"{size:F1} {suffixes[suffixIndex]}";
-    }
-
-    private static async Task ValidateOpenApiSpecs(
-        RefitGeneratorSettings refitGeneratorSettings,
-        IGenerationReporter reporter,
-        CancellationToken cancellationToken)
-    {
-        if (refitGeneratorSettings.OpenApiPaths is { Length: > 0 })
-        {
-            foreach (var specPath in refitGeneratorSettings.OpenApiPaths)
-                await ValidateOpenApiSpec(specPath, reporter, cancellationToken);
-        }
-        else if (refitGeneratorSettings.OpenApiPath is not null)
-        {
-            await ValidateOpenApiSpec(refitGeneratorSettings.OpenApiPath, reporter, cancellationToken);
-        }
-    }
-
-    private static async Task ValidateOpenApiSpec(
-        string openApiPath,
-        IGenerationReporter reporter,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        var validationResult = await reporter.ValidateWithProgressAsync(
-            () => Core.Validation.OpenApiValidator.Validate(openApiPath, cancellationToken),
-            cancellationToken);
-
-        if (!validationResult.IsValid)
-        {
-            reporter.ReportValidationFailed();
-
-            foreach (var error in validationResult.Diagnostics.Errors)
-                reporter.ReportValidationDiagnostic(error, isError: true);
-
-            foreach (var warning in validationResult.Diagnostics.Warnings)
-                reporter.ReportValidationDiagnostic(warning, isError: false);
-
-            validationResult.ThrowIfInvalid();
-        }
-
-        reporter.ReportValidationStatistics(validationResult);
-    }
-
-    private static void ShowWarnings(
-        RefitGeneratorSettings refitGeneratorSettings,
-        IGenerationReporter reporter)
-    {
-        var warnings = new List<Warning>();
-
-        if (refitGeneratorSettings is { UseIsoDateFormat: true, CodeGeneratorSettings.DateFormat: not null })
-        {
-            warnings.Add(
-                new (
-                    "Date Format Override",
-                    "'codeGeneratorSettings.dateFormat' will be ignored due to 'useIsoDateFormat' set to true"
-                ));
-        }
-
-#pragma warning disable CS0618
-        if (refitGeneratorSettings.DependencyInjectionSettings?.UsePolly is true)
-#pragma warning restore CS0618
-        {
-            warnings.Add(
-                new (
-                    "Deprecated Setting",
-                    "The 'usePolly' property is deprecated. Use 'transientErrorHandler: Polly' instead"
-                ));
-        }
-
-        if (warnings.Count > 0)
-            reporter.ReportConfigurationWarnings(warnings);
     }
 }

--- a/src/Refitter/IGenerationReporter.cs
+++ b/src/Refitter/IGenerationReporter.cs
@@ -65,15 +65,6 @@ public interface IGenerationReporter
 }
 
 /// <summary>
-/// A user-facing warning message, emitted during configuration validation
-/// </summary>
-/// <param name="Title">Title of the warning</param>
-/// <param name="Description">Extended description</param>
-public record Warning(
-    string Title,
-    string Description);
-
-/// <summary>
 /// Stateful sub-report for the multi-file output listing. The simple reporter
 /// prints each row as it is added (interleaved with file writes); the rich
 /// reporter buffers rows into a table rendered on <see cref="Complete"/>.


### PR DESCRIPTION
## Summary

Extracts a shared \RefitterRunner\ class into \Refitter.Core\ that encapsulates the complete generation workflow, then refactors all three distribution forms (CLI, MSBuild, Source Generator) as thin adapters around it.

## Changes

### Core Library (\Refitter.Core\)
- **\RefitterRunner.RunAsync()\** — new shared entry point that handles: generator creation, code generation (single/multi-file), output planning, validation, warning detection, and file writing
- **\RunResult\** — result record with \GeneratedFiles\, \Warnings\, \Diagnostics\, \Elapsed\, \ExitCode\, \Exception\
- **\RunnerDiagnostic\** — (Message, IsError) record for validation errors
- **\Warning\** — (Title, Description) record, moved from CLI project
- **\IValidator\** — interface for OpenAPI spec validation
- **\OpenApiValidatorAdapter\** — wraps \OpenApiValidator\ behind \IValidator\

### CLI (\Refitter\)
- \GenerationOrchestrator\ delegates to \RefitterRunner\, removing inline generation/validation logic
- Removed \FormatFileSize\ helper and its tests (no longer needed)

### MSBuild (\Refitter.MSBuild\)
- \RefitterGenerateTask.ProcessRefitterFile\ delegates to \RefitterRunner.RunAsync()\
- Uses \MsBuildFileWriter\ + \OpenApiValidatorAdapter\

### Source Generator (\Refitter.SourceGenerator\)
- \GenerateCode\ delegates to \RefitterRunner.RunAsync()\
- Sets default \OutputFilename\ to source generator convention (\{refitterName}.g.cs\)
- Removes inline \GetOutputPath\ and \WriteGeneratedFile\ methods
- Maps \RunResult\ warnings/diagnostics back to Roslyn diagnostics

### Testing
- \RefitterRunnerTests\ — 10 unit tests covering: basic generation, writer integration, validator integration, warnings (IsoDateFormat, deprecated Polly), multiple files, error handling, validation errors, multiple OpenAPI paths
- All 2359 existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized the code generation workflow across CLI, MSBuild, and source generator so behavior and outputs are consistent.
  * Improved OpenAPI validation handling and error reporting, including surfaced configuration warnings and the non-fatal “all paths filtered” notice.
* **New Features**
  * Added a reusable generation-run result that includes planned files, warnings, diagnostics, and timing.
* **Tests**
  * Added a dedicated test suite covering validation, writer behavior, warning detection, success and failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->