### PR TITLE
Split up Unit and Integration tests using [Category]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     - name: 🛠️ Build
       run: dotnet build -c Release src/Refitter.slnx -p:UseSourceLink=true -p:PackageVersion="${{ env.VERSION }}" -p:Version="${{ env.VERSION }}"
     - name: 🧪 Unit tests (fast gate)
-      run: dotnet test --solution src/Refitter.slnx -c Release --no-build --treenode-filter "/*/*/*/*[Category=Unit]"
+      run: dotnet test --solution src/Refitter.slnx -c Release --no-build --treenode-filter "/*/*/*/*[Category!=Integration]"
     - name: 🧪 Full test suite
       if: ${{ success() }}
       run: dotnet test --solution src/Refitter.slnx -c Release --no-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,11 @@ jobs:
         dotnet msbuild src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
     - name: 🛠️ Build
       run: dotnet build -c Release src/Refitter.slnx -p:UseSourceLink=true -p:PackageVersion="${{ env.VERSION }}" -p:Version="${{ env.VERSION }}"
-    - name: 🧪 Test
-      run: dotnet test --solution src/Refitter.slnx -c Release
+    - name: 🧪 Unit tests (fast gate)
+      run: dotnet test --solution src/Refitter.slnx -c Release --no-build --treenode-filter "/*/*/*/*[Category=Unit]"
+    - name: 🧪 Full test suite
+      if: ${{ success() }}
+      run: dotnet test --solution src/Refitter.slnx -c Release --no-build
     - name: 🗳️ Upload
       uses: actions/upload-artifact@v7
       with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,23 @@ OpenAPI-to-Refit code generator. Multi-package solution: CLI tool, MSBuild task,
 - Build: `dotnet build -c Release src/Refitter.slnx`
 - Test: `dotnet test --solution src/Refitter.slnx -c Release`
 
+### Fast Feedback (TUnit category filters)
+
+TUnit uses `--treenode-filter` instead of the VSTest `--filter` syntax.
+
+```bash
+# Fast unit tests only (no subprocess compilation — ~41s, 2152 tests)
+dotnet test --treenode-filter "/*/*/*/*[Category=Unit]" --solution src/Refitter.slnx -c Release --no-build
+
+# Integration tests only (compilation verification — ~17s, 88 tests)
+dotnet test --treenode-filter "/*/*/*/*[Category=Integration]" --solution src/Refitter.slnx -c Release --no-build
+
+# Full suite before commit
+dotnet test --solution src/Refitter.slnx -c Release
+```
+
+**Convention:** All `[Test]` methods MUST have either `[Category("Unit")]` or `[Category("Integration")]`. `[Category("Unit")]` — string-only assertion, no subprocess. `[Category("Integration")]` — calls `BuildHelper.BuildCSharp()` which spawns `dotnet build`.
+
 **Source Generator tests require a pre-build step.** Before running `dotnet test` on `Refitter.SourceGenerator.Tests`, the CI does:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ TUnit uses `--treenode-filter` instead of the VSTest `--filter` syntax.
 
 ```bash
 # Fast unit tests only (no subprocess compilation — ~41s, 2152 tests)
-dotnet test --treenode-filter "/*/*/*/*[Category=Unit]" --solution src/Refitter.slnx -c Release --no-build
+dotnet test --treenode-filter "/*/*/*/*[Category!=Integration]" --solution src/Refitter.slnx -c Release --no-build
 
 # Integration tests only (compilation verification — ~17s, 88 tests)
 dotnet test --project src/Refitter.Tests/Refitter.Tests.csproj -c Release --no-build --treenode-filter "/*/*/*/*[Category=Integration]"
@@ -24,7 +24,7 @@ dotnet test --project src/Refitter.Tests/Refitter.Tests.csproj -c Release --no-b
 dotnet test --solution src/Refitter.slnx -c Release
 ```
 
-**Convention:** All `[Test]` methods MUST have either `[Category("Unit")]` or `[Category("Integration")]`. `[Category("Unit")]` — string-only assertion, no subprocess. `[Category("Integration")]` — calls `BuildHelper.BuildCSharp()` which spawns `dotnet build`.
+**Convention:** Only `[Category("Integration")]` is explicitly declared — tests that call `BuildHelper.BuildCSharp()` which spawns `dotnet build`. All other tests are unmarked and treated as unit tests by default.
 
 **Source Generator tests require a pre-build step.** Before running `dotnet test` on `Refitter.SourceGenerator.Tests`, the CI does:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ TUnit uses `--treenode-filter` instead of the VSTest `--filter` syntax.
 dotnet test --treenode-filter "/*/*/*/*[Category=Unit]" --solution src/Refitter.slnx -c Release --no-build
 
 # Integration tests only (compilation verification — ~17s, 88 tests)
-dotnet test --treenode-filter "/*/*/*/*[Category=Integration]" --solution src/Refitter.slnx -c Release --no-build
+dotnet test --project src/Refitter.Tests/Refitter.Tests.csproj -c Release --no-build --treenode-filter "/*/*/*/*[Category=Integration]"
 
 # Full suite before commit
 dotnet test --solution src/Refitter.slnx -c Release

--- a/src/Refitter.SourceGenerator.Tests/CustomOutputFolderGeneratorTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/CustomOutputFolderGeneratorTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.SourceGenerators.Tests;
 
 
-[Category("Unit")]
 public class CustomOutputFolderGeneratorTests
 {
     [Test]

--- a/src/Refitter.SourceGenerator.Tests/CustomOutputFolderGeneratorTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/CustomOutputFolderGeneratorTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.SourceGenerators.Tests;
 
+
+[Category("Unit")]
 public class CustomOutputFolderGeneratorTests
 {
     [Test]

--- a/src/Refitter.SourceGenerator.Tests/MultipleInterfaceByTagGeneratorTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/MultipleInterfaceByTagGeneratorTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.SourceGenerators.Tests;
 
 
-[Category("Unit")]
 public class MultipleInterfaceByTagGeneratorTests
 {
     private const string ExpectedNamespace = "Refitter.Tests.AdditionalFiles.ByTag";

--- a/src/Refitter.SourceGenerator.Tests/MultipleInterfaceByTagGeneratorTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/MultipleInterfaceByTagGeneratorTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.SourceGenerators.Tests;
 
+
+[Category("Unit")]
 public class MultipleInterfaceByTagGeneratorTests
 {
     private const string ExpectedNamespace = "Refitter.Tests.AdditionalFiles.ByTag";

--- a/src/Refitter.SourceGenerator.Tests/MultipleInterfaceGeneratorTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/MultipleInterfaceGeneratorTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.SourceGenerators.Tests;
 
+
+[Category("Unit")]
 public class MultipleInterfaceGeneratorTests
 {
     private const string ExpectedNamespace = "Refitter.Tests.AdditionalFiles.ByEndpoint";

--- a/src/Refitter.SourceGenerator.Tests/MultipleInterfaceGeneratorTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/MultipleInterfaceGeneratorTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.SourceGenerators.Tests;
 
 
-[Category("Unit")]
 public class MultipleInterfaceGeneratorTests
 {
     private const string ExpectedNamespace = "Refitter.Tests.AdditionalFiles.ByEndpoint";

--- a/src/Refitter.SourceGenerator.Tests/OptionalParametersGeneratorTest.cs
+++ b/src/Refitter.SourceGenerator.Tests/OptionalParametersGeneratorTest.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.SourceGenerators.Tests;
 
 
-[Category("Unit")]
 public class OperationalParametersGeneratorTest
 {
     [Test]

--- a/src/Refitter.SourceGenerator.Tests/OptionalParametersGeneratorTest.cs
+++ b/src/Refitter.SourceGenerator.Tests/OptionalParametersGeneratorTest.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.SourceGenerators.Tests;
 
+
+[Category("Unit")]
 public class OperationalParametersGeneratorTest
 {
     [Test]

--- a/src/Refitter.SourceGenerator.Tests/PropertyNamingPolicyGeneratorTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/PropertyNamingPolicyGeneratorTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.SourceGenerators.Tests;
 
 
-[Category("Unit")]
 public class PropertyNamingPolicyGeneratorTests
 {
     [Test]

--- a/src/Refitter.SourceGenerator.Tests/PropertyNamingPolicyGeneratorTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/PropertyNamingPolicyGeneratorTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.SourceGenerators.Tests;
 
+
+[Category("Unit")]
 public class PropertyNamingPolicyGeneratorTests
 {
     [Test]

--- a/src/Refitter.SourceGenerator.Tests/SingleInterfaceGeneratorTest.cs
+++ b/src/Refitter.SourceGenerator.Tests/SingleInterfaceGeneratorTest.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.SourceGenerators.Tests;
 
+
+[Category("Unit")]
 public class SingleInterfaceGeneratorTest
 {
     [Test]

--- a/src/Refitter.SourceGenerator.Tests/SingleInterfaceGeneratorTest.cs
+++ b/src/Refitter.SourceGenerator.Tests/SingleInterfaceGeneratorTest.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.SourceGenerators.Tests;
 
 
-[Category("Unit")]
 public class SingleInterfaceGeneratorTest
 {
     [Test]

--- a/src/Refitter.SourceGenerator.Tests/SourceGeneratorFileIOTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/SourceGeneratorFileIOTests.cs
@@ -5,6 +5,8 @@ using Refitter.SourceGenerators.Tests.TestUtilities;
 
 namespace Refitter.SourceGenerators.Tests;
 
+
+[Category("Unit")]
 public class SourceGeneratorFileIOTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.SourceGenerator.Tests/SourceGeneratorFileIOTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/SourceGeneratorFileIOTests.cs
@@ -6,7 +6,6 @@ using Refitter.SourceGenerators.Tests.TestUtilities;
 namespace Refitter.SourceGenerators.Tests;
 
 
-[Category("Unit")]
 public class SourceGeneratorFileIOTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.SourceGenerator.Tests/UseJsonInheritanceConverterTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/UseJsonInheritanceConverterTests.cs
@@ -4,6 +4,8 @@ using TUnit.Core;
 
 namespace Refitter.SourceGenerators.Tests;
 
+
+[Category("Unit")]
 public class UseJsonInheritanceConverterTests
 {
     [Test]

--- a/src/Refitter.SourceGenerator.Tests/UseJsonInheritanceConverterTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/UseJsonInheritanceConverterTests.cs
@@ -5,7 +5,6 @@ using TUnit.Core;
 namespace Refitter.SourceGenerators.Tests;
 
 
-[Category("Unit")]
 public class UseJsonInheritanceConverterTests
 {
     [Test]

--- a/src/Refitter.SourceGenerator.Tests/UsePolymorphicSerializationTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/UsePolymorphicSerializationTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.SourceGenerators.Tests;
 
 
-[Category("Unit")]
 public class UsePolymorphicSerializationTests
 {
     [Test]

--- a/src/Refitter.SourceGenerator.Tests/UsePolymorphicSerializationTests.cs
+++ b/src/Refitter.SourceGenerator.Tests/UsePolymorphicSerializationTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.SourceGenerators.Tests;
 
+
+[Category("Unit")]
 public class UsePolymorphicSerializationTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/ApizrGeneratorWithMicrosoftHttpResilienceTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrGeneratorWithMicrosoftHttpResilienceTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class ApizrGeneratorWithMicrosoftHttpResilienceTests
 {
     private readonly RefitGeneratorSettings extendedSettings = new()

--- a/src/Refitter.Tests/Apizr/ApizrGeneratorWithMicrosoftHttpResilienceTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrGeneratorWithMicrosoftHttpResilienceTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class ApizrGeneratorWithMicrosoftHttpResilienceTests
 {
     private readonly RefitGeneratorSettings extendedSettings = new()

--- a/src/Refitter.Tests/Apizr/ApizrGeneratorWithPollyTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrGeneratorWithPollyTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class ApizrGeneratorWithPollyTests
 {
     private readonly RefitGeneratorSettings extendedSettings = new()

--- a/src/Refitter.Tests/Apizr/ApizrGeneratorWithPollyTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrGeneratorWithPollyTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class ApizrGeneratorWithPollyTests
 {
     private readonly RefitGeneratorSettings extendedSettings = new()

--- a/src/Refitter.Tests/Apizr/ApizrOptionsAdapterPipelineTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrOptionsAdapterPipelineTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class ApizrOptionsAdapterPipelineTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/ApizrOptionsAdapterPipelineTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrOptionsAdapterPipelineTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class ApizrOptionsAdapterPipelineTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/ApizrRegistrationGeneratorBranchTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrRegistrationGeneratorBranchTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class ApizrRegistrationGeneratorBranchTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/ApizrRegistrationGeneratorBranchTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrRegistrationGeneratorBranchTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class ApizrRegistrationGeneratorBranchTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/ApizrRegistrationGeneratorTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrRegistrationGeneratorTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class ApizrRegistrationGeneratorTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/ApizrRegistrationGeneratorTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrRegistrationGeneratorTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class ApizrRegistrationGeneratorTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/ApizrTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrTests.cs
@@ -6,7 +6,6 @@ using Refitter.Tests.TestUtilities;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class ApizrTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Apizr/ApizrTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrTests.cs
@@ -5,6 +5,8 @@ using Refitter.Tests.TestUtilities;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class ApizrTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Apizr/ApizrWithCancellationTokensTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrWithCancellationTokensTests.cs
@@ -5,6 +5,8 @@ using Refitter.Tests.TestUtilities;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class ApizrWithCancellationTokensTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Apizr/ApizrWithCancellationTokensTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrWithCancellationTokensTests.cs
@@ -6,7 +6,6 @@ using Refitter.Tests.TestUtilities;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class ApizrWithCancellationTokensTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Apizr/CacheProviderAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/CacheProviderAdapterTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class CacheProviderAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/CacheProviderAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/CacheProviderAdapterTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class CacheProviderAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/FileTransferAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/FileTransferAdapterTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class FileTransferAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/FileTransferAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/FileTransferAdapterTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class FileTransferAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/HttpMessageHandlerAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/HttpMessageHandlerAdapterTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class HttpMessageHandlerAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/HttpMessageHandlerAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/HttpMessageHandlerAdapterTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class HttpMessageHandlerAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/MappingProviderAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/MappingProviderAdapterTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class MappingProviderAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/MappingProviderAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/MappingProviderAdapterTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class MappingProviderAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/MediationAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/MediationAdapterTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class MediationAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/MediationAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/MediationAdapterTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class MediationAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/PriorityAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/PriorityAdapterTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class PriorityAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/PriorityAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/PriorityAdapterTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class PriorityAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/RetryHandlerAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/RetryHandlerAdapterTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class RetryHandlerAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/RetryHandlerAdapterTests.cs
+++ b/src/Refitter.Tests/Apizr/RetryHandlerAdapterTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class RetryHandlerAdapterTests
 {
     [Test]

--- a/src/Refitter.Tests/Apizr/SwaggerPetstoreApizrTests.cs
+++ b/src/Refitter.Tests/Apizr/SwaggerPetstoreApizrTests.cs
@@ -6,7 +6,6 @@ using Refitter.Tests.Resources;
 namespace Refitter.Tests.Apizr;
 
 
-[Category("Unit")]
 public class SwaggerPetstoreApizrTests
 {
     private class ApizrGeneratorSettings : RefitGeneratorSettings

--- a/src/Refitter.Tests/Apizr/SwaggerPetstoreApizrTests.cs
+++ b/src/Refitter.Tests/Apizr/SwaggerPetstoreApizrTests.cs
@@ -5,6 +5,8 @@ using Refitter.Tests.Resources;
 
 namespace Refitter.Tests.Apizr;
 
+
+[Category("Unit")]
 public class SwaggerPetstoreApizrTests
 {
     private class ApizrGeneratorSettings : RefitGeneratorSettings

--- a/src/Refitter.Tests/CSharpClientGeneratorFactoryIntegrationTests.cs
+++ b/src/Refitter.Tests/CSharpClientGeneratorFactoryIntegrationTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class CSharpClientGeneratorFactoryIntegrationTests
 {
     [Test]

--- a/src/Refitter.Tests/CSharpClientGeneratorFactoryIntegrationTests.cs
+++ b/src/Refitter.Tests/CSharpClientGeneratorFactoryIntegrationTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class CSharpClientGeneratorFactoryIntegrationTests
 {
     [Test]

--- a/src/Refitter.Tests/CSharpClientGeneratorFactoryTests.cs
+++ b/src/Refitter.Tests/CSharpClientGeneratorFactoryTests.cs
@@ -351,6 +351,7 @@ public class CSharpClientGeneratorFactoryTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForIntegerWithoutFormat()
     {
@@ -358,6 +359,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("long IntegerNoFormat");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForNestedInteger()
     {
@@ -365,6 +367,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("long NestedInt");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForArrayItems()
     {
@@ -372,6 +375,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("ICollection<long> ArrayOfIntegers");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForAdditionalProperties()
     {
@@ -379,6 +383,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("IDictionary<string, long>");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForAllOfSchemas()
     {
@@ -386,6 +391,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("long AllOfProp");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForOneOfSchemas()
     {
@@ -393,6 +399,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("long OneOfProp");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForAnyOfSchemas()
     {
@@ -402,6 +409,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("AnyOfInt");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForParameterWithoutFormat()
     {
@@ -410,6 +418,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("intParam");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_CanBuildGeneratedCode()
     {
@@ -420,6 +429,7 @@ public class CSharpClientGeneratorFactoryTests
             .BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task ProcessSchemaWalkers_WithRecursivePropertyItemAndAdditionalPropertiesSchemas_CanBuildGeneratedCode()
     {
@@ -432,6 +442,7 @@ public class CSharpClientGeneratorFactoryTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task ProcessSchemaWalkers_WithRecursiveAllOfSchemas_CanBuildGeneratedCode()
     {
@@ -442,6 +453,7 @@ public class CSharpClientGeneratorFactoryTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task ProcessSchemaWalkers_WithRecursivePropertyItemAndAdditionalPropertiesSchemas_V2_CanBuildGeneratedCode()
     {
@@ -454,6 +466,7 @@ public class CSharpClientGeneratorFactoryTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task ProcessSchemaWalkers_WithRecursiveAllOfSchemas_V2_CanBuildGeneratedCode()
     {
@@ -552,6 +565,7 @@ public class CSharpClientGeneratorFactoryTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Create_WithGenerateDefaultAdditionalPropertiesFalse_DoesNotGenerateAdditionalProperties()
     {
@@ -562,6 +576,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().NotContain("Dictionary<string, object> AdditionalProperties");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Create_WithGenerateDefaultAdditionalPropertiesTrue_GeneratesAdditionalProperties()
     {
@@ -570,6 +585,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("IDictionary<string, object>");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Create_WithGenerateDefaultAdditionalPropertiesFalse_AppliesToAllSchemas()
     {
@@ -584,6 +600,7 @@ public class CSharpClientGeneratorFactoryTests
         additionalPropsLines.Should().BeEmpty();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Create_WithGenerateDefaultAdditionalPropertiesFalse_CanBuildGeneratedCode()
     {
@@ -594,6 +611,7 @@ public class CSharpClientGeneratorFactoryTests
             .BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Create_WithGenerateDefaultAdditionalPropertiesTrue_CanBuildGeneratedCode()
     {
@@ -781,6 +799,7 @@ public class CSharpClientGeneratorFactoryTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_GeneratesBaseClass()
     {
@@ -788,6 +807,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("class Vehicle");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_DoesNotGenerateAnonymousTypes()
     {
@@ -796,6 +816,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().NotContain("Anonymous");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_GeneratesInheritanceHierarchy()
     {
@@ -804,6 +825,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("Truck : Vehicle");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_GeneratesAllSubtypes()
     {
@@ -812,6 +834,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("class Truck");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_CanBuildGeneratedCode()
     {
@@ -822,6 +845,7 @@ public class CSharpClientGeneratorFactoryTests
             .BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertAnyOfWithDiscriminatorToAllOf_GeneratesBaseClass()
     {
@@ -829,6 +853,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("class Payment");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertAnyOfWithDiscriminatorToAllOf_DoesNotGenerateAnonymousTypes()
     {
@@ -837,6 +862,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().NotContain("Anonymous");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertAnyOfWithDiscriminatorToAllOf_GeneratesInheritanceHierarchy()
     {
@@ -845,6 +871,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("BankTransfer : Payment");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertAnyOfWithDiscriminatorToAllOf_GeneratesAllSubtypes()
     {
@@ -853,6 +880,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("class BankTransfer");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertAnyOfWithDiscriminatorToAllOf_CanBuildGeneratedCode()
     {
@@ -863,6 +891,7 @@ public class CSharpClientGeneratorFactoryTests
             .BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_WithPolymorphicSerialization_GeneratesJsonAttributes()
     {
@@ -872,6 +901,7 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("[JsonDerivedType(typeof(Truck)");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_WithPolymorphicSerialization_CanBuildGeneratedCode()
     {

--- a/src/Refitter.Tests/CSharpClientGeneratorFactoryTests.cs
+++ b/src/Refitter.Tests/CSharpClientGeneratorFactoryTests.cs
@@ -351,7 +351,6 @@ public class CSharpClientGeneratorFactoryTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForIntegerWithoutFormat()
     {
@@ -359,7 +358,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("long IntegerNoFormat");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForNestedInteger()
     {
@@ -367,7 +365,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("long NestedInt");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForArrayItems()
     {
@@ -375,7 +372,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("ICollection<long> ArrayOfIntegers");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForAdditionalProperties()
     {
@@ -383,7 +379,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("IDictionary<string, long>");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForAllOfSchemas()
     {
@@ -391,7 +386,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("long AllOfProp");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForOneOfSchemas()
     {
@@ -399,7 +393,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("long OneOfProp");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForAnyOfSchemas()
     {
@@ -409,7 +402,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("AnyOfInt");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_GeneratesLongForParameterWithoutFormat()
     {
@@ -418,7 +410,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("intParam");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ProcessSchemaForIntegerType_WithInt64Setting_CanBuildGeneratedCode()
     {
@@ -565,7 +556,6 @@ public class CSharpClientGeneratorFactoryTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Create_WithGenerateDefaultAdditionalPropertiesFalse_DoesNotGenerateAdditionalProperties()
     {
@@ -576,7 +566,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().NotContain("Dictionary<string, object> AdditionalProperties");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Create_WithGenerateDefaultAdditionalPropertiesTrue_GeneratesAdditionalProperties()
     {
@@ -585,7 +574,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("IDictionary<string, object>");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Create_WithGenerateDefaultAdditionalPropertiesFalse_AppliesToAllSchemas()
     {
@@ -600,7 +588,6 @@ public class CSharpClientGeneratorFactoryTests
         additionalPropsLines.Should().BeEmpty();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Create_WithGenerateDefaultAdditionalPropertiesFalse_CanBuildGeneratedCode()
     {
@@ -611,7 +598,6 @@ public class CSharpClientGeneratorFactoryTests
             .BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Create_WithGenerateDefaultAdditionalPropertiesTrue_CanBuildGeneratedCode()
     {
@@ -799,7 +785,6 @@ public class CSharpClientGeneratorFactoryTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_GeneratesBaseClass()
     {
@@ -807,7 +792,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("class Vehicle");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_DoesNotGenerateAnonymousTypes()
     {
@@ -816,7 +800,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().NotContain("Anonymous");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_GeneratesInheritanceHierarchy()
     {
@@ -825,7 +808,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("Truck : Vehicle");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_GeneratesAllSubtypes()
     {
@@ -834,7 +816,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("class Truck");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_CanBuildGeneratedCode()
     {
@@ -845,7 +826,6 @@ public class CSharpClientGeneratorFactoryTests
             .BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertAnyOfWithDiscriminatorToAllOf_GeneratesBaseClass()
     {
@@ -853,7 +833,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("class Payment");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertAnyOfWithDiscriminatorToAllOf_DoesNotGenerateAnonymousTypes()
     {
@@ -862,7 +841,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().NotContain("Anonymous");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertAnyOfWithDiscriminatorToAllOf_GeneratesInheritanceHierarchy()
     {
@@ -871,7 +849,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("BankTransfer : Payment");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertAnyOfWithDiscriminatorToAllOf_GeneratesAllSubtypes()
     {
@@ -880,7 +857,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("class BankTransfer");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertAnyOfWithDiscriminatorToAllOf_CanBuildGeneratedCode()
     {
@@ -891,7 +867,6 @@ public class CSharpClientGeneratorFactoryTests
             .BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_WithPolymorphicSerialization_GeneratesJsonAttributes()
     {
@@ -901,7 +876,6 @@ public class CSharpClientGeneratorFactoryTests
         generatedCode.Should().Contain("[JsonDerivedType(typeof(Truck)");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertOneOfWithDiscriminatorToAllOf_WithPolymorphicSerialization_CanBuildGeneratedCode()
     {

--- a/src/Refitter.Tests/CliFileWriterTests.cs
+++ b/src/Refitter.Tests/CliFileWriterTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class CliFileWriterTests
 {
     [Test]

--- a/src/Refitter.Tests/CliFileWriterTests.cs
+++ b/src/Refitter.Tests/CliFileWriterTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class CliFileWriterTests
 {
     [Test]

--- a/src/Refitter.Tests/ContractTypeSuffixApplierTests.cs
+++ b/src/Refitter.Tests/ContractTypeSuffixApplierTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class ContractTypeSuffixApplierTests
 {
     [Test]

--- a/src/Refitter.Tests/ContractTypeSuffixApplierTests.cs
+++ b/src/Refitter.Tests/ContractTypeSuffixApplierTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class ContractTypeSuffixApplierTests
 {
     [Test]

--- a/src/Refitter.Tests/CustomCSharpGeneratorSettingsTests.cs
+++ b/src/Refitter.Tests/CustomCSharpGeneratorSettingsTests.cs
@@ -170,7 +170,6 @@ public class CustomCSharpGeneratorSettingsTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -187,7 +186,6 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain(settings.CodeGeneratorSettings!.DateType);
     }
 
-    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -204,7 +202,6 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain(settings.CodeGeneratorSettings!.DateTimeType);
     }
 
-    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -221,7 +218,6 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain("ICollection<");
     }
 
-    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -239,7 +235,6 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain("DateTime");
     }
 
-    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -257,7 +252,6 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain("DateTime");
     }
 
-    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -275,7 +269,6 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain("System.Collection.Generic.IList<");
     }
 
-    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -360,7 +353,6 @@ public class CustomCSharpGeneratorSettingsTests
         BuildHelper.BuildCSharp(generatedCode, RecursiveExternalNodeStub).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -377,7 +369,6 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain("[JsonConstructor]");
     }
 
-    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]

--- a/src/Refitter.Tests/CustomCSharpGeneratorSettingsTests.cs
+++ b/src/Refitter.Tests/CustomCSharpGeneratorSettingsTests.cs
@@ -170,6 +170,7 @@ public class CustomCSharpGeneratorSettingsTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -186,6 +187,7 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain(settings.CodeGeneratorSettings!.DateType);
     }
 
+    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -202,6 +204,7 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain(settings.CodeGeneratorSettings!.DateTimeType);
     }
 
+    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -218,6 +221,7 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain("ICollection<");
     }
 
+    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -235,6 +239,7 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain("DateTime");
     }
 
+    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -252,6 +257,7 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain("DateTime");
     }
 
+    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -269,6 +275,7 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain("System.Collection.Generic.IList<");
     }
 
+    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -289,6 +296,7 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().NotContain("class User");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Generate_With_ExcludedTypeNames_On_Recursive_Schema_And_PreserveOriginal_Property_Names()
     {
@@ -320,6 +328,7 @@ public class CustomCSharpGeneratorSettingsTests
         BuildHelper.BuildCSharp(generatedCode, RecursiveExternalNodeStub).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Generate_With_ExcludedTypeNames_On_Recursive_Schema_And_PreserveOriginal_Property_Names_V2()
     {
@@ -351,6 +360,7 @@ public class CustomCSharpGeneratorSettingsTests
         BuildHelper.BuildCSharp(generatedCode, RecursiveExternalNodeStub).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]
@@ -367,6 +377,7 @@ public class CustomCSharpGeneratorSettingsTests
         generatedCode.Should().Contain("[JsonConstructor]");
     }
 
+    [Category("Unit")]
     [Test]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreJsonV3, "SwaggerPetstore.json")]
     [Arguments(SampleOpenSpecifications.SwaggerPetstoreYamlV3, "SwaggerPetstore.yaml")]

--- a/src/Refitter.Tests/CustomCSharpTypeResolverTests.cs
+++ b/src/Refitter.Tests/CustomCSharpTypeResolverTests.cs
@@ -6,7 +6,6 @@ using Refitter.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class CustomCSharpTypeResolverTests
 {
     [Test]

--- a/src/Refitter.Tests/CustomCSharpTypeResolverTests.cs
+++ b/src/Refitter.Tests/CustomCSharpTypeResolverTests.cs
@@ -5,6 +5,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class CustomCSharpTypeResolverTests
 {
     [Test]

--- a/src/Refitter.Tests/CustomIntegerTypeMutatorTests.cs
+++ b/src/Refitter.Tests/CustomIntegerTypeMutatorTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class CustomIntegerTypeMutatorTests
 {
     [Test]

--- a/src/Refitter.Tests/CustomIntegerTypeMutatorTests.cs
+++ b/src/Refitter.Tests/CustomIntegerTypeMutatorTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class CustomIntegerTypeMutatorTests
 {
     [Test]

--- a/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorBranchTests.cs
+++ b/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorBranchTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.DependencyInjection;
 
+
+[Category("Unit")]
 public class DependencyInjectionGeneratorBranchTests
 {
     [Test]

--- a/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorBranchTests.cs
+++ b/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorBranchTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.DependencyInjection;
 
 
-[Category("Unit")]
 public class DependencyInjectionGeneratorBranchTests
 {
     [Test]

--- a/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorWithMicrosoftHttpResilienceTests.cs
+++ b/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorWithMicrosoftHttpResilienceTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.DependencyInjection;
 
 
-[Category("Unit")]
 public class DependencyInjectionGeneratorWithMicrosoftHttpResilienceTests
 {
     private readonly RefitGeneratorSettings settings = new()

--- a/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorWithMicrosoftHttpResilienceTests.cs
+++ b/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorWithMicrosoftHttpResilienceTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.DependencyInjection;
 
+
+[Category("Unit")]
 public class DependencyInjectionGeneratorWithMicrosoftHttpResilienceTests
 {
     private readonly RefitGeneratorSettings settings = new()

--- a/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorWithPollyTests.cs
+++ b/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorWithPollyTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.DependencyInjection;
 
+
+[Category("Unit")]
 public class DependencyInjectionGeneratorWithPollyTests
 {
     private readonly RefitGeneratorSettings settings = new()

--- a/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorWithPollyTests.cs
+++ b/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorWithPollyTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.DependencyInjection;
 
 
-[Category("Unit")]
 public class DependencyInjectionGeneratorWithPollyTests
 {
     private readonly RefitGeneratorSettings settings = new()

--- a/src/Refitter.Tests/DisableAdditionalPropertiesMutatorTests.cs
+++ b/src/Refitter.Tests/DisableAdditionalPropertiesMutatorTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class DisableAdditionalPropertiesMutatorTests
 {
     [Test]

--- a/src/Refitter.Tests/DisableAdditionalPropertiesMutatorTests.cs
+++ b/src/Refitter.Tests/DisableAdditionalPropertiesMutatorTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class DisableAdditionalPropertiesMutatorTests
 {
     [Test]

--- a/src/Refitter.Tests/FixMissingIntegerTypesMutatorTests.cs
+++ b/src/Refitter.Tests/FixMissingIntegerTypesMutatorTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class FixMissingIntegerTypesMutatorTests
 {
     [Test]

--- a/src/Refitter.Tests/FixMissingIntegerTypesMutatorTests.cs
+++ b/src/Refitter.Tests/FixMissingIntegerTypesMutatorTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class FixMissingIntegerTypesMutatorTests
 {
     [Test]

--- a/src/Refitter.Tests/GenerateCommandTests.cs
+++ b/src/Refitter.Tests/GenerateCommandTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class GenerateCommandTests
 {
     [Test]

--- a/src/Refitter.Tests/GenerateCommandTests.cs
+++ b/src/Refitter.Tests/GenerateCommandTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class GenerateCommandTests
 {
     [Test]

--- a/src/Refitter.Tests/GenerationOrchestratorTests.cs
+++ b/src/Refitter.Tests/GenerationOrchestratorTests.cs
@@ -5,6 +5,8 @@ using Refitter.Core.Validation;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class GenerationOrchestratorTests
 {
     [Test]

--- a/src/Refitter.Tests/GenerationOrchestratorTests.cs
+++ b/src/Refitter.Tests/GenerationOrchestratorTests.cs
@@ -6,7 +6,6 @@ using Refitter.Core.Validation;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class GenerationOrchestratorTests
 {
     [Test]

--- a/src/Refitter.Tests/GeneratorPipelineTests.cs
+++ b/src/Refitter.Tests/GeneratorPipelineTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class GeneratorPipelineTests
 {
     private const string OpenApiSpec = """

--- a/src/Refitter.Tests/GeneratorPipelineTests.cs
+++ b/src/Refitter.Tests/GeneratorPipelineTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class GeneratorPipelineTests
 {
     private const string OpenApiSpec = """

--- a/src/Refitter.Tests/IdentifierUtilsTests.cs
+++ b/src/Refitter.Tests/IdentifierUtilsTests.cs
@@ -4,6 +4,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class IdentifierUtilsTests
 {
     [Test]

--- a/src/Refitter.Tests/IdentifierUtilsTests.cs
+++ b/src/Refitter.Tests/IdentifierUtilsTests.cs
@@ -5,7 +5,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class IdentifierUtilsTests
 {
     [Test]

--- a/src/Refitter.Tests/IllegalSymbolsTests.cs
+++ b/src/Refitter.Tests/IllegalSymbolsTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class IllegalSymbolsTests
 {
     [Test]

--- a/src/Refitter.Tests/IllegalSymbolsTests.cs
+++ b/src/Refitter.Tests/IllegalSymbolsTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class IllegalSymbolsTests
 {
     [Test]

--- a/src/Refitter.Tests/JsonSerializerContextGeneratorTests.cs
+++ b/src/Refitter.Tests/JsonSerializerContextGeneratorTests.cs
@@ -6,6 +6,7 @@ namespace Refitter.Tests;
 
 public class JsonSerializerContextGeneratorTests
 {
+    [Category("Unit")]
     [Test]
     public void Generate_Returns_Empty_When_Contracts_Are_Whitespace()
     {
@@ -14,6 +15,7 @@ public class JsonSerializerContextGeneratorTests
             .BeEmpty();
     }
 
+    [Category("Unit")]
     [Test]
     public void Generate_Returns_Empty_When_No_Types()
     {
@@ -24,6 +26,7 @@ public class JsonSerializerContextGeneratorTests
             .BeEmpty();
     }
 
+    [Category("Unit")]
     [Test]
     public void Generate_Uses_OpenApi_Title_For_Context_Name_When_Enabled()
     {
@@ -45,6 +48,7 @@ public class JsonSerializerContextGeneratorTests
         result.Should().NotContain("IgnoredApiSerializerContext");
     }
 
+    [Category("Unit")]
     [Test]
     public void Generate_Sanitizes_Angle_Brackets_In_OpenApi_Title_For_Context_Name()
     {
@@ -66,6 +70,7 @@ public class JsonSerializerContextGeneratorTests
         result.Should().NotContain("Pet<Service>SerializerContext");
     }
 
+    [Category("Unit")]
     [Test]
     public void Generate_Uses_Contracts_Namespace_And_Strips_Interface_Prefix()
     {
@@ -86,6 +91,7 @@ public class JsonSerializerContextGeneratorTests
         result.Should().NotContain("IMyApiSerializerContext");
     }
 
+    [Category("Unit")]
     [Test]
     public void Generate_Falls_Back_To_Default_Context_Name_When_Interface_Name_Is_Missing()
     {
@@ -104,6 +110,7 @@ public class JsonSerializerContextGeneratorTests
         result.Should().Contain("internal partial class ApiClientSerializerContext : global::System.Text.Json.Serialization.JsonSerializerContext");
     }
 
+    [Category("Unit")]
     [Test]
     public void Generate_Registers_Types_Once()
     {
@@ -136,6 +143,7 @@ public class JsonSerializerContextGeneratorTests
         result.Split("[global::System.Text.Json.Serialization.JsonSerializable(typeof(Pet))]").Length.Should().Be(2);
     }
 
+    [Category("Integration")]
     [Test]
     public void Generate_Registers_Nested_Types_With_Qualified_Name()
     {
@@ -158,6 +166,7 @@ public class JsonSerializerContextGeneratorTests
         BuildHelper.BuildCSharp(new[] { contracts, result }).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public void Generate_Registers_Closed_Generic_Usages_And_Skips_Open_Generic_Declarations()
     {
@@ -187,6 +196,7 @@ public class JsonSerializerContextGeneratorTests
         BuildHelper.BuildCSharp(new[] { contracts, result }).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public void Generate_Skips_Generic_Usages_That_Still_Reference_Open_Type_Parameters()
     {
@@ -222,6 +232,7 @@ public class JsonSerializerContextGeneratorTests
         BuildHelper.BuildCSharp(new[] { contracts, result }).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public void Generate_Global_Qualifies_Types_Outside_The_Context_Namespace()
     {
@@ -248,6 +259,7 @@ public class JsonSerializerContextGeneratorTests
         BuildHelper.BuildCSharp(new[] { contracts, result }).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public void Generate_Formats_Nullable_Array_And_Qualified_Generic_Usages()
     {
@@ -281,6 +293,7 @@ public class JsonSerializerContextGeneratorTests
         BuildHelper.BuildCSharp(new[] { contracts, result }).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public void Generate_Formats_Alias_Qualified_Generic_Usages()
     {
@@ -314,6 +327,7 @@ public class JsonSerializerContextGeneratorTests
         BuildHelper.BuildCSharp(new[] { contracts, result }).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public void Generate_Formats_Alias_Qualified_Declared_Types_Using_Namespace_Alias()
     {
@@ -347,6 +361,7 @@ public class JsonSerializerContextGeneratorTests
         BuildHelper.BuildCSharp(new[] { contracts, result }).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public void Generate_Formats_NonDeclared_Generic_Type_Arguments()
     {
@@ -377,6 +392,7 @@ public class JsonSerializerContextGeneratorTests
         BuildHelper.BuildCSharp(new[] { contracts, result }).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public void Generate_Handles_Declared_Types_In_Global_Namespace()
     {

--- a/src/Refitter.Tests/JsonSerializerContextGeneratorTests.cs
+++ b/src/Refitter.Tests/JsonSerializerContextGeneratorTests.cs
@@ -6,7 +6,6 @@ namespace Refitter.Tests;
 
 public class JsonSerializerContextGeneratorTests
 {
-    [Category("Unit")]
     [Test]
     public void Generate_Returns_Empty_When_Contracts_Are_Whitespace()
     {
@@ -15,7 +14,6 @@ public class JsonSerializerContextGeneratorTests
             .BeEmpty();
     }
 
-    [Category("Unit")]
     [Test]
     public void Generate_Returns_Empty_When_No_Types()
     {
@@ -26,7 +24,6 @@ public class JsonSerializerContextGeneratorTests
             .BeEmpty();
     }
 
-    [Category("Unit")]
     [Test]
     public void Generate_Uses_OpenApi_Title_For_Context_Name_When_Enabled()
     {
@@ -48,7 +45,6 @@ public class JsonSerializerContextGeneratorTests
         result.Should().NotContain("IgnoredApiSerializerContext");
     }
 
-    [Category("Unit")]
     [Test]
     public void Generate_Sanitizes_Angle_Brackets_In_OpenApi_Title_For_Context_Name()
     {
@@ -70,7 +66,6 @@ public class JsonSerializerContextGeneratorTests
         result.Should().NotContain("Pet<Service>SerializerContext");
     }
 
-    [Category("Unit")]
     [Test]
     public void Generate_Uses_Contracts_Namespace_And_Strips_Interface_Prefix()
     {
@@ -91,7 +86,6 @@ public class JsonSerializerContextGeneratorTests
         result.Should().NotContain("IMyApiSerializerContext");
     }
 
-    [Category("Unit")]
     [Test]
     public void Generate_Falls_Back_To_Default_Context_Name_When_Interface_Name_Is_Missing()
     {
@@ -110,7 +104,6 @@ public class JsonSerializerContextGeneratorTests
         result.Should().Contain("internal partial class ApiClientSerializerContext : global::System.Text.Json.Serialization.JsonSerializerContext");
     }
 
-    [Category("Unit")]
     [Test]
     public void Generate_Registers_Types_Once()
     {

--- a/src/Refitter.Tests/MSBuild/RefitterGenerateTaskTests.cs
+++ b/src/Refitter.Tests/MSBuild/RefitterGenerateTaskTests.cs
@@ -6,7 +6,6 @@ using Refitter.MSBuild;
 namespace Refitter.Tests.MSBuild;
 
 
-[Category("Unit")]
 public class RefitterGenerateTaskTests
 {
     [Test]

--- a/src/Refitter.Tests/MSBuild/RefitterGenerateTaskTests.cs
+++ b/src/Refitter.Tests/MSBuild/RefitterGenerateTaskTests.cs
@@ -5,6 +5,8 @@ using Refitter.MSBuild;
 
 namespace Refitter.Tests.MSBuild;
 
+
+[Category("Unit")]
 public class RefitterGenerateTaskTests
 {
     [Test]

--- a/src/Refitter.Tests/MethodAttributeGeneratorTests.cs
+++ b/src/Refitter.Tests/MethodAttributeGeneratorTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class MethodAttributeGeneratorTests
 {
     [Test]

--- a/src/Refitter.Tests/MethodAttributeGeneratorTests.cs
+++ b/src/Refitter.Tests/MethodAttributeGeneratorTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class MethodAttributeGeneratorTests
 {
     [Test]

--- a/src/Refitter.Tests/MethodSignatureGeneratorTests.cs
+++ b/src/Refitter.Tests/MethodSignatureGeneratorTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class MethodSignatureGeneratorTests
 {
     [Test]

--- a/src/Refitter.Tests/MethodSignatureGeneratorTests.cs
+++ b/src/Refitter.Tests/MethodSignatureGeneratorTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class MethodSignatureGeneratorTests
 {
     [Test]

--- a/src/Refitter.Tests/MsBuildFileWriterTests.cs
+++ b/src/Refitter.Tests/MsBuildFileWriterTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class MsBuildFileWriterTests
 {
     [Test]

--- a/src/Refitter.Tests/MsBuildFileWriterTests.cs
+++ b/src/Refitter.Tests/MsBuildFileWriterTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class MsBuildFileWriterTests
 {
     [Test]

--- a/src/Refitter.Tests/OneOfDiscriminatorToAllOfMutatorTests.cs
+++ b/src/Refitter.Tests/OneOfDiscriminatorToAllOfMutatorTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class OneOfDiscriminatorToAllOfMutatorTests
 {
     [Test]

--- a/src/Refitter.Tests/OneOfDiscriminatorToAllOfMutatorTests.cs
+++ b/src/Refitter.Tests/OneOfDiscriminatorToAllOfMutatorTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class OneOfDiscriminatorToAllOfMutatorTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/DocumentLoaderCompositorTests.cs
+++ b/src/Refitter.Tests/OpenApi/DocumentLoaderCompositorTests.cs
@@ -4,6 +4,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.OpenApi;
 
+
+[Category("Unit")]
 public class DocumentLoaderCompositorTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/DocumentLoaderCompositorTests.cs
+++ b/src/Refitter.Tests/OpenApi/DocumentLoaderCompositorTests.cs
@@ -5,7 +5,6 @@ using Refitter.Core;
 namespace Refitter.Tests.OpenApi;
 
 
-[Category("Unit")]
 public class DocumentLoaderCompositorTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/FileDocumentStrategyTests.cs
+++ b/src/Refitter.Tests/OpenApi/FileDocumentStrategyTests.cs
@@ -4,6 +4,8 @@ using Refitter.Tests.Resources;
 
 namespace Refitter.Tests.OpenApi;
 
+
+[Category("Unit")]
 public class FileDocumentStrategyTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/FileDocumentStrategyTests.cs
+++ b/src/Refitter.Tests/OpenApi/FileDocumentStrategyTests.cs
@@ -5,7 +5,6 @@ using Refitter.Tests.Resources;
 namespace Refitter.Tests.OpenApi;
 
 
-[Category("Unit")]
 public class FileDocumentStrategyTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/HttpDocumentStrategyTests.cs
+++ b/src/Refitter.Tests/OpenApi/HttpDocumentStrategyTests.cs
@@ -4,6 +4,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.OpenApi;
 
+
+[Category("Unit")]
 public class HttpDocumentStrategyTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/HttpDocumentStrategyTests.cs
+++ b/src/Refitter.Tests/OpenApi/HttpDocumentStrategyTests.cs
@@ -5,7 +5,6 @@ using Refitter.Core;
 namespace Refitter.Tests.OpenApi;
 
 
-[Category("Unit")]
 public class HttpDocumentStrategyTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/OpenApiDocumentFactoryMergeTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiDocumentFactoryMergeTests.cs
@@ -7,6 +7,8 @@ using Refitter.Tests.Resources;
 
 namespace Refitter.Tests.OpenApi;
 
+
+[Category("Unit")]
 public class OpenApiDocumentFactoryMergeTests
 {
     private static readonly DocumentEquivalenceComparer Comparer = new();

--- a/src/Refitter.Tests/OpenApi/OpenApiDocumentFactoryMergeTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiDocumentFactoryMergeTests.cs
@@ -8,7 +8,6 @@ using Refitter.Tests.Resources;
 namespace Refitter.Tests.OpenApi;
 
 
-[Category("Unit")]
 public class OpenApiDocumentFactoryMergeTests
 {
     private static readonly DocumentEquivalenceComparer Comparer = new();

--- a/src/Refitter.Tests/OpenApi/OpenApiDocumentFactoryTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiDocumentFactoryTests.cs
@@ -4,6 +4,8 @@ using Refitter.Tests.Resources;
 
 namespace Refitter.Tests.OpenApi;
 
+
+[Category("Unit")]
 public class OpenApiDocumentFactoryTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/OpenApiDocumentFactoryTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiDocumentFactoryTests.cs
@@ -5,7 +5,6 @@ using Refitter.Tests.Resources;
 namespace Refitter.Tests.OpenApi;
 
 
-[Category("Unit")]
 public class OpenApiDocumentFactoryTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/OpenApiReaderDocumentStrategyTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiReaderDocumentStrategyTests.cs
@@ -5,7 +5,6 @@ using Refitter.Core;
 namespace Refitter.Tests.OpenApi;
 
 
-[Category("Unit")]
 public class OpenApiReaderDocumentStrategyTests
 {
 

--- a/src/Refitter.Tests/OpenApi/OpenApiReaderDocumentStrategyTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiReaderDocumentStrategyTests.cs
@@ -4,6 +4,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.OpenApi;
 
+
+[Category("Unit")]
 public class OpenApiReaderDocumentStrategyTests
 {
 

--- a/src/Refitter.Tests/OpenApi/OpenApiStatsTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiStatsTests.cs
@@ -4,6 +4,8 @@ using Refitter.Core.Validation;
 
 namespace Refitter.Tests.OpenApi;
 
+
+[Category("Unit")]
 public class OpenApiStatsTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/OpenApiStatsTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiStatsTests.cs
@@ -5,7 +5,6 @@ using Refitter.Core.Validation;
 namespace Refitter.Tests.OpenApi;
 
 
-[Category("Unit")]
 public class OpenApiStatsTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/OpenApiValidationExceptionTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiValidationExceptionTests.cs
@@ -5,7 +5,6 @@ using Refitter.Core.Validation;
 namespace Refitter.Tests.OpenApi;
 
 
-[Category("Unit")]
 public class OpenApiValidationExceptionTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/OpenApiValidationExceptionTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiValidationExceptionTests.cs
@@ -4,6 +4,8 @@ using Refitter.Core.Validation;
 
 namespace Refitter.Tests.OpenApi;
 
+
+[Category("Unit")]
 public class OpenApiValidationExceptionTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/OpenApiValidationResultTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiValidationResultTests.cs
@@ -4,6 +4,8 @@ using Refitter.Core.Validation;
 
 namespace Refitter.Tests.OpenApi;
 
+
+[Category("Unit")]
 public class OpenApiValidationResultTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/OpenApiValidationResultTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiValidationResultTests.cs
@@ -5,7 +5,6 @@ using Refitter.Core.Validation;
 namespace Refitter.Tests.OpenApi;
 
 
-[Category("Unit")]
 public class OpenApiValidationResultTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/OpenApiValidatorTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiValidatorTests.cs
@@ -4,6 +4,8 @@ using Refitter.Core.Validation;
 
 namespace Refitter.Tests.OpenApi;
 
+
+[Category("Unit")]
 public class OpenApiValidatorTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/OpenApiValidatorTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiValidatorTests.cs
@@ -5,7 +5,6 @@ using Refitter.Core.Validation;
 namespace Refitter.Tests.OpenApi;
 
 
-[Category("Unit")]
 public class OpenApiValidatorTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/PathUtilitiesTests.cs
+++ b/src/Refitter.Tests/OpenApi/PathUtilitiesTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.OpenApi;
 
 
-[Category("Unit")]
 public class PathUtilitiesTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApi/PathUtilitiesTests.cs
+++ b/src/Refitter.Tests/OpenApi/PathUtilitiesTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.OpenApi;
 
+
+[Category("Unit")]
 public class PathUtilitiesTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApiStatisticsFormatterTests.cs
+++ b/src/Refitter.Tests/OpenApiStatisticsFormatterTests.cs
@@ -4,7 +4,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class OpenApiStatisticsFormatterTests
 {
     [Test]

--- a/src/Refitter.Tests/OpenApiStatisticsFormatterTests.cs
+++ b/src/Refitter.Tests/OpenApiStatisticsFormatterTests.cs
@@ -3,6 +3,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class OpenApiStatisticsFormatterTests
 {
     [Test]

--- a/src/Refitter.Tests/OutputPlannerAdapterTests.cs
+++ b/src/Refitter.Tests/OutputPlannerAdapterTests.cs
@@ -4,6 +4,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class OutputPlannerAdapterTests
 {
     private static readonly IOutputPlanner planner = new OutputPlannerAdapter();

--- a/src/Refitter.Tests/OutputPlannerAdapterTests.cs
+++ b/src/Refitter.Tests/OutputPlannerAdapterTests.cs
@@ -5,7 +5,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class OutputPlannerAdapterTests
 {
     private static readonly IOutputPlanner planner = new OutputPlannerAdapter();

--- a/src/Refitter.Tests/OutputPlannerTests.cs
+++ b/src/Refitter.Tests/OutputPlannerTests.cs
@@ -4,6 +4,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class OutputPlannerTests
 {
     private static readonly string ContractsFileName = $"{TypenameConstants.Contracts}.cs";

--- a/src/Refitter.Tests/OutputPlannerTests.cs
+++ b/src/Refitter.Tests/OutputPlannerTests.cs
@@ -5,7 +5,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class OutputPlannerTests
 {
     private static readonly string ContractsFileName = $"{TypenameConstants.Contracts}.cs";

--- a/src/Refitter.Tests/Parameters/ParameterExtractorDeepCoverageTests.cs
+++ b/src/Refitter.Tests/Parameters/ParameterExtractorDeepCoverageTests.cs
@@ -133,6 +133,7 @@ public class ParameterExtractorDeepCoverageTests
 }
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task EscapeString_Handles_Tab_Character()
     {
@@ -141,6 +142,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain(@"= ""before\tafter""");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task EscapeString_Handles_Carriage_Return()
     {
@@ -149,6 +151,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain(@"= ""line1\rline2""");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task EscapeString_Handles_Form_Feed()
     {
@@ -157,6 +160,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain(@"= ""page1\fpage2""");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task EscapeString_Handles_Backspace()
     {
@@ -438,6 +442,7 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
+    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Float_Has_F_Suffix()
     {
@@ -446,6 +451,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("float? floatValue = 3.14f");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Decimal_Has_M_Suffix()
     {
@@ -454,6 +460,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("decimal? decimalValue = 99.99m");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Double_Has_Implicit_Suffix()
     {
@@ -462,6 +469,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().NotContain("2.718d");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Long_Has_L_Suffix()
     {
@@ -470,6 +478,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("long? longValue = 9223372036854775807L");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Ulong_Has_UL_Suffix()
     {
@@ -478,6 +487,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("ulong? ulongValue = 18446744073709551615UL");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Uint_Has_U_Suffix()
     {
@@ -487,6 +497,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("int? uintValue = 4294967295");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_All_Types_Together()
     {
@@ -500,6 +511,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("uintValue = 300");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task FormatNumericValue_Generated_Code_Builds()
     {
@@ -684,6 +696,7 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
+    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_String_Type()
     {
@@ -691,6 +704,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("string? stringParam");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Integer_Type()
     {
@@ -698,6 +712,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("int? intParam");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Number_Type()
     {
@@ -705,6 +720,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("double? numberParam");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Boolean_Type()
     {
@@ -712,6 +728,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("bool? boolParam");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Array_Type()
     {
@@ -721,6 +738,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("arrayParam");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Object_Type()
     {
@@ -729,6 +747,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("string objectParam");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Nullable_With_OptionalParameters()
     {
@@ -776,6 +795,7 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
+    [Category("Unit")]
     [Test]
     public async Task NullablePattern_Matches_Escaped_CSharp_Identifier()
     {
@@ -794,6 +814,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("@class = default");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Array_Of_Integers()
     {
@@ -803,6 +824,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("intArray");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Array_Of_Booleans()
     {
@@ -812,6 +834,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("boolArray");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task GetCSharpType_All_Types_Build()
     {
@@ -915,6 +938,7 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
+    [Category("Unit")]
     [Test]
     public async Task GetIntegerTypeName_Int32_Format_Returns_Int()
     {
@@ -922,6 +946,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("int? int32Value");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetIntegerTypeName_Int64_Format_Returns_Long()
     {
@@ -929,6 +954,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("long? int64Value");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetIntegerTypeName_No_Format_Defaults_To_Int()
     {
@@ -936,6 +962,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("int? integerValue");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetIntegerTypeName_With_Int64_Setting()
     {
@@ -955,6 +982,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("long? integerValue");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GetIntegerTypeName_Format_Overrides_Setting()
     {
@@ -974,6 +1002,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("int? int32Value");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task GetIntegerTypeName_Generated_Code_Builds()
     {
@@ -1015,6 +1044,7 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
+    [Category("Unit")]
     [Test]
     public async Task GetArrayType_Null_Item_Returns_Object_Array()
     {
@@ -1024,6 +1054,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("arrayWithoutItems");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task GetArrayType_Null_Item_Generated_Code_Builds()
     {
@@ -1099,6 +1130,7 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
+    [Category("Unit")]
     [Test]
     public async Task FormatDoubleLiteral_Integer_Value_Adds_Point_Zero()
     {
@@ -1107,6 +1139,7 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("double? doubleValue = 42.0");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task FormatDoubleLiteral_With_Exponent_No_Point_Zero()
     {

--- a/src/Refitter.Tests/Parameters/ParameterExtractorDeepCoverageTests.cs
+++ b/src/Refitter.Tests/Parameters/ParameterExtractorDeepCoverageTests.cs
@@ -133,7 +133,6 @@ public class ParameterExtractorDeepCoverageTests
 }
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task EscapeString_Handles_Tab_Character()
     {
@@ -142,7 +141,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain(@"= ""before\tafter""");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task EscapeString_Handles_Carriage_Return()
     {
@@ -151,7 +149,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain(@"= ""line1\rline2""");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task EscapeString_Handles_Form_Feed()
     {
@@ -160,7 +157,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain(@"= ""page1\fpage2""");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task EscapeString_Handles_Backspace()
     {
@@ -442,7 +438,6 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
-    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Float_Has_F_Suffix()
     {
@@ -451,7 +446,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("float? floatValue = 3.14f");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Decimal_Has_M_Suffix()
     {
@@ -460,7 +454,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("decimal? decimalValue = 99.99m");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Double_Has_Implicit_Suffix()
     {
@@ -469,7 +462,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().NotContain("2.718d");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Long_Has_L_Suffix()
     {
@@ -478,7 +470,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("long? longValue = 9223372036854775807L");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Ulong_Has_UL_Suffix()
     {
@@ -487,7 +478,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("ulong? ulongValue = 18446744073709551615UL");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_Uint_Has_U_Suffix()
     {
@@ -497,7 +487,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("int? uintValue = 4294967295");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task FormatNumericValue_All_Types_Together()
     {
@@ -696,7 +685,6 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
-    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_String_Type()
     {
@@ -704,7 +692,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("string? stringParam");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Integer_Type()
     {
@@ -712,7 +699,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("int? intParam");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Number_Type()
     {
@@ -720,7 +706,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("double? numberParam");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Boolean_Type()
     {
@@ -728,7 +713,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("bool? boolParam");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Array_Type()
     {
@@ -738,7 +722,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("arrayParam");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Object_Type()
     {
@@ -747,7 +730,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("string objectParam");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Nullable_With_OptionalParameters()
     {
@@ -795,7 +777,6 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
-    [Category("Unit")]
     [Test]
     public async Task NullablePattern_Matches_Escaped_CSharp_Identifier()
     {
@@ -814,7 +795,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("@class = default");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Array_Of_Integers()
     {
@@ -824,7 +804,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("intArray");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetCSharpType_Array_Of_Booleans()
     {
@@ -938,7 +917,6 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
-    [Category("Unit")]
     [Test]
     public async Task GetIntegerTypeName_Int32_Format_Returns_Int()
     {
@@ -946,7 +924,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("int? int32Value");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetIntegerTypeName_Int64_Format_Returns_Long()
     {
@@ -954,7 +931,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("long? int64Value");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetIntegerTypeName_No_Format_Defaults_To_Int()
     {
@@ -962,7 +938,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("int? integerValue");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetIntegerTypeName_With_Int64_Setting()
     {
@@ -982,7 +957,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("long? integerValue");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GetIntegerTypeName_Format_Overrides_Setting()
     {
@@ -1044,7 +1018,6 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
-    [Category("Unit")]
     [Test]
     public async Task GetArrayType_Null_Item_Returns_Object_Array()
     {
@@ -1130,7 +1103,6 @@ public class ParameterExtractorDeepCoverageTests
 }
 """;
 
-    [Category("Unit")]
     [Test]
     public async Task FormatDoubleLiteral_Integer_Value_Adds_Point_Zero()
     {
@@ -1139,7 +1111,6 @@ public class ParameterExtractorDeepCoverageTests
         generatedCode.Should().Contain("double? doubleValue = 42.0");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task FormatDoubleLiteral_With_Exponent_No_Point_Zero()
     {

--- a/src/Refitter.Tests/Parameters/ParameterExtractorEdgeCaseTests.cs
+++ b/src/Refitter.Tests/Parameters/ParameterExtractorEdgeCaseTests.cs
@@ -49,6 +49,7 @@ public class ParameterExtractorEdgeCaseTests
 }
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertToVariableName_Handles_Empty_String_Property()
     {
@@ -57,6 +58,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[AliasAs(\"\")] string unnamed");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertToVariableName_Handles_Dashes()
     {
@@ -66,6 +68,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[AliasAs(\"field-with-dashes\")] string field_with_dashes");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertToVariableName_Handles_Dots()
     {
@@ -75,6 +78,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[AliasAs(\"field.with.dots\")] string field_with_dots");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertToVariableName_Handles_Special_Characters()
     {
@@ -83,6 +87,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[AliasAs(\"field@special#chars\")] string fieldspecial_chars");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ConvertToVariableName_Generated_Code_Builds()
     {
@@ -150,6 +155,7 @@ public class ParameterExtractorEdgeCaseTests
 }
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Multipart_FormData_Includes_Text_Fields()
     {
@@ -160,6 +166,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("string category");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Multipart_FormData_Includes_Array_Text_Fields()
     {
@@ -167,6 +174,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("IEnumerable<string> tags");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Multipart_FormData_Includes_Binary_Fields()
     {
@@ -175,6 +183,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("StreamPart documentFile");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Multipart_FormData_Text_Fields_Have_Correct_Attributes()
     {
@@ -185,6 +194,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("IEnumerable<string> tags");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Multipart_FormData_Mixed_Fields_Builds()
     {
@@ -252,6 +262,7 @@ public class ParameterExtractorEdgeCaseTests
 }
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task ApizrRequestOptions_Included_When_Enabled()
     {
@@ -259,6 +270,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[RequestOptions] IApizrRequestOptions options");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ApizrRequestOptions_Not_Included_When_Disabled()
     {
@@ -274,6 +286,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().NotContain("IApizrRequestOptions options");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ApizrRequestOptions_Included_In_All_Methods()
     {
@@ -285,6 +298,7 @@ public class ParameterExtractorEdgeCaseTests
         occurrences.Count.Should().BeGreaterThanOrEqualTo(2);
     }
 
+    [Category("Integration")]
     [Test]
     public async Task ApizrRequestOptions_Code_Builds()
     {
@@ -349,6 +363,7 @@ public class ParameterExtractorEdgeCaseTests
 }
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task CancellationToken_Included_When_Enabled()
     {
@@ -356,6 +371,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("CancellationToken cancellationToken = default");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task CancellationToken_Not_Included_When_Disabled()
     {
@@ -371,6 +387,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().NotContain("CancellationToken cancellationToken");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task CancellationToken_Included_In_All_Methods()
     {
@@ -382,6 +399,7 @@ public class ParameterExtractorEdgeCaseTests
         occurrences.Count.Should().BeGreaterThanOrEqualTo(2);
     }
 
+    [Category("Integration")]
     [Test]
     public async Task CancellationToken_Code_Builds()
     {
@@ -389,6 +407,7 @@ public class ParameterExtractorEdgeCaseTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task CancellationToken_Not_Included_When_ApizrRequestOptions_Used()
     {
@@ -471,6 +490,7 @@ public class ParameterExtractorEdgeCaseTests
 }
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Complex_Multipart_With_Special_Characters_And_Mixed_Types()
     {
@@ -492,6 +512,7 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[AliasAs(\"profile.pic\")]");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Complex_Multipart_Code_Builds()
     {

--- a/src/Refitter.Tests/Parameters/ParameterExtractorEdgeCaseTests.cs
+++ b/src/Refitter.Tests/Parameters/ParameterExtractorEdgeCaseTests.cs
@@ -49,7 +49,6 @@ public class ParameterExtractorEdgeCaseTests
 }
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertToVariableName_Handles_Empty_String_Property()
     {
@@ -58,7 +57,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[AliasAs(\"\")] string unnamed");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertToVariableName_Handles_Dashes()
     {
@@ -68,7 +66,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[AliasAs(\"field-with-dashes\")] string field_with_dashes");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertToVariableName_Handles_Dots()
     {
@@ -78,7 +75,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[AliasAs(\"field.with.dots\")] string field_with_dots");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertToVariableName_Handles_Special_Characters()
     {
@@ -87,7 +83,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[AliasAs(\"field@special#chars\")] string fieldspecial_chars");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ConvertToVariableName_Generated_Code_Builds()
     {
@@ -155,7 +150,6 @@ public class ParameterExtractorEdgeCaseTests
 }
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Multipart_FormData_Includes_Text_Fields()
     {
@@ -166,7 +160,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("string category");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Multipart_FormData_Includes_Array_Text_Fields()
     {
@@ -174,7 +167,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("IEnumerable<string> tags");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Multipart_FormData_Includes_Binary_Fields()
     {
@@ -183,7 +175,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("StreamPart documentFile");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Multipart_FormData_Text_Fields_Have_Correct_Attributes()
     {
@@ -194,7 +185,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("IEnumerable<string> tags");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Multipart_FormData_Mixed_Fields_Builds()
     {
@@ -262,7 +252,6 @@ public class ParameterExtractorEdgeCaseTests
 }
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task ApizrRequestOptions_Included_When_Enabled()
     {
@@ -270,7 +259,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[RequestOptions] IApizrRequestOptions options");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ApizrRequestOptions_Not_Included_When_Disabled()
     {
@@ -286,7 +274,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().NotContain("IApizrRequestOptions options");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ApizrRequestOptions_Included_In_All_Methods()
     {
@@ -363,7 +350,6 @@ public class ParameterExtractorEdgeCaseTests
 }
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task CancellationToken_Included_When_Enabled()
     {
@@ -371,7 +357,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("CancellationToken cancellationToken = default");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task CancellationToken_Not_Included_When_Disabled()
     {
@@ -387,7 +372,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().NotContain("CancellationToken cancellationToken");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task CancellationToken_Included_In_All_Methods()
     {
@@ -407,7 +391,6 @@ public class ParameterExtractorEdgeCaseTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task CancellationToken_Not_Included_When_ApizrRequestOptions_Used()
     {
@@ -490,7 +473,6 @@ public class ParameterExtractorEdgeCaseTests
 }
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Complex_Multipart_With_Special_Characters_And_Mixed_Types()
     {
@@ -512,7 +494,6 @@ public class ParameterExtractorEdgeCaseTests
         generatedCode.Should().Contain("[AliasAs(\"profile.pic\")]");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Complex_Multipart_Code_Builds()
     {

--- a/src/Refitter.Tests/Parameters/ParameterExtractorPrivateCoverageTests.cs
+++ b/src/Refitter.Tests/Parameters/ParameterExtractorPrivateCoverageTests.cs
@@ -6,6 +6,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Parameters;
 
+
+[Category("Unit")]
 public class ParameterExtractorPrivateCoverageTests
 {
     [Test]

--- a/src/Refitter.Tests/Parameters/ParameterExtractorPrivateCoverageTests.cs
+++ b/src/Refitter.Tests/Parameters/ParameterExtractorPrivateCoverageTests.cs
@@ -7,7 +7,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Parameters;
 
 
-[Category("Unit")]
 public class ParameterExtractorPrivateCoverageTests
 {
     [Test]

--- a/src/Refitter.Tests/PathParametersWithUrlTests.cs
+++ b/src/Refitter.Tests/PathParametersWithUrlTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class PathParametersWithUrlTests
 {
     [Test]

--- a/src/Refitter.Tests/PathParametersWithUrlTests.cs
+++ b/src/Refitter.Tests/PathParametersWithUrlTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class PathParametersWithUrlTests
 {
     [Test]

--- a/src/Refitter.Tests/RefitCodeGeneratorTests.cs
+++ b/src/Refitter.Tests/RefitCodeGeneratorTests.cs
@@ -55,7 +55,6 @@ paths:
           description: success
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Generate_Produces_Valid_Code()
     {
@@ -74,7 +73,6 @@ paths:
         result.Should().Contain("TestNamespace");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generate_WithFilteredDocument_ProducesValidCode()
     {
@@ -114,7 +112,6 @@ paths:
         BuildHelper.BuildCSharp(result).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Produces_Output()
     {
@@ -136,7 +133,6 @@ paths:
         result.Files.Should().Contain(f => f.TypeName == "Contracts");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generate_WithSwagger20_Produces_Valid_Code()
     {
@@ -155,7 +151,6 @@ paths:
         result.Should().Contain("TestNamespace");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_WithSwagger20_Produces_Output()
     {

--- a/src/Refitter.Tests/RefitCodeGeneratorTests.cs
+++ b/src/Refitter.Tests/RefitCodeGeneratorTests.cs
@@ -55,6 +55,7 @@ paths:
           description: success
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Generate_Produces_Valid_Code()
     {
@@ -73,6 +74,7 @@ paths:
         result.Should().Contain("TestNamespace");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generate_WithFilteredDocument_ProducesValidCode()
     {
@@ -92,6 +94,7 @@ paths:
         result.Should().NotContain("\"/foo\"");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generate_Compiles_Successfully()
     {
@@ -111,6 +114,7 @@ paths:
         BuildHelper.BuildCSharp(result).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Produces_Output()
     {
@@ -132,6 +136,7 @@ paths:
         result.Files.Should().Contain(f => f.TypeName == "Contracts");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generate_WithSwagger20_Produces_Valid_Code()
     {
@@ -150,6 +155,7 @@ paths:
         result.Should().Contain("TestNamespace");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_WithSwagger20_Produces_Output()
     {

--- a/src/Refitter.Tests/RefitDocumentFilterTests.cs
+++ b/src/Refitter.Tests/RefitDocumentFilterTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class RefitDocumentFilterTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/RefitDocumentFilterTests.cs
+++ b/src/Refitter.Tests/RefitDocumentFilterTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class RefitDocumentFilterTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/RefitGeneratorTests.cs
+++ b/src/Refitter.Tests/RefitGeneratorTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class RefitGeneratorTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/RefitGeneratorTests.cs
+++ b/src/Refitter.Tests/RefitGeneratorTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class RefitGeneratorTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/RefitInterfaceImportTests.cs
+++ b/src/Refitter.Tests/RefitInterfaceImportTests.cs
@@ -4,6 +4,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class RefitInterfaceImportTests
 {
     [Test]

--- a/src/Refitter.Tests/RefitInterfaceImportTests.cs
+++ b/src/Refitter.Tests/RefitInterfaceImportTests.cs
@@ -5,7 +5,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class RefitInterfaceImportTests
 {
     [Test]

--- a/src/Refitter.Tests/RefitterRunnerTests.cs
+++ b/src/Refitter.Tests/RefitterRunnerTests.cs
@@ -6,7 +6,6 @@ using Refitter.Core.Validation;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class RefitterRunnerTests
 {
     private static string CreateTempDirectory() =>

--- a/src/Refitter.Tests/RefitterRunnerTests.cs
+++ b/src/Refitter.Tests/RefitterRunnerTests.cs
@@ -5,6 +5,8 @@ using Refitter.Core.Validation;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class RefitterRunnerTests
 {
     private static string CreateTempDirectory() =>

--- a/src/Refitter.Tests/Regression/ByEndpointQueryParamsInternalITests.cs
+++ b/src/Refitter.Tests/Regression/ByEndpointQueryParamsInternalITests.cs
@@ -37,7 +37,6 @@ public class ByEndpointQueryParamsInternalITests
                   description: 'ok'
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task ByEndpoint_Dynamic_Query_Params_Keep_Internal_I_Characters()
     {

--- a/src/Refitter.Tests/Regression/ByEndpointQueryParamsInternalITests.cs
+++ b/src/Refitter.Tests/Regression/ByEndpointQueryParamsInternalITests.cs
@@ -37,6 +37,7 @@ public class ByEndpointQueryParamsInternalITests
                   description: 'ok'
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task ByEndpoint_Dynamic_Query_Params_Keep_Internal_I_Characters()
     {
@@ -48,6 +49,7 @@ public class ByEndpointQueryParamsInternalITests
         generatedCode.Should().NotContain("GetnvoicenfoQueryParams");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task ByEndpoint_Dynamic_Query_Params_With_Internal_I_Characters_Build()
     {

--- a/src/Refitter.Tests/Regression/ContractSuffixCorruptionTests.cs
+++ b/src/Refitter.Tests/Regression/ContractSuffixCorruptionTests.cs
@@ -9,6 +9,8 @@ namespace Refitter.Tests.Regression;
 /// Regression tests for Issue #1013: ContractTypeSuffix regex corruption
 /// Validates that suffix replacement doesn't corrupt XML comments, string literals, or partial name matches
 /// </summary>
+
+[Category("Unit")]
 public class ContractSuffixCorruptionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Regression/ContractSuffixCorruptionTests.cs
+++ b/src/Refitter.Tests/Regression/ContractSuffixCorruptionTests.cs
@@ -10,7 +10,6 @@ namespace Refitter.Tests.Regression;
 /// Validates that suffix replacement doesn't corrupt XML comments, string literals, or partial name matches
 /// </summary>
 
-[Category("Unit")]
 public class ContractSuffixCorruptionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Regression/DynamicQuerystringMutationTests.cs
+++ b/src/Refitter.Tests/Regression/DynamicQuerystringMutationTests.cs
@@ -7,6 +7,8 @@ namespace Refitter.Tests.Regression;
 /// Regression tests for Issue #1039: dynamic querystring extraction mutates the shared NSwag model.
 /// Validates that XML documentation still sees the original query parameters after wrapper generation.
 /// </summary>
+
+[Category("Unit")]
 public class DynamicQuerystringMutationTests
 {
     private const string OpenApiSpec = """

--- a/src/Refitter.Tests/Regression/DynamicQuerystringMutationTests.cs
+++ b/src/Refitter.Tests/Regression/DynamicQuerystringMutationTests.cs
@@ -8,7 +8,6 @@ namespace Refitter.Tests.Regression;
 /// Validates that XML documentation still sees the original query parameters after wrapper generation.
 /// </summary>
 
-[Category("Unit")]
 public class DynamicQuerystringMutationTests
 {
     private const string OpenApiSpec = """

--- a/src/Refitter.Tests/Regression/EnumConverterInjectionTests.cs
+++ b/src/Refitter.Tests/Regression/EnumConverterInjectionTests.cs
@@ -10,7 +10,6 @@ namespace Refitter.Tests.Regression;
 /// Validates that both internal and public enums receive JsonConverter attributes
 /// </summary>
 
-[Category("Unit")]
 public class EnumConverterInjectionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Regression/EnumConverterInjectionTests.cs
+++ b/src/Refitter.Tests/Regression/EnumConverterInjectionTests.cs
@@ -9,6 +9,8 @@ namespace Refitter.Tests.Regression;
 /// Regression tests for Issue #1014: Internal enum JsonConverter injection
 /// Validates that both internal and public enums receive JsonConverter attributes
 /// </summary>
+
+[Category("Unit")]
 public class EnumConverterInjectionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Regression/MalformedUnicodeEscapeTests.cs
+++ b/src/Refitter.Tests/Regression/MalformedUnicodeEscapeTests.cs
@@ -7,6 +7,8 @@ namespace Refitter.Tests.Regression;
 /// Regression tests for Issue #1051: XmlDocumentationGenerator.DecodeJsonEscapedText mishandles malformed \u sequences
 /// Validates that malformed Unicode escape sequences (e.g., \uZZZZ) are handled correctly without consuming extra characters
 /// </summary>
+
+[Category("Unit")]
 public class MalformedUnicodeEscapeTests
 {
     [Test]

--- a/src/Refitter.Tests/Regression/MalformedUnicodeEscapeTests.cs
+++ b/src/Refitter.Tests/Regression/MalformedUnicodeEscapeTests.cs
@@ -8,7 +8,6 @@ namespace Refitter.Tests.Regression;
 /// Validates that malformed Unicode escape sequences (e.g., \uZZZZ) are handled correctly without consuming extra characters
 /// </summary>
 
-[Category("Unit")]
 public class MalformedUnicodeEscapeTests
 {
     [Test]

--- a/src/Refitter.Tests/Regression/MissingInterfaceXmlDocsWarningsAsErrorsTests.cs
+++ b/src/Refitter.Tests/Regression/MissingInterfaceXmlDocsWarningsAsErrorsTests.cs
@@ -50,6 +50,7 @@ public class MissingInterfaceXmlDocsWarningsAsErrorsTests
                   description: 'ok'
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task ByTag_Generates_Interface_Fallback_Summary_When_Tag_Description_Is_Missing()
     {
@@ -59,6 +60,7 @@ public class MissingInterfaceXmlDocsWarningsAsErrorsTests
         generatedCode.Should().Contain("/// <summary>Operations for Orders.</summary>");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task ByTag_Generated_Code_Builds_With_Warnings_As_Errors()
     {
@@ -67,6 +69,7 @@ public class MissingInterfaceXmlDocsWarningsAsErrorsTests
         BuildHelper.BuildCSharp(warningsAsErrors: true, generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task ByEndpoint_Generates_Interface_Fallback_Summary_When_Endpoint_Summary_Is_Missing()
     {
@@ -77,6 +80,7 @@ public class MissingInterfaceXmlDocsWarningsAsErrorsTests
         generatedCode.Should().Contain("/// <summary>Operations for");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task ByEndpoint_Generated_Code_Builds_With_Warnings_As_Errors()
     {

--- a/src/Refitter.Tests/Regression/MissingInterfaceXmlDocsWarningsAsErrorsTests.cs
+++ b/src/Refitter.Tests/Regression/MissingInterfaceXmlDocsWarningsAsErrorsTests.cs
@@ -50,7 +50,6 @@ public class MissingInterfaceXmlDocsWarningsAsErrorsTests
                   description: 'ok'
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task ByTag_Generates_Interface_Fallback_Summary_When_Tag_Description_Is_Missing()
     {
@@ -69,7 +68,6 @@ public class MissingInterfaceXmlDocsWarningsAsErrorsTests
         BuildHelper.BuildCSharp(warningsAsErrors: true, generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task ByEndpoint_Generates_Interface_Fallback_Summary_When_Endpoint_Summary_Is_Missing()
     {

--- a/src/Refitter.Tests/Regression/MultiSpecSchemaMergeTests.cs
+++ b/src/Refitter.Tests/Regression/MultiSpecSchemaMergeTests.cs
@@ -8,6 +8,8 @@ namespace Refitter.Tests.Regression;
 /// Regression tests for Issue #1016: Multi-spec merge drops schemas
 /// Validates that schemas from all OpenAPI specs are preserved during merge
 /// </summary>
+
+[Category("Unit")]
 public class MultiSpecSchemaMergeTests
 {
     // First spec: has paths but NO components section

--- a/src/Refitter.Tests/Regression/MultiSpecSchemaMergeTests.cs
+++ b/src/Refitter.Tests/Regression/MultiSpecSchemaMergeTests.cs
@@ -9,7 +9,6 @@ namespace Refitter.Tests.Regression;
 /// Validates that schemas from all OpenAPI specs are preserved during merge
 /// </summary>
 
-[Category("Unit")]
 public class MultiSpecSchemaMergeTests
 {
     // First spec: has paths but NO components section

--- a/src/Refitter.Tests/Regression/OneOfDiscriminatorNullRefTests.cs
+++ b/src/Refitter.Tests/Regression/OneOfDiscriminatorNullRefTests.cs
@@ -116,7 +116,6 @@ public class OneOfDiscriminatorNullRefTests
 }
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Not_Throw_NRE_On_Swagger_20_Document()
     {
@@ -131,7 +130,6 @@ public class OneOfDiscriminatorNullRefTests
             "Swagger 2.0 documents have null Components, code should handle this gracefully");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Not_Throw_NRE_On_OpenAPI_Without_Components()
     {
@@ -145,7 +143,6 @@ public class OneOfDiscriminatorNullRefTests
             "OpenAPI documents without components section should be handled gracefully");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Not_Throw_NRE_On_OpenAPI_Without_Schemas()
     {
@@ -159,7 +156,6 @@ public class OneOfDiscriminatorNullRefTests
             "OpenAPI documents with components but no schemas should be handled gracefully");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_From_Swagger_20()
     {
@@ -169,7 +165,6 @@ public class OneOfDiscriminatorNullRefTests
         generatedCode.Should().Contain("GetPets");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_From_OpenAPI_Without_Components()
     {
@@ -179,7 +174,6 @@ public class OneOfDiscriminatorNullRefTests
         generatedCode.Should().Contain("HealthCheck");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_From_OpenAPI_Without_Schemas()
     {

--- a/src/Refitter.Tests/Regression/OneOfDiscriminatorNullRefTests.cs
+++ b/src/Refitter.Tests/Regression/OneOfDiscriminatorNullRefTests.cs
@@ -116,6 +116,7 @@ public class OneOfDiscriminatorNullRefTests
 }
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Not_Throw_NRE_On_Swagger_20_Document()
     {
@@ -130,6 +131,7 @@ public class OneOfDiscriminatorNullRefTests
             "Swagger 2.0 documents have null Components, code should handle this gracefully");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Not_Throw_NRE_On_OpenAPI_Without_Components()
     {
@@ -143,6 +145,7 @@ public class OneOfDiscriminatorNullRefTests
             "OpenAPI documents without components section should be handled gracefully");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Not_Throw_NRE_On_OpenAPI_Without_Schemas()
     {
@@ -156,6 +159,7 @@ public class OneOfDiscriminatorNullRefTests
             "OpenAPI documents with components but no schemas should be handled gracefully");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_From_Swagger_20()
     {
@@ -165,6 +169,7 @@ public class OneOfDiscriminatorNullRefTests
         generatedCode.Should().Contain("GetPets");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_From_OpenAPI_Without_Components()
     {
@@ -174,6 +179,7 @@ public class OneOfDiscriminatorNullRefTests
         generatedCode.Should().Contain("HealthCheck");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_From_OpenAPI_Without_Schemas()
     {
@@ -183,6 +189,7 @@ public class OneOfDiscriminatorNullRefTests
         generatedCode.Should().Contain("GetData");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code_From_All_Variants()
     {

--- a/src/Refitter.Tests/Regression/OpenApiTitleAngleBracketIdentifierTests.cs
+++ b/src/Refitter.Tests/Regression/OpenApiTitleAngleBracketIdentifierTests.cs
@@ -34,7 +34,6 @@ public class OpenApiTitleAngleBracketIdentifierTests
                   type: string
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task OpenApi_Title_With_Angle_Brackets_Does_Not_Leak_Invalid_Interface_Or_Context_Names()
     {

--- a/src/Refitter.Tests/Regression/OpenApiTitleAngleBracketIdentifierTests.cs
+++ b/src/Refitter.Tests/Regression/OpenApiTitleAngleBracketIdentifierTests.cs
@@ -34,6 +34,7 @@ public class OpenApiTitleAngleBracketIdentifierTests
                   type: string
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task OpenApi_Title_With_Angle_Brackets_Does_Not_Leak_Invalid_Interface_Or_Context_Names()
     {
@@ -45,6 +46,7 @@ public class OpenApiTitleAngleBracketIdentifierTests
         generatedCode.Should().NotContain("Invoice<Client>APISerializerContext");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task OpenApi_Title_With_Angle_Brackets_Generated_Code_Builds()
     {

--- a/src/Refitter.Tests/Regression/RefitGeneratorAdvancedTests.cs
+++ b/src/Refitter.Tests/Regression/RefitGeneratorAdvancedTests.cs
@@ -92,6 +92,7 @@ public class RefitGeneratorAdvancedTests
 
     #region Gap 1: ContractTypeSuffix in GenerateMultipleFiles (Lines 249-256)
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Applies_ContractTypeSuffix_To_All_Files()
     {
@@ -127,6 +128,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_ContractTypeSuffix_Can_Build()
     {
@@ -157,6 +159,7 @@ public class RefitGeneratorAdvancedTests
 
     #region Gap 2: GenerateContracts = false in GenerateMultipleFiles (Lines 221-227)
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_GenerateContracts_False_Excludes_Contracts_File()
     {
@@ -181,6 +184,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_GenerateContracts_False_Still_Has_Interface_Files()
     {
@@ -209,6 +213,7 @@ public class RefitGeneratorAdvancedTests
 
     #region Gap 3: Empty DI config should not add config file (Lines 229-247)
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Empty_DI_Config_Does_Not_Add_DependencyInjection_File()
     {
@@ -239,6 +244,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_Valid_DI_Config_Includes_DependencyInjection_File()
     {
@@ -275,6 +281,7 @@ public class RefitGeneratorAdvancedTests
 
     #region Gap 4: AdditionalNamespaces in GenerateClient (Lines 297-305)
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_AdditionalNamespaces_Includes_Using_Statements()
     {
@@ -308,6 +315,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Integration")]
     [Test]
     public async Task GenerateMultipleFiles_With_AdditionalNamespaces_Code_Builds()
     {
@@ -332,6 +340,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_AdditionalNamespaces_With_MultipleInterfaces_ByEndpoint()
     {
@@ -368,6 +377,7 @@ public class RefitGeneratorAdvancedTests
 
     #region Gap 5: OpenApiPaths array (Line 45-46)
 
+    [Category("Unit")]
     [Test]
     public async Task CreateAsync_With_OpenApiPaths_Array_Loads_Multiple_Documents()
     {
@@ -444,6 +454,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Integration")]
     [Test]
     public async Task CreateAsync_With_OpenApiPaths_Array_Builds_Successfully()
     {
@@ -548,6 +559,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Unit")]
     [Test]
     public async Task CreateAsync_With_OpenApiPaths_Array_In_MultipleFiles_Mode()
     {
@@ -630,6 +642,7 @@ public class RefitGeneratorAdvancedTests
 
     #region Combined Scenarios
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_ContractTypeSuffix_And_AdditionalNamespaces()
     {
@@ -671,6 +684,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Integration")]
     [Test]
     public async Task GenerateMultipleFiles_With_JsonSerializerContext_Adds_Context_File()
     {
@@ -702,6 +716,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_GenerateContracts_False_And_ContractTypeSuffix()
     {
@@ -733,6 +748,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Integration")]
     [Test]
     public void NormalizeSwagger2OptionalReferencePropertyNullability_Removes_Nullability_From_Reference_Type_Shapes()
     {
@@ -781,6 +797,7 @@ public class RefitGeneratorAdvancedTests
         BuildHelper.BuildCSharp(normalized).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public void NormalizeSwagger2OptionalReferencePropertyNullability_Incorrectly_Removes_Nullability_From_Struct_Value_Types()
     {
@@ -850,6 +867,7 @@ public class RefitGeneratorAdvancedTests
         normalized.Should().Contain("public int? BuiltInValueType { get; set; }");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generate_Does_Not_Emit_JsonSerializerContext_When_Contracts_Are_Disabled()
     {
@@ -880,6 +898,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Does_Not_Add_JsonSerializerContext_File_When_Contracts_Are_Disabled()
     {
@@ -910,6 +929,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Handles_Missing_Document_Info_For_JsonSerializerContext_File_Name()
     {
@@ -941,6 +961,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Unit")]
     [Test]
     public void GenerateJsonSerializerContext_Handles_Missing_Document_Info()
     {
@@ -971,6 +992,7 @@ public class RefitGeneratorAdvancedTests
         serializerContext.Should().Contain("internal partial class TestApiSerializerContext");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Does_Not_Add_JsonSerializerContext_File_When_No_Contract_Types_Are_Generated()
     {
@@ -1022,6 +1044,7 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_Whitespace_OpenApi_Title_Uses_InterfaceName_For_Apizr_Title_Fallback()
     {

--- a/src/Refitter.Tests/Regression/RefitGeneratorAdvancedTests.cs
+++ b/src/Refitter.Tests/Regression/RefitGeneratorAdvancedTests.cs
@@ -92,7 +92,6 @@ public class RefitGeneratorAdvancedTests
 
     #region Gap 1: ContractTypeSuffix in GenerateMultipleFiles (Lines 249-256)
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Applies_ContractTypeSuffix_To_All_Files()
     {
@@ -128,7 +127,6 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_ContractTypeSuffix_Can_Build()
     {
@@ -159,7 +157,6 @@ public class RefitGeneratorAdvancedTests
 
     #region Gap 2: GenerateContracts = false in GenerateMultipleFiles (Lines 221-227)
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_GenerateContracts_False_Excludes_Contracts_File()
     {
@@ -184,7 +181,6 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_GenerateContracts_False_Still_Has_Interface_Files()
     {
@@ -213,7 +209,6 @@ public class RefitGeneratorAdvancedTests
 
     #region Gap 3: Empty DI config should not add config file (Lines 229-247)
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Empty_DI_Config_Does_Not_Add_DependencyInjection_File()
     {
@@ -244,7 +239,6 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_Valid_DI_Config_Includes_DependencyInjection_File()
     {
@@ -281,7 +275,6 @@ public class RefitGeneratorAdvancedTests
 
     #region Gap 4: AdditionalNamespaces in GenerateClient (Lines 297-305)
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_AdditionalNamespaces_Includes_Using_Statements()
     {
@@ -340,7 +333,6 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_AdditionalNamespaces_With_MultipleInterfaces_ByEndpoint()
     {
@@ -377,7 +369,6 @@ public class RefitGeneratorAdvancedTests
 
     #region Gap 5: OpenApiPaths array (Line 45-46)
 
-    [Category("Unit")]
     [Test]
     public async Task CreateAsync_With_OpenApiPaths_Array_Loads_Multiple_Documents()
     {
@@ -559,7 +550,6 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
-    [Category("Unit")]
     [Test]
     public async Task CreateAsync_With_OpenApiPaths_Array_In_MultipleFiles_Mode()
     {
@@ -642,7 +632,6 @@ public class RefitGeneratorAdvancedTests
 
     #region Combined Scenarios
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_ContractTypeSuffix_And_AdditionalNamespaces()
     {
@@ -716,7 +705,6 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_GenerateContracts_False_And_ContractTypeSuffix()
     {
@@ -797,7 +785,6 @@ public class RefitGeneratorAdvancedTests
         BuildHelper.BuildCSharp(normalized).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public void NormalizeSwagger2OptionalReferencePropertyNullability_Incorrectly_Removes_Nullability_From_Struct_Value_Types()
     {
@@ -867,7 +854,6 @@ public class RefitGeneratorAdvancedTests
         normalized.Should().Contain("public int? BuiltInValueType { get; set; }");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generate_Does_Not_Emit_JsonSerializerContext_When_Contracts_Are_Disabled()
     {
@@ -898,7 +884,6 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Does_Not_Add_JsonSerializerContext_File_When_Contracts_Are_Disabled()
     {
@@ -929,7 +914,6 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Handles_Missing_Document_Info_For_JsonSerializerContext_File_Name()
     {
@@ -961,7 +945,6 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
-    [Category("Unit")]
     [Test]
     public void GenerateJsonSerializerContext_Handles_Missing_Document_Info()
     {
@@ -992,7 +975,6 @@ public class RefitGeneratorAdvancedTests
         serializerContext.Should().Contain("internal partial class TestApiSerializerContext");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_Does_Not_Add_JsonSerializerContext_File_When_No_Contract_Types_Are_Generated()
     {
@@ -1044,7 +1026,6 @@ public class RefitGeneratorAdvancedTests
         }
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GenerateMultipleFiles_With_Whitespace_OpenApi_Title_Uses_InterfaceName_For_Apizr_Title_Fallback()
     {

--- a/src/Refitter.Tests/Regression/SettingsCliRegressionTests.cs
+++ b/src/Refitter.Tests/Regression/SettingsCliRegressionTests.cs
@@ -9,7 +9,6 @@ namespace Refitter.Tests.Regression;
 /// Tests issues: #1021, #1030, #1031, #1044, #1045, #1046, #1048, #1050, #1054
 /// </summary>
 
-[Category("Unit")]
 public class SettingsCliRegressionTests
 {
     [Test]

--- a/src/Refitter.Tests/Regression/SettingsCliRegressionTests.cs
+++ b/src/Refitter.Tests/Regression/SettingsCliRegressionTests.cs
@@ -8,6 +8,8 @@ namespace Refitter.Tests.Regression;
 /// Regression tests for #1057 settings and CLI workstream issues.
 /// Tests issues: #1021, #1030, #1031, #1044, #1045, #1046, #1048, #1050, #1054
 /// </summary>
+
+[Category("Unit")]
 public class SettingsCliRegressionTests
 {
     [Test]

--- a/src/Refitter.Tests/Regression/XmlDocEscapingTests.cs
+++ b/src/Refitter.Tests/Regression/XmlDocEscapingTests.cs
@@ -319,7 +319,6 @@ public class XmlDocEscapingTests
 }
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Ampersand_In_Parameter_Description()
     {
@@ -330,7 +329,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().NotContain("/// <summary>\n                /// Search filter: use & for");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Less_Than_In_Parameter_Description()
     {
@@ -340,7 +338,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Greater_Than_In_Parameter_Description()
     {
@@ -350,7 +347,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&gt;");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Multiple_Unsafe_Chars_In_Parameter_Description()
     {
@@ -360,7 +356,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;100 &amp; offset&gt;0");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Response_Description()
     {
@@ -370,7 +365,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("Success: returns data where x&lt;100 &amp; y&gt;0");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Exception_Description()
     {
@@ -380,7 +374,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;10 &amp;");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Dynamic_Querystring_Parameter_Descriptions()
     {
@@ -439,7 +432,6 @@ public class XmlDocEscapingTests
 
     // ── Swagger 2.0 companion tests ─────────────────────────────────────────
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Ampersand_In_Parameter_Description_Swagger2()
     {
@@ -449,7 +441,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().NotContain("/// <summary>\n                /// Search filter: use & for");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Less_Than_In_Parameter_Description_Swagger2()
     {
@@ -458,7 +449,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Greater_Than_In_Parameter_Description_Swagger2()
     {
@@ -467,7 +457,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&gt;");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Multiple_Unsafe_Chars_In_Parameter_Description_Swagger2()
     {
@@ -476,7 +465,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;100 &amp; offset&gt;0");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Response_Description_Swagger2()
     {
@@ -485,7 +473,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("Success: returns data where x&lt;100 &amp; y&gt;0");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Exception_Description_Swagger2()
     {
@@ -494,7 +481,6 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;10 &amp;");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Dynamic_Querystring_Parameter_Descriptions_Swagger2()
     {

--- a/src/Refitter.Tests/Regression/XmlDocEscapingTests.cs
+++ b/src/Refitter.Tests/Regression/XmlDocEscapingTests.cs
@@ -319,6 +319,7 @@ public class XmlDocEscapingTests
 }
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Ampersand_In_Parameter_Description()
     {
@@ -329,6 +330,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().NotContain("/// <summary>\n                /// Search filter: use & for");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Less_Than_In_Parameter_Description()
     {
@@ -338,6 +340,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Greater_Than_In_Parameter_Description()
     {
@@ -347,6 +350,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&gt;");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Multiple_Unsafe_Chars_In_Parameter_Description()
     {
@@ -356,6 +360,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;100 &amp; offset&gt;0");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Response_Description()
     {
@@ -365,6 +370,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("Success: returns data where x&lt;100 &amp; y&gt;0");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Exception_Description()
     {
@@ -374,6 +380,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;10 &amp;");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Dynamic_Querystring_Parameter_Descriptions()
     {
@@ -392,6 +399,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&gt;");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code_With_Escaped_Parameter_Descriptions()
     {
@@ -402,6 +410,7 @@ public class XmlDocEscapingTests
             "Generated code with escaped parameter descriptions should compile");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code_With_Escaped_Response_Descriptions()
     {
@@ -411,6 +420,7 @@ public class XmlDocEscapingTests
             "Generated code with escaped response descriptions should compile");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code_With_Escaped_Dynamic_Querystring_Descriptions()
     {
@@ -429,6 +439,7 @@ public class XmlDocEscapingTests
 
     // ── Swagger 2.0 companion tests ─────────────────────────────────────────
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Ampersand_In_Parameter_Description_Swagger2()
     {
@@ -438,6 +449,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().NotContain("/// <summary>\n                /// Search filter: use & for");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Less_Than_In_Parameter_Description_Swagger2()
     {
@@ -446,6 +458,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Greater_Than_In_Parameter_Description_Swagger2()
     {
@@ -454,6 +467,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&gt;");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Multiple_Unsafe_Chars_In_Parameter_Description_Swagger2()
     {
@@ -462,6 +476,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;100 &amp; offset&gt;0");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Response_Description_Swagger2()
     {
@@ -470,6 +485,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("Success: returns data where x&lt;100 &amp; y&gt;0");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Exception_Description_Swagger2()
     {
@@ -478,6 +494,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&lt;10 &amp;");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Should_Escape_Unsafe_Chars_In_Dynamic_Querystring_Parameter_Descriptions_Swagger2()
     {
@@ -495,6 +512,7 @@ public class XmlDocEscapingTests
         generatedCode.Should().Contain("&gt;");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code_With_Escaped_Parameter_Descriptions_Swagger2()
     {
@@ -504,6 +522,7 @@ public class XmlDocEscapingTests
             "Generated code with escaped parameter descriptions should compile");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code_With_Escaped_Response_Descriptions_Swagger2()
     {
@@ -513,6 +532,7 @@ public class XmlDocEscapingTests
             "Generated code with escaped response descriptions should compile");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code_With_Escaped_Dynamic_Querystring_Descriptions_Swagger2()
     {

--- a/src/Refitter.Tests/ReturnTypeGeneratorTests.cs
+++ b/src/Refitter.Tests/ReturnTypeGeneratorTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class ReturnTypeGeneratorTests
 {
     [Test]

--- a/src/Refitter.Tests/ReturnTypeGeneratorTests.cs
+++ b/src/Refitter.Tests/ReturnTypeGeneratorTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class ReturnTypeGeneratorTests
 {
     [Test]

--- a/src/Refitter.Tests/RichGenerationReporterTests.cs
+++ b/src/Refitter.Tests/RichGenerationReporterTests.cs
@@ -11,6 +11,8 @@ namespace Refitter.Tests;
 /// AnsiConsole/Spectre.Console which cannot be captured in unit tests.
 /// A clean run (no exception) is the success criterion.
 /// </summary>
+
+[Category("Unit")]
 public class RichGenerationReporterTests
 {
     [Test]

--- a/src/Refitter.Tests/RichGenerationReporterTests.cs
+++ b/src/Refitter.Tests/RichGenerationReporterTests.cs
@@ -12,7 +12,6 @@ namespace Refitter.Tests;
 /// A clean run (no exception) is the success criterion.
 /// </summary>
 
-[Category("Unit")]
 public class RichGenerationReporterTests
 {
     [Test]

--- a/src/Refitter.Tests/Scenarios/AddContentTypeHeadersTests.cs
+++ b/src/Refitter.Tests/Scenarios/AddContentTypeHeadersTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class AddContentTypeHeadersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/AddContentTypeHeadersTests.cs
+++ b/src/Refitter.Tests/Scenarios/AddContentTypeHeadersTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class AddContentTypeHeadersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/AdditionalNamespacesTests.cs
+++ b/src/Refitter.Tests/Scenarios/AdditionalNamespacesTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class AdditionalNamespacesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/AdditionalNamespacesTests.cs
+++ b/src/Refitter.Tests/Scenarios/AdditionalNamespacesTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class AdditionalNamespacesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/AllHeadersDisabledTests.cs
+++ b/src/Refitter.Tests/Scenarios/AllHeadersDisabledTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class AllHeadersDisabledTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/AllHeadersDisabledTests.cs
+++ b/src/Refitter.Tests/Scenarios/AllHeadersDisabledTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class AllHeadersDisabledTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/AnyTypeBodySerializationTests.cs
+++ b/src/Refitter.Tests/Scenarios/AnyTypeBodySerializationTests.cs
@@ -50,6 +50,7 @@ public class AnyTypeBodySerializationTests
 }
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_BodySerializationMethod_For_Object_Parameter()
     {
@@ -57,6 +58,7 @@ public class AnyTypeBodySerializationTests
         generatedCode.Should().Contain("[Body(BodySerializationMethod.Serialized)] object body");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {

--- a/src/Refitter.Tests/Scenarios/AnyTypeBodySerializationTests.cs
+++ b/src/Refitter.Tests/Scenarios/AnyTypeBodySerializationTests.cs
@@ -50,7 +50,6 @@ public class AnyTypeBodySerializationTests
 }
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_BodySerializationMethod_For_Object_Parameter()
     {

--- a/src/Refitter.Tests/Scenarios/ArrayTypeReturnMultipleInterfacesByEndpointTests.cs
+++ b/src/Refitter.Tests/Scenarios/ArrayTypeReturnMultipleInterfacesByEndpointTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class ArrayTypeReturnMultipleInterfacesByEndpointTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ArrayTypeReturnMultipleInterfacesByEndpointTests.cs
+++ b/src/Refitter.Tests/Scenarios/ArrayTypeReturnMultipleInterfacesByEndpointTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class ArrayTypeReturnMultipleInterfacesByEndpointTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ArrayTypeReturnMultipleInterfacesByTagTests.cs
+++ b/src/Refitter.Tests/Scenarios/ArrayTypeReturnMultipleInterfacesByTagTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class ArrayTypeReturnMultipleInterfacesByTagTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ArrayTypeReturnMultipleInterfacesByTagTests.cs
+++ b/src/Refitter.Tests/Scenarios/ArrayTypeReturnMultipleInterfacesByTagTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class ArrayTypeReturnMultipleInterfacesByTagTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ArrayTypeReturnTests.cs
+++ b/src/Refitter.Tests/Scenarios/ArrayTypeReturnTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class ArrayTypeReturnTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ArrayTypeReturnTests.cs
+++ b/src/Refitter.Tests/Scenarios/ArrayTypeReturnTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class ArrayTypeReturnTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/BlockerRegressions.cs
+++ b/src/Refitter.Tests/Scenarios/BlockerRegressions.cs
@@ -77,7 +77,6 @@ public class BlockerRegressions
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1013_Prevents_Suffix_Collision_When_Target_Type_Already_Exists()
     {
@@ -92,7 +91,6 @@ public class BlockerRegressions
         result.Should().Contain("public partial class PetDto");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1013_Does_Not_Corrupt_Type_References_When_Collision_Exists()
     {
@@ -163,7 +161,6 @@ public class BlockerRegressions
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1018_Deduplicates_Multipart_Parameters_By_Sanitized_Identifier()
     {
@@ -178,7 +175,6 @@ public class BlockerRegressions
         matches.Count.Should().BeLessThanOrEqualTo(1, "deduplication should prevent duplicate sanitized identifiers");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1018_First_Multipart_Parameter_Wins_After_Sanitization()
     {
@@ -263,7 +259,6 @@ public class BlockerRegressions
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1053_Keywords_Are_Escaped_Not_Double_Prefixed()
     {
@@ -281,7 +276,6 @@ public class BlockerRegressions
         generatedCode.Should().NotContain("_@event");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1053_Sanitize_Routes_Through_EscapeReservedKeyword()
     {
@@ -293,7 +287,6 @@ public class BlockerRegressions
         sanitizedEvent.Should().Be("@event", "Sanitize must escape reserved keywords");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1053_Title_With_Special_Chars_Does_Not_Produce_Invalid_Identifiers()
     {
@@ -306,7 +299,6 @@ public class BlockerRegressions
         generatedCode.Should().NotContain("class @");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1053_Parameter_Name_With_Leading_At_Sign_Is_Stripped()
     {
@@ -318,7 +310,6 @@ public class BlockerRegressions
         generatedCode.Should().NotContain("@@while");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1053_Schema_Names_As_Keywords_Are_Properly_Escaped()
     {
@@ -384,7 +375,6 @@ public class BlockerRegressions
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1102_TagNamedPublic_DoesNotProduceIAtPublicApi()
     {
@@ -424,7 +414,6 @@ public class BlockerRegressions
             "generated code must compile (I@publicApi is invalid and would not compile)");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1102_TagNamedPublic_AllReservedKeywordsHandled()
     {

--- a/src/Refitter.Tests/Scenarios/BlockerRegressions.cs
+++ b/src/Refitter.Tests/Scenarios/BlockerRegressions.cs
@@ -77,6 +77,7 @@ public class BlockerRegressions
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1013_Prevents_Suffix_Collision_When_Target_Type_Already_Exists()
     {
@@ -91,6 +92,7 @@ public class BlockerRegressions
         result.Should().Contain("public partial class PetDto");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1013_Does_Not_Corrupt_Type_References_When_Collision_Exists()
     {
@@ -103,6 +105,7 @@ public class BlockerRegressions
         result.Should().NotContain("Task<PetDtoDto>");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Issue1013_Generated_Code_With_Suffix_Collision_Compiles()
     {
@@ -160,6 +163,7 @@ public class BlockerRegressions
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1018_Deduplicates_Multipart_Parameters_By_Sanitized_Identifier()
     {
@@ -174,6 +178,7 @@ public class BlockerRegressions
         matches.Count.Should().BeLessThanOrEqualTo(1, "deduplication should prevent duplicate sanitized identifiers");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1018_First_Multipart_Parameter_Wins_After_Sanitization()
     {
@@ -184,6 +189,7 @@ public class BlockerRegressions
         generatedCode.Should().Contain("[AliasAs(\"a-b\")]", "first parameter with sanitized name should be emitted");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Issue1018_Generated_Code_With_Duplicate_Sanitized_Names_Compiles()
     {
@@ -257,6 +263,7 @@ public class BlockerRegressions
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1053_Keywords_Are_Escaped_Not_Double_Prefixed()
     {
@@ -274,6 +281,7 @@ public class BlockerRegressions
         generatedCode.Should().NotContain("_@event");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1053_Sanitize_Routes_Through_EscapeReservedKeyword()
     {
@@ -285,6 +293,7 @@ public class BlockerRegressions
         sanitizedEvent.Should().Be("@event", "Sanitize must escape reserved keywords");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1053_Title_With_Special_Chars_Does_Not_Produce_Invalid_Identifiers()
     {
@@ -297,6 +306,7 @@ public class BlockerRegressions
         generatedCode.Should().NotContain("class @");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1053_Parameter_Name_With_Leading_At_Sign_Is_Stripped()
     {
@@ -308,6 +318,7 @@ public class BlockerRegressions
         generatedCode.Should().NotContain("@@while");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1053_Schema_Names_As_Keywords_Are_Properly_Escaped()
     {
@@ -326,6 +337,7 @@ public class BlockerRegressions
         generatedCode.Should().Contain("@while");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Issue1053_Generated_Code_With_Keywords_Compiles()
     {
@@ -372,6 +384,7 @@ public class BlockerRegressions
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1102_TagNamedPublic_DoesNotProduceIAtPublicApi()
     {
@@ -393,6 +406,7 @@ public class BlockerRegressions
         generatedCode.Should().Contain("interface IPublicApi");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Issue1102_TagNamedPublic_GeneratedCode_Compiles()
     {
@@ -410,6 +424,7 @@ public class BlockerRegressions
             "generated code must compile (I@publicApi is invalid and would not compile)");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1102_TagNamedPublic_AllReservedKeywordsHandled()
     {

--- a/src/Refitter.Tests/Scenarios/CancellationTokensWithMultipleInterfacesTests.cs
+++ b/src/Refitter.Tests/Scenarios/CancellationTokensWithMultipleInterfacesTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class CancellationTokensWithMultipleInterfacesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/CancellationTokensWithMultipleInterfacesTests.cs
+++ b/src/Refitter.Tests/Scenarios/CancellationTokensWithMultipleInterfacesTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class CancellationTokensWithMultipleInterfacesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/CaseSensitiveParametersTests.cs
+++ b/src/Refitter.Tests/Scenarios/CaseSensitiveParametersTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class CaseSensitiveParametersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/CaseSensitiveParametersTests.cs
+++ b/src/Refitter.Tests/Scenarios/CaseSensitiveParametersTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class CaseSensitiveParametersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/CollectionFormatTests.cs
+++ b/src/Refitter.Tests/Scenarios/CollectionFormatTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class CollectionFormatTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/CollectionFormatTests.cs
+++ b/src/Refitter.Tests/Scenarios/CollectionFormatTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class CollectionFormatTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ColonsInPathTests.cs
+++ b/src/Refitter.Tests/Scenarios/ColonsInPathTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class ColonsInPathTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ColonsInPathTests.cs
+++ b/src/Refitter.Tests/Scenarios/ColonsInPathTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class ColonsInPathTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ContractOnlyWithMultipleInterfacesTests.cs
+++ b/src/Refitter.Tests/Scenarios/ContractOnlyWithMultipleInterfacesTests.cs
@@ -60,7 +60,6 @@ components:
           type: number
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -76,7 +75,6 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_Interface()
     {
@@ -86,7 +84,6 @@ components:
         generatedCode.Should().NotContain("[Post(");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Contracts()
     {

--- a/src/Refitter.Tests/Scenarios/ContractOnlyWithMultipleInterfacesTests.cs
+++ b/src/Refitter.Tests/Scenarios/ContractOnlyWithMultipleInterfacesTests.cs
@@ -60,6 +60,7 @@ components:
           type: number
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -67,6 +68,7 @@ components:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {
@@ -74,6 +76,7 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_Interface()
     {
@@ -83,6 +86,7 @@ components:
         generatedCode.Should().NotContain("[Post(");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Contracts()
     {

--- a/src/Refitter.Tests/Scenarios/ContractTypeSuffixTests.cs
+++ b/src/Refitter.Tests/Scenarios/ContractTypeSuffixTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class ContractTypeSuffixTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ContractTypeSuffixTests.cs
+++ b/src/Refitter.Tests/Scenarios/ContractTypeSuffixTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class ContractTypeSuffixTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ContractsNamespaceTests.cs
+++ b/src/Refitter.Tests/Scenarios/ContractsNamespaceTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class ContractsNamespaceTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ContractsNamespaceTests.cs
+++ b/src/Refitter.Tests/Scenarios/ContractsNamespaceTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class ContractsNamespaceTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/CustomCodeGeneratorWithDateTimeTests.cs
+++ b/src/Refitter.Tests/Scenarios/CustomCodeGeneratorWithDateTimeTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class CustomCodeGeneratorWithDateTimeTests
 {
     private const string OpenApiSpec =

--- a/src/Refitter.Tests/Scenarios/CustomCodeGeneratorWithDateTimeTests.cs
+++ b/src/Refitter.Tests/Scenarios/CustomCodeGeneratorWithDateTimeTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class CustomCodeGeneratorWithDateTimeTests
 {
     private const string OpenApiSpec =

--- a/src/Refitter.Tests/Scenarios/CustomDateFormatTests.cs
+++ b/src/Refitter.Tests/Scenarios/CustomDateFormatTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class CustomDateFormatTests
 {
 

--- a/src/Refitter.Tests/Scenarios/CustomDateFormatTests.cs
+++ b/src/Refitter.Tests/Scenarios/CustomDateFormatTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class CustomDateFormatTests
 {
 

--- a/src/Refitter.Tests/Scenarios/DefaultResponseObjectTests.cs
+++ b/src/Refitter.Tests/Scenarios/DefaultResponseObjectTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class DefaultResponseObjectTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DefaultResponseObjectTests.cs
+++ b/src/Refitter.Tests/Scenarios/DefaultResponseObjectTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class DefaultResponseObjectTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DeprecatedEndpointTests.cs
+++ b/src/Refitter.Tests/Scenarios/DeprecatedEndpointTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class DeprecatedEndpointTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DeprecatedEndpointTests.cs
+++ b/src/Refitter.Tests/Scenarios/DeprecatedEndpointTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class DeprecatedEndpointTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DeprecatedEndpointsSkippedTests.cs
+++ b/src/Refitter.Tests/Scenarios/DeprecatedEndpointsSkippedTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class DeprecatedEndpointsSkippedTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DeprecatedEndpointsSkippedTests.cs
+++ b/src/Refitter.Tests/Scenarios/DeprecatedEndpointsSkippedTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class DeprecatedEndpointsSkippedTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DeprecatedMultipleInterfaceByTagEndpointsSkippedTests.cs
+++ b/src/Refitter.Tests/Scenarios/DeprecatedMultipleInterfaceByTagEndpointsSkippedTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class DeprecatedMultipleInterfaceByTagEndpointsSkippedTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DeprecatedMultipleInterfaceByTagEndpointsSkippedTests.cs
+++ b/src/Refitter.Tests/Scenarios/DeprecatedMultipleInterfaceByTagEndpointsSkippedTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class DeprecatedMultipleInterfaceByTagEndpointsSkippedTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DeprecatedMultipleInterfaceEndpointsSkippedTests.cs
+++ b/src/Refitter.Tests/Scenarios/DeprecatedMultipleInterfaceEndpointsSkippedTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class DeprecatedMultipleInterfaceEndpointsSkippedTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DeprecatedMultipleInterfaceEndpointsSkippedTests.cs
+++ b/src/Refitter.Tests/Scenarios/DeprecatedMultipleInterfaceEndpointsSkippedTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class DeprecatedMultipleInterfaceEndpointsSkippedTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DisposableWithDependencyInjectionTests.cs
+++ b/src/Refitter.Tests/Scenarios/DisposableWithDependencyInjectionTests.cs
@@ -77,6 +77,7 @@ components:
           type: string
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -84,6 +85,7 @@ components:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {
@@ -91,6 +93,7 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_IDisposable()
     {
@@ -98,6 +101,7 @@ components:
         generatedCode.Should().Contain("IDisposable");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_DI_Registration()
     {

--- a/src/Refitter.Tests/Scenarios/DisposableWithDependencyInjectionTests.cs
+++ b/src/Refitter.Tests/Scenarios/DisposableWithDependencyInjectionTests.cs
@@ -77,7 +77,6 @@ components:
           type: string
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -93,7 +92,6 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_IDisposable()
     {
@@ -101,7 +99,6 @@ components:
         generatedCode.Should().Contain("IDisposable");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_DI_Registration()
     {

--- a/src/Refitter.Tests/Scenarios/DuplicateOperationIdTests.cs
+++ b/src/Refitter.Tests/Scenarios/DuplicateOperationIdTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class DuplicateOperationIdTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DuplicateOperationIdTests.cs
+++ b/src/Refitter.Tests/Scenarios/DuplicateOperationIdTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class DuplicateOperationIdTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/DynamicQueryStringParametersEdgeCasesTests.cs
+++ b/src/Refitter.Tests/Scenarios/DynamicQueryStringParametersEdgeCasesTests.cs
@@ -8,6 +8,7 @@ namespace Refitter.Tests.Scenarios;
 
 public class DynamicQueryStringParametersEdgeCasesTests
 {
+    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Escaped_String_Defaults()
     {
@@ -69,6 +70,7 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("string? BackslashString { get; set; } = \"path\\\\to\\\\file\"");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_All_Escape_Characters()
     {
@@ -140,6 +142,7 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("string? TabString { get; set; } = \"col1\\tcol2\"");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Float_And_Decimal_Defaults()
     {
@@ -203,6 +206,7 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("decimal? DecimalValue { get; set; } = 99.99m");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Boolean_Defaults()
     {
@@ -264,6 +268,7 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("bool? IsDisabled { get; set; } = false");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Integer_Defaults()
     {
@@ -327,6 +332,7 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("long? LongValue { get; set; } = 9999");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Dynamic_QueryString_Generated_Code_Should_Build()
     {
@@ -396,6 +402,7 @@ public class DynamicQueryStringParametersEdgeCasesTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Mixed_Escape_Characters()
     {
@@ -447,6 +454,7 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("string? ComplexString { get; set; } = \"path\\\\to\\\\file with \\\"quotes\\\"\\nand newlines\"");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Long_And_ULong_Defaults()
     {
@@ -510,6 +518,7 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("ulong? UlongValue { get; set; } = 5000000000UL");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Double_Integer_Value()
     {

--- a/src/Refitter.Tests/Scenarios/DynamicQueryStringParametersEdgeCasesTests.cs
+++ b/src/Refitter.Tests/Scenarios/DynamicQueryStringParametersEdgeCasesTests.cs
@@ -8,7 +8,6 @@ namespace Refitter.Tests.Scenarios;
 
 public class DynamicQueryStringParametersEdgeCasesTests
 {
-    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Escaped_String_Defaults()
     {
@@ -70,7 +69,6 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("string? BackslashString { get; set; } = \"path\\\\to\\\\file\"");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_All_Escape_Characters()
     {
@@ -142,7 +140,6 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("string? TabString { get; set; } = \"col1\\tcol2\"");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Float_And_Decimal_Defaults()
     {
@@ -206,7 +203,6 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("decimal? DecimalValue { get; set; } = 99.99m");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Boolean_Defaults()
     {
@@ -268,7 +264,6 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("bool? IsDisabled { get; set; } = false");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Integer_Defaults()
     {
@@ -402,7 +397,6 @@ public class DynamicQueryStringParametersEdgeCasesTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Mixed_Escape_Characters()
     {
@@ -454,7 +448,6 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("string? ComplexString { get; set; } = \"path\\\\to\\\\file with \\\"quotes\\\"\\nand newlines\"");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Long_And_ULong_Defaults()
     {
@@ -518,7 +511,6 @@ public class DynamicQueryStringParametersEdgeCasesTests
         generatedCode.Should().Contain("ulong? UlongValue { get; set; } = 5000000000UL");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Dynamic_QueryString_With_Double_Integer_Value()
     {

--- a/src/Refitter.Tests/Scenarios/DynamicQueryStringParametersWithDefaultValuesTests.cs
+++ b/src/Refitter.Tests/Scenarios/DynamicQueryStringParametersWithDefaultValuesTests.cs
@@ -90,7 +90,6 @@ public class DynamicQueryStringParametersWithDefaultValuesTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -98,7 +97,6 @@ public class DynamicQueryStringParametersWithDefaultValuesTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Should_Have_Optional_Parameters_With_Default_Values()
     {
@@ -108,7 +106,6 @@ public class DynamicQueryStringParametersWithDefaultValuesTests
         generatedCode.Should().Contain("string? Filter { get; set; } = \"active\"");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Should_Have_Required_Parameters_Without_Defaults()
     {

--- a/src/Refitter.Tests/Scenarios/DynamicQueryStringParametersWithDefaultValuesTests.cs
+++ b/src/Refitter.Tests/Scenarios/DynamicQueryStringParametersWithDefaultValuesTests.cs
@@ -90,6 +90,7 @@ public class DynamicQueryStringParametersWithDefaultValuesTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -97,6 +98,7 @@ public class DynamicQueryStringParametersWithDefaultValuesTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Should_Have_Optional_Parameters_With_Default_Values()
     {
@@ -106,6 +108,7 @@ public class DynamicQueryStringParametersWithDefaultValuesTests
         generatedCode.Should().Contain("string? Filter { get; set; } = \"active\"");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Should_Have_Required_Parameters_Without_Defaults()
     {
@@ -116,6 +119,7 @@ public class DynamicQueryStringParametersWithDefaultValuesTests
         generatedCode.Should().NotContain("System.DateTimeOffset  End { get; set; } =");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {

--- a/src/Refitter.Tests/Scenarios/EmptyPathsTests.cs
+++ b/src/Refitter.Tests/Scenarios/EmptyPathsTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class EmptyPathsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/EmptyPathsTests.cs
+++ b/src/Refitter.Tests/Scenarios/EmptyPathsTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class EmptyPathsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ExcludeNamespacesTests.cs
+++ b/src/Refitter.Tests/Scenarios/ExcludeNamespacesTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class ExcludeNamespacesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ExcludeNamespacesTests.cs
+++ b/src/Refitter.Tests/Scenarios/ExcludeNamespacesTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class ExcludeNamespacesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/FileStreamResponseTests.cs
+++ b/src/Refitter.Tests/Scenarios/FileStreamResponseTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class FileStreamResponseTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/FileStreamResponseTests.cs
+++ b/src/Refitter.Tests/Scenarios/FileStreamResponseTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class FileStreamResponseTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/FilterByPathTests.cs
+++ b/src/Refitter.Tests/Scenarios/FilterByPathTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class FilterByPathTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/FilterByPathTests.cs
+++ b/src/Refitter.Tests/Scenarios/FilterByPathTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class FilterByPathTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/FilterByTagsTests.cs
+++ b/src/Refitter.Tests/Scenarios/FilterByTagsTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class FilterByTagsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/FilterByTagsTests.cs
+++ b/src/Refitter.Tests/Scenarios/FilterByTagsTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class FilterByTagsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/FormDataParameterCasingTests.cs
+++ b/src/Refitter.Tests/Scenarios/FormDataParameterCasingTests.cs
@@ -60,7 +60,6 @@ public class FormDataParameterCasingTests
 }
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -76,7 +75,6 @@ public class FormDataParameterCasingTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Multipart_Attribute()
     {
@@ -84,7 +82,6 @@ public class FormDataParameterCasingTests
         generatedCode.Should().Contain("[Multipart]");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task FormData_Parameters_Should_Have_AliasAs_Attribute()
     {

--- a/src/Refitter.Tests/Scenarios/FormDataParameterCasingTests.cs
+++ b/src/Refitter.Tests/Scenarios/FormDataParameterCasingTests.cs
@@ -60,6 +60,7 @@ public class FormDataParameterCasingTests
 }
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -67,6 +68,7 @@ public class FormDataParameterCasingTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {
@@ -74,6 +76,7 @@ public class FormDataParameterCasingTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Multipart_Attribute()
     {
@@ -81,6 +84,7 @@ public class FormDataParameterCasingTests
         generatedCode.Should().Contain("[Multipart]");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task FormData_Parameters_Should_Have_AliasAs_Attribute()
     {

--- a/src/Refitter.Tests/Scenarios/GenerateDefaultAdditionalPropertiesTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateDefaultAdditionalPropertiesTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class GenerateDefaultAdditionalPropertiesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/GenerateDefaultAdditionalPropertiesTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateDefaultAdditionalPropertiesTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class GenerateDefaultAdditionalPropertiesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/GenerateDisposableClientsEnhancedTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateDisposableClientsEnhancedTests.cs
@@ -53,6 +53,7 @@ components:
           type: string
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -60,6 +61,7 @@ components:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {
@@ -67,6 +69,7 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_IDisposable()
     {
@@ -75,6 +78,7 @@ components:
         generatedCode.Should().Contain("interface ITestAPI : IDisposable");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_IDisposable_When_Disabled()
     {
@@ -82,6 +86,7 @@ components:
         generatedCode.Should().NotContain(": IDisposable");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code_Without_Disposable()
     {
@@ -89,6 +94,7 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Disposable_Code_Contains_Using_System()
     {

--- a/src/Refitter.Tests/Scenarios/GenerateDisposableClientsEnhancedTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateDisposableClientsEnhancedTests.cs
@@ -53,7 +53,6 @@ components:
           type: string
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -69,7 +68,6 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_IDisposable()
     {
@@ -78,7 +76,6 @@ components:
         generatedCode.Should().Contain("interface ITestAPI : IDisposable");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_IDisposable_When_Disabled()
     {
@@ -94,7 +91,6 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Disposable_Code_Contains_Using_System()
     {

--- a/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class GenerateJsonSerializerContextPolymorphismTests
 {
     private const string OpenApiSpec = """

--- a/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class GenerateJsonSerializerContextPolymorphismTests
 {
     private const string OpenApiSpec = """

--- a/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextTests.cs
@@ -55,7 +55,6 @@ public class GenerateJsonSerializerContextTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -63,7 +62,6 @@ public class GenerateJsonSerializerContextTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_JsonSerializerContext()
     {
@@ -96,7 +94,6 @@ public class GenerateJsonSerializerContextTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_JsonSerializerContext_When_Disabled()
     {

--- a/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextTests.cs
@@ -55,6 +55,7 @@ public class GenerateJsonSerializerContextTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -62,6 +63,7 @@ public class GenerateJsonSerializerContextTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_JsonSerializerContext()
     {
@@ -71,6 +73,7 @@ public class GenerateJsonSerializerContextTests
         generatedCode.Should().Contain("internal partial class UsersApiSerializerContext : global::System.Text.Json.Serialization.JsonSerializerContext");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_JsonSerializerContext_Can_Build()
     {
@@ -79,6 +82,7 @@ public class GenerateJsonSerializerContextTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Separate_Contracts_Namespace_Can_Build()
     {
@@ -92,6 +96,7 @@ public class GenerateJsonSerializerContextTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_JsonSerializerContext_When_Disabled()
     {

--- a/src/Refitter.Tests/Scenarios/GenerateStatusCodeCommentsTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateStatusCodeCommentsTests.cs
@@ -94,6 +94,7 @@ paths:
 ";
 
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -101,6 +102,7 @@ paths:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {
@@ -108,6 +110,7 @@ paths:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Status_Code_Comments_When_Enabled()
     {
@@ -117,6 +120,7 @@ paths:
         generatedCode.Should().Contain("500");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_Status_Code_Comments_When_Disabled()
     {
@@ -133,6 +137,7 @@ paths:
         countWithout.Should().BeLessThan(countWith);
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Response_Descriptions_When_Comments_Enabled()
     {
@@ -141,6 +146,7 @@ paths:
         generatedCode.Should().Contain("Bad request");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Preserves_Readable_Unicode_In_Status_Code_Comments()
     {
@@ -151,6 +157,7 @@ paths:
             .And.NotContain(@"\u041e\u0448");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Preserves_Readable_Unicode_In_Status_Code_Comments_Swagger20()
     {
@@ -161,6 +168,7 @@ paths:
             .And.NotContain(@"\u041e\u0448");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Unicode_Status_Code_Comments_Can_Build()
     {

--- a/src/Refitter.Tests/Scenarios/GenerateStatusCodeCommentsTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateStatusCodeCommentsTests.cs
@@ -94,7 +94,6 @@ paths:
 ";
 
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -110,7 +109,6 @@ paths:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Status_Code_Comments_When_Enabled()
     {
@@ -120,7 +118,6 @@ paths:
         generatedCode.Should().Contain("500");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_Status_Code_Comments_When_Disabled()
     {
@@ -137,7 +134,6 @@ paths:
         countWithout.Should().BeLessThan(countWith);
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Response_Descriptions_When_Comments_Enabled()
     {
@@ -146,7 +142,6 @@ paths:
         generatedCode.Should().Contain("Bad request");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Preserves_Readable_Unicode_In_Status_Code_Comments()
     {
@@ -157,7 +152,6 @@ paths:
             .And.NotContain(@"\u041e\u0448");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Preserves_Readable_Unicode_In_Status_Code_Comments_Swagger20()
     {

--- a/src/Refitter.Tests/Scenarios/HyphenatedEnumValuesTests.cs
+++ b/src/Refitter.Tests/Scenarios/HyphenatedEnumValuesTests.cs
@@ -16,6 +16,8 @@ namespace Refitter.Tests.Scenarios;
 /// so users can override it via JsonSerializerOptions.Converters with a converter that
 /// respects [EnumMember] (e.g. JsonStringEnumMemberConverter).
 /// </summary>
+
+[Category("Unit")]
 public class HyphenatedEnumValuesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/HyphenatedEnumValuesTests.cs
+++ b/src/Refitter.Tests/Scenarios/HyphenatedEnumValuesTests.cs
@@ -17,7 +17,6 @@ namespace Refitter.Tests.Scenarios;
 /// respects [EnumMember] (e.g. JsonStringEnumMemberConverter).
 /// </summary>
 
-[Category("Unit")]
 public class HyphenatedEnumValuesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/IdentifierCorrectnessTests.cs
+++ b/src/Refitter.Tests/Scenarios/IdentifierCorrectnessTests.cs
@@ -55,6 +55,7 @@ public class IdentifierCorrectnessTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Invalid_Multipart_Identifiers()
     {
@@ -62,6 +63,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Multipart_LeadingDigit_Identifiers_Are_Prefixed()
     {
@@ -70,6 +72,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("string 123File");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Multipart_ReservedKeyword_Identifiers_Are_Escaped()
     {
@@ -78,6 +81,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().Contain("@event");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Multipart_SpecialChar_Identifiers_Are_Sanitized()
     {
@@ -86,6 +90,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("string !special");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Invalid_Multipart_Identifiers_Compiles()
     {
@@ -141,6 +146,7 @@ public class IdentifierCorrectnessTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Invalid_Security_Identifiers()
     {
@@ -150,6 +156,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task SecurityScheme_LeadingDigit_Identifiers_Are_Prefixed()
     {
@@ -160,6 +167,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("string 1Token");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task SecurityScheme_ReservedKeyword_Identifiers_Are_Escaped()
     {
@@ -169,6 +177,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().Contain("@class");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Invalid_Security_Identifiers_Compiles()
     {
@@ -222,6 +231,7 @@ public class IdentifierCorrectnessTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Querystring_Leading_NonLetter()
     {
@@ -231,6 +241,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_With_Querystring_Leading_NonLetter_Uses_This_Qualifier()
     {
@@ -242,6 +253,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().Contain("this._foo = _foo;");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Querystring_Leading_NonLetter_Compiles()
     {
@@ -298,6 +310,7 @@ public class IdentifierCorrectnessTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Generic_Parameters()
     {
@@ -305,6 +318,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generic_Dictionary_Parameter_Not_Misclassified_As_Nullable()
     {
@@ -315,6 +329,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("IDictionary<string, string?> filters = default");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Generic_Parameters_Compiles()
     {
@@ -373,6 +388,7 @@ public class IdentifierCorrectnessTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Invalid_Multipart_Identifiers_Swagger2()
     {
@@ -380,6 +396,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Multipart_LeadingDigit_Identifiers_Are_Prefixed_Swagger2()
     {
@@ -388,6 +405,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("string 123File");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Multipart_ReservedKeyword_Identifiers_Are_Escaped_Swagger2()
     {
@@ -396,6 +414,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().Contain("@event");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Multipart_SpecialChar_Identifiers_Are_Sanitized_Swagger2()
     {
@@ -404,6 +423,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("string !special");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Invalid_Multipart_Identifiers_Compiles_Swagger2()
     {
@@ -459,6 +479,7 @@ public class IdentifierCorrectnessTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Invalid_Security_Identifiers_Swagger2()
     {
@@ -468,6 +489,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task SecurityScheme_LeadingDigit_Identifiers_Are_Prefixed_Swagger2()
     {
@@ -478,6 +500,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("string 1Token");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task SecurityScheme_ReservedKeyword_Identifiers_Are_Escaped_Swagger2()
     {
@@ -487,6 +510,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().Contain("@class");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Invalid_Security_Identifiers_Compiles_Swagger2()
     {
@@ -538,6 +562,7 @@ public class IdentifierCorrectnessTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Querystring_Leading_NonLetter_Swagger2()
     {
@@ -547,6 +572,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_With_Querystring_Leading_NonLetter_Uses_This_Qualifier_Swagger2()
     {
@@ -558,6 +584,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().Contain("this._foo = _foo;");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Querystring_Leading_NonLetter_Compiles_Swagger2()
     {
@@ -612,6 +639,7 @@ public class IdentifierCorrectnessTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Generic_Parameters_Swagger2()
     {
@@ -619,6 +647,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generic_Dictionary_Parameter_Not_Misclassified_As_Nullable_Swagger2()
     {
@@ -629,6 +658,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("IDictionary<string, string?> filters = default");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Generic_Parameters_Compiles_Swagger2()
     {
@@ -673,6 +703,7 @@ public class IdentifierCorrectnessTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Optional_Parameter_With_Unsanitized_Name_Falls_Back_To_Sanitized_Variable_Name()
     {
@@ -684,6 +715,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().Contain("\"abc\"");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Unsanitized_Parameter_Name_Compiles()
     {
@@ -731,6 +763,7 @@ public class IdentifierCorrectnessTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Optional_Parameter_With_Unsanitized_Name_Falls_Back_To_Sanitized_Variable_Name_Swagger2()
     {
@@ -742,6 +775,7 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().Contain("\"abc\"");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Unsanitized_Parameter_Name_Compiles_Swagger2()
     {
@@ -756,6 +790,7 @@ public class IdentifierCorrectnessTests
 
     #region Issue #1037 - Empty Namespace List Crash
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Empty_Namespace_List()
     {
@@ -790,6 +825,7 @@ public class IdentifierCorrectnessTests
 
     #region Issue #1053 - Reserved Keyword Escaping
 
+    [Category("Unit")]
     [Test]
     public void Sanitize_Escapes_Underscore_Keywords()
     {
@@ -799,6 +835,7 @@ public class IdentifierCorrectnessTests
         "__refvalue".Sanitize().Should().Be("@__refvalue");
     }
 
+    [Category("Unit")]
     [Test]
     public void Sanitize_Escapes_Common_Keywords()
     {

--- a/src/Refitter.Tests/Scenarios/IdentifierCorrectnessTests.cs
+++ b/src/Refitter.Tests/Scenarios/IdentifierCorrectnessTests.cs
@@ -55,7 +55,6 @@ public class IdentifierCorrectnessTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Invalid_Multipart_Identifiers()
     {
@@ -63,7 +62,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Multipart_LeadingDigit_Identifiers_Are_Prefixed()
     {
@@ -72,7 +70,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("string 123File");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Multipart_ReservedKeyword_Identifiers_Are_Escaped()
     {
@@ -81,7 +78,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().Contain("@event");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Multipart_SpecialChar_Identifiers_Are_Sanitized()
     {
@@ -146,7 +142,6 @@ public class IdentifierCorrectnessTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Invalid_Security_Identifiers()
     {
@@ -156,7 +151,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task SecurityScheme_LeadingDigit_Identifiers_Are_Prefixed()
     {
@@ -167,7 +161,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("string 1Token");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task SecurityScheme_ReservedKeyword_Identifiers_Are_Escaped()
     {
@@ -231,7 +224,6 @@ public class IdentifierCorrectnessTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Querystring_Leading_NonLetter()
     {
@@ -241,7 +233,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_With_Querystring_Leading_NonLetter_Uses_This_Qualifier()
     {
@@ -310,7 +301,6 @@ public class IdentifierCorrectnessTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Generic_Parameters()
     {
@@ -318,7 +308,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generic_Dictionary_Parameter_Not_Misclassified_As_Nullable()
     {
@@ -388,7 +377,6 @@ public class IdentifierCorrectnessTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Invalid_Multipart_Identifiers_Swagger2()
     {
@@ -396,7 +384,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Multipart_LeadingDigit_Identifiers_Are_Prefixed_Swagger2()
     {
@@ -405,7 +392,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("string 123File");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Multipart_ReservedKeyword_Identifiers_Are_Escaped_Swagger2()
     {
@@ -414,7 +400,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().Contain("@event");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Multipart_SpecialChar_Identifiers_Are_Sanitized_Swagger2()
     {
@@ -479,7 +464,6 @@ public class IdentifierCorrectnessTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Invalid_Security_Identifiers_Swagger2()
     {
@@ -489,7 +473,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task SecurityScheme_LeadingDigit_Identifiers_Are_Prefixed_Swagger2()
     {
@@ -500,7 +483,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotContain("string 1Token");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task SecurityScheme_ReservedKeyword_Identifiers_Are_Escaped_Swagger2()
     {
@@ -562,7 +544,6 @@ public class IdentifierCorrectnessTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Querystring_Leading_NonLetter_Swagger2()
     {
@@ -572,7 +553,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_With_Querystring_Leading_NonLetter_Uses_This_Qualifier_Swagger2()
     {
@@ -639,7 +619,6 @@ public class IdentifierCorrectnessTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Generic_Parameters_Swagger2()
     {
@@ -647,7 +626,6 @@ public class IdentifierCorrectnessTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generic_Dictionary_Parameter_Not_Misclassified_As_Nullable_Swagger2()
     {
@@ -703,7 +681,6 @@ public class IdentifierCorrectnessTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Optional_Parameter_With_Unsanitized_Name_Falls_Back_To_Sanitized_Variable_Name()
     {
@@ -763,7 +740,6 @@ public class IdentifierCorrectnessTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Optional_Parameter_With_Unsanitized_Name_Falls_Back_To_Sanitized_Variable_Name_Swagger2()
     {
@@ -790,7 +766,6 @@ public class IdentifierCorrectnessTests
 
     #region Issue #1037 - Empty Namespace List Crash
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Empty_Namespace_List()
     {
@@ -825,7 +800,6 @@ public class IdentifierCorrectnessTests
 
     #region Issue #1053 - Reserved Keyword Escaping
 
-    [Category("Unit")]
     [Test]
     public void Sanitize_Escapes_Underscore_Keywords()
     {
@@ -835,7 +809,6 @@ public class IdentifierCorrectnessTests
         "__refvalue".Sanitize().Should().Be("@__refvalue");
     }
 
-    [Category("Unit")]
     [Test]
     public void Sanitize_Escapes_Common_Keywords()
     {

--- a/src/Refitter.Tests/Scenarios/ImmutableRecordsWithPolymorphicSerializationTests.cs
+++ b/src/Refitter.Tests/Scenarios/ImmutableRecordsWithPolymorphicSerializationTests.cs
@@ -67,6 +67,7 @@ components:
               type: string
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -74,6 +75,7 @@ components:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {
@@ -81,6 +83,7 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Record_Keyword()
     {
@@ -88,6 +91,7 @@ components:
         generatedCode.Should().Contain("record ");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_JsonPolymorphic_Attribute()
     {

--- a/src/Refitter.Tests/Scenarios/ImmutableRecordsWithPolymorphicSerializationTests.cs
+++ b/src/Refitter.Tests/Scenarios/ImmutableRecordsWithPolymorphicSerializationTests.cs
@@ -67,7 +67,6 @@ components:
               type: string
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -83,7 +82,6 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Record_Keyword()
     {
@@ -91,7 +89,6 @@ components:
         generatedCode.Should().Contain("record ");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_JsonPolymorphic_Attribute()
     {

--- a/src/Refitter.Tests/Scenarios/IncludeInheritanceHierarchyTests.cs
+++ b/src/Refitter.Tests/Scenarios/IncludeInheritanceHierarchyTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios
 {
-    [Category("Unit")]
     public class IncludeInheritanceHierarchyTests
     {
         private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/IncludeInheritanceHierarchyTests.cs
+++ b/src/Refitter.Tests/Scenarios/IncludeInheritanceHierarchyTests.cs
@@ -6,6 +6,7 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios
 {
+    [Category("Unit")]
     public class IncludeInheritanceHierarchyTests
     {
         private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/InlineJsonConvertersTests.cs
+++ b/src/Refitter.Tests/Scenarios/InlineJsonConvertersTests.cs
@@ -10,7 +10,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class InlineJsonConvertersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/InlineJsonConvertersTests.cs
+++ b/src/Refitter.Tests/Scenarios/InlineJsonConvertersTests.cs
@@ -9,6 +9,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class InlineJsonConvertersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/Int32FormatWithPatternTests.cs
+++ b/src/Refitter.Tests/Scenarios/Int32FormatWithPatternTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class Int32FormatWithPatternTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/Int32FormatWithPatternTests.cs
+++ b/src/Refitter.Tests/Scenarios/Int32FormatWithPatternTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class Int32FormatWithPatternTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/IntegerFormatTests.cs
+++ b/src/Refitter.Tests/Scenarios/IntegerFormatTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class IntegerFormatTests
 {
     private const string OpenApiSpec =

--- a/src/Refitter.Tests/Scenarios/IntegerFormatTests.cs
+++ b/src/Refitter.Tests/Scenarios/IntegerFormatTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class IntegerFormatTests
 {
     private const string OpenApiSpec =

--- a/src/Refitter.Tests/Scenarios/InterfaceOnlyTests.cs
+++ b/src/Refitter.Tests/Scenarios/InterfaceOnlyTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class InterfaceOnlyTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/InterfaceOnlyTests.cs
+++ b/src/Refitter.Tests/Scenarios/InterfaceOnlyTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class InterfaceOnlyTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/JsonLibraryVersionTests.cs
+++ b/src/Refitter.Tests/Scenarios/JsonLibraryVersionTests.cs
@@ -14,7 +14,6 @@ namespace Refitter.Tests.Scenarios;
 /// When JsonLibraryVersion is 8.0 or below (default), enums use [EnumMember] attributes.
 /// </summary>
 
-[Category("Unit")]
 public class JsonLibraryVersionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/JsonLibraryVersionTests.cs
+++ b/src/Refitter.Tests/Scenarios/JsonLibraryVersionTests.cs
@@ -13,6 +13,8 @@ namespace Refitter.Tests.Scenarios;
 /// (requires NSwag/NJsonSchema version that supports this in their Enum.liquid template).
 /// When JsonLibraryVersion is 8.0 or below (default), enums use [EnumMember] attributes.
 /// </summary>
+
+[Category("Unit")]
 public class JsonLibraryVersionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/KebabCaseTests.cs
+++ b/src/Refitter.Tests/Scenarios/KebabCaseTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class KebabCaseTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/KebabCaseTests.cs
+++ b/src/Refitter.Tests/Scenarios/KebabCaseTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class KebabCaseTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/KeepSchemaPatternsTests.cs
+++ b/src/Refitter.Tests/Scenarios/KeepSchemaPatternsTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class KeepSchemaPatternsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/KeepSchemaPatternsTests.cs
+++ b/src/Refitter.Tests/Scenarios/KeepSchemaPatternsTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class KeepSchemaPatternsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MissingParameterDescriptionTests.cs
+++ b/src/Refitter.Tests/Scenarios/MissingParameterDescriptionTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class MissingParameterDescriptionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MissingParameterDescriptionTests.cs
+++ b/src/Refitter.Tests/Scenarios/MissingParameterDescriptionTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class MissingParameterDescriptionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultiPartFormDataArrayTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultiPartFormDataArrayTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class MultiPartFormDataArrayTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultiPartFormDataArrayTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultiPartFormDataArrayTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class MultiPartFormDataArrayTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultiPartFormDataTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultiPartFormDataTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class MultiPartFormDataTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultiPartFormDataTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultiPartFormDataTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class MultiPartFormDataTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleFilesWithDependencyInjectionTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleFilesWithDependencyInjectionTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class MultipleFilesWithDependencyInjectionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleFilesWithDependencyInjectionTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleFilesWithDependencyInjectionTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class MultipleFilesWithDependencyInjectionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class MultipleInterfacesByEndpointTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class MultipleInterfacesByEndpointTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointWithIoCTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointWithIoCTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class MultipleInterfacesByEndpointWithIoCTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointWithIoCTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointWithIoCTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class MultipleInterfacesByEndpointWithIoCTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointWithOperationNameTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointWithOperationNameTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class MultipleInterfacesByEndpointWithOperationNameTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointWithOperationNameTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByEndpointWithOperationNameTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class MultipleInterfacesByEndpointWithOperationNameTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagMethodNamingTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagMethodNamingTests.cs
@@ -11,7 +11,6 @@ namespace Refitter.Tests.Scenarios;
 /// https://github.com/christianhelle/refitter/issues/672
 /// </summary>
 
-[Category("Unit")]
 public class MultipleInterfacesByTagMethodNamingTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagMethodNamingTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagMethodNamingTests.cs
@@ -10,6 +10,8 @@ namespace Refitter.Tests.Scenarios;
 /// Test for Issue #672: Method naming increments globally instead of per-interface
 /// https://github.com/christianhelle/refitter/issues/672
 /// </summary>
+
+[Category("Unit")]
 public class MultipleInterfacesByTagMethodNamingTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagWithDependencyInjectionTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagWithDependencyInjectionTests.cs
@@ -75,6 +75,7 @@ components:
           type: string
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -82,6 +83,7 @@ components:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {
@@ -89,6 +91,7 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Multiple_Interfaces()
     {
@@ -97,6 +100,7 @@ components:
         interfaceCount.Should().BeGreaterThan(1);
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_DI_Registration()
     {

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagWithDependencyInjectionTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagWithDependencyInjectionTests.cs
@@ -75,7 +75,6 @@ components:
           type: string
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -91,7 +90,6 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Multiple_Interfaces()
     {
@@ -100,7 +98,6 @@ components:
         interfaceCount.Should().BeGreaterThan(1);
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_DI_Registration()
     {

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagsTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagsTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class MultipleInterfacesByTagsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagsTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagsTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class MultipleInterfacesByTagsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagsWithSamePathSegmentTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagsWithSamePathSegmentTests.cs
@@ -11,6 +11,8 @@ namespace Refitter.Tests.Scenarios;
 /// When using ByTag, method names should not have numeric suffixes added for
 /// cross-interface uniqueness - deduplication should be per-interface.
 /// </summary>
+
+[Category("Unit")]
 public class MultipleInterfacesByTagsWithSamePathSegmentTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagsWithSamePathSegmentTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagsWithSamePathSegmentTests.cs
@@ -12,7 +12,6 @@ namespace Refitter.Tests.Scenarios;
 /// cross-interface uniqueness - deduplication should be per-interface.
 /// </summary>
 
-[Category("Unit")]
 public class MultipleInterfacesByTagsWithSamePathSegmentTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleOpenApiPathsTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleOpenApiPathsTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class MultipleOpenApiPathsTests
 {
     private const string PetstoreV1Spec = @"openapi: '3.0.0'

--- a/src/Refitter.Tests/Scenarios/MultipleOpenApiPathsTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleOpenApiPathsTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class MultipleOpenApiPathsTests
 {
     private const string PetstoreV1Spec = @"openapi: '3.0.0'

--- a/src/Refitter.Tests/Scenarios/MultipleSuccessResponsesTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleSuccessResponsesTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class MultipleSuccessResponsesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MultipleSuccessResponsesTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleSuccessResponsesTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class MultipleSuccessResponsesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MutuallyExclusiveSettingsTests.cs
+++ b/src/Refitter.Tests/Scenarios/MutuallyExclusiveSettingsTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class MutuallyExclusiveSettingsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/MutuallyExclusiveSettingsTests.cs
+++ b/src/Refitter.Tests/Scenarios/MutuallyExclusiveSettingsTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class MutuallyExclusiveSettingsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/NamingSettingsTests.cs
+++ b/src/Refitter.Tests/Scenarios/NamingSettingsTests.cs
@@ -37,6 +37,7 @@ components:
           type: string
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -44,6 +45,7 @@ components:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {
@@ -51,6 +53,7 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Uses_OpenApi_Title_As_Interface_Name()
     {
@@ -58,6 +61,7 @@ components:
         generatedCode.Should().Contain("interface IPetStore");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Uses_Custom_Interface_Name()
     {
@@ -65,6 +69,7 @@ components:
         generatedCode.Should().Contain("interface IMyCustomApi");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Uses_Default_Interface_Name_When_Not_Configured()
     {
@@ -72,6 +77,7 @@ components:
         generatedCode.Should().Contain("interface IApiClient");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Custom_Interface_Name_Takes_Precedence_Over_OpenApi_Title()
     {

--- a/src/Refitter.Tests/Scenarios/NamingSettingsTests.cs
+++ b/src/Refitter.Tests/Scenarios/NamingSettingsTests.cs
@@ -37,7 +37,6 @@ components:
           type: string
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -53,7 +52,6 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Uses_OpenApi_Title_As_Interface_Name()
     {
@@ -61,7 +59,6 @@ components:
         generatedCode.Should().Contain("interface IPetStore");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Uses_Custom_Interface_Name()
     {
@@ -69,7 +66,6 @@ components:
         generatedCode.Should().Contain("interface IMyCustomApi");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Uses_Default_Interface_Name_When_Not_Configured()
     {
@@ -77,7 +73,6 @@ components:
         generatedCode.Should().Contain("interface IApiClient");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Custom_Interface_Name_Takes_Precedence_Over_OpenApi_Title()
     {

--- a/src/Refitter.Tests/Scenarios/NewlineInParameterDescriptionJsonTests.cs
+++ b/src/Refitter.Tests/Scenarios/NewlineInParameterDescriptionJsonTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class NewlineInParameterDescriptionJsonTests
 {
     private const string OpenApiSpec =

--- a/src/Refitter.Tests/Scenarios/NewlineInParameterDescriptionJsonTests.cs
+++ b/src/Refitter.Tests/Scenarios/NewlineInParameterDescriptionJsonTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class NewlineInParameterDescriptionJsonTests
 {
     private const string OpenApiSpec =

--- a/src/Refitter.Tests/Scenarios/NewlineInParameterDescriptionYamlTests.cs
+++ b/src/Refitter.Tests/Scenarios/NewlineInParameterDescriptionYamlTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class NewlineInParameterDescriptionYamlTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/NewlineInParameterDescriptionYamlTests.cs
+++ b/src/Refitter.Tests/Scenarios/NewlineInParameterDescriptionYamlTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class NewlineInParameterDescriptionYamlTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/NoContentApiResponseTests.cs
+++ b/src/Refitter.Tests/Scenarios/NoContentApiResponseTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class NoContentApiResponseTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/NoContentApiResponseTests.cs
+++ b/src/Refitter.Tests/Scenarios/NoContentApiResponseTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class NoContentApiResponseTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/NullableStringPropertyTests.cs
+++ b/src/Refitter.Tests/Scenarios/NullableStringPropertyTests.cs
@@ -11,7 +11,6 @@ namespace Refitter.Tests.Scenarios;
 /// https://github.com/christianhelle/refitter/issues/580
 /// </summary>
 
-[Category("Unit")]
 public class NullableStringPropertyTests
 {
     private const string OpenApiSpecWithNullableProperties = @"

--- a/src/Refitter.Tests/Scenarios/NullableStringPropertyTests.cs
+++ b/src/Refitter.Tests/Scenarios/NullableStringPropertyTests.cs
@@ -10,6 +10,8 @@ namespace Refitter.Tests.Scenarios;
 /// Test for Issue #580: Nullable string properties should generate with string? (not string)
 /// https://github.com/christianhelle/refitter/issues/580
 /// </summary>
+
+[Category("Unit")]
 public class NullableStringPropertyTests
 {
     private const string OpenApiSpecWithNullableProperties = @"

--- a/src/Refitter.Tests/Scenarios/NumericFormatWithPatternTests.cs
+++ b/src/Refitter.Tests/Scenarios/NumericFormatWithPatternTests.cs
@@ -2,9 +2,11 @@ using FluentAssertions;
 using Refitter.Core;
 using Refitter.Tests.Build;
 using Refitter.Tests.TestUtilities;
+using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios
 {
+    [Category("Unit")]
     public class NumericFormatWithPatternTests
     {
         private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/NumericFormatWithPatternTests.cs
+++ b/src/Refitter.Tests/Scenarios/NumericFormatWithPatternTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios
 {
-    [Category("Unit")]
     public class NumericFormatWithPatternTests
     {
         private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/OctetStreamBodyTests.cs
+++ b/src/Refitter.Tests/Scenarios/OctetStreamBodyTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class OctetStreamBodyTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/OctetStreamBodyTests.cs
+++ b/src/Refitter.Tests/Scenarios/OctetStreamBodyTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class OctetStreamBodyTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/OneOfDiscriminatorTests.cs
+++ b/src/Refitter.Tests/Scenarios/OneOfDiscriminatorTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class OneOfDiscriminatorTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/OneOfDiscriminatorTests.cs
+++ b/src/Refitter.Tests/Scenarios/OneOfDiscriminatorTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class OneOfDiscriminatorTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/OpenApiUrlTests.cs
+++ b/src/Refitter.Tests/Scenarios/OpenApiUrlTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class OpenApiUrlTests
 {
     [Test]

--- a/src/Refitter.Tests/Scenarios/OpenApiUrlTests.cs
+++ b/src/Refitter.Tests/Scenarios/OpenApiUrlTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class OpenApiUrlTests
 {
     [Test]

--- a/src/Refitter.Tests/Scenarios/OperationIdWithInvalidFirstCharTests.cs
+++ b/src/Refitter.Tests/Scenarios/OperationIdWithInvalidFirstCharTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class OperationIdWithInvalidFirstCharTests
 {
 

--- a/src/Refitter.Tests/Scenarios/OperationIdWithInvalidFirstCharTests.cs
+++ b/src/Refitter.Tests/Scenarios/OperationIdWithInvalidFirstCharTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class OperationIdWithInvalidFirstCharTests
 {
 

--- a/src/Refitter.Tests/Scenarios/OperationIdWithSpacesTests.cs
+++ b/src/Refitter.Tests/Scenarios/OperationIdWithSpacesTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class OperationIdWithSpacesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/OperationIdWithSpacesTests.cs
+++ b/src/Refitter.Tests/Scenarios/OperationIdWithSpacesTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class OperationIdWithSpacesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/OperationNameGeneratorTypesTests.cs
+++ b/src/Refitter.Tests/Scenarios/OperationNameGeneratorTypesTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class OperationNameGeneratorTypesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/OperationNameGeneratorTypesTests.cs
+++ b/src/Refitter.Tests/Scenarios/OperationNameGeneratorTypesTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class OperationNameGeneratorTypesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/OptionalNullableParametersTests.cs
+++ b/src/Refitter.Tests/Scenarios/OptionalNullableParametersTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class OptionalNullableParametersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/OptionalNullableParametersTests.cs
+++ b/src/Refitter.Tests/Scenarios/OptionalNullableParametersTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class OptionalNullableParametersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/OptionalParametersWithDefaultValuesEdgeCasesTests.cs
+++ b/src/Refitter.Tests/Scenarios/OptionalParametersWithDefaultValuesEdgeCasesTests.cs
@@ -8,7 +8,6 @@ namespace Refitter.Tests.Scenarios;
 
 public class OptionalParametersWithDefaultValuesEdgeCasesTests
 {
-    [Category("Unit")]
     [Test]
     public async Task String_Default_Values_Should_Be_Escaped()
     {
@@ -72,7 +71,6 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("string? newlineString = \"line1\\nline2\"");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task String_Default_Values_With_All_Escape_Characters_Should_Be_Escaped()
     {
@@ -136,7 +134,6 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("string? allSpecialChars = \"test\\n\\r\\t\\\\\\\"\"");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Float_Default_Values_Should_Have_Type_Suffix()
     {
@@ -181,7 +178,6 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("float? floatValue = 1.5f");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Decimal_Default_Values_Should_Have_Type_Suffix()
     {
@@ -321,7 +317,6 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Integer_Default_Values_Should_Not_Have_Suffix()
     {
@@ -377,7 +372,6 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("long? longValue = 9999");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Double_Default_Values_Should_Have_Decimal_Point()
     {
@@ -434,7 +428,6 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("double? doubleIntValue = 10.0");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Boolean_Default_Values_Should_Be_Lowercase()
     {
@@ -488,7 +481,6 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("bool? isDisabled = false");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Empty_String_Default_Value_Should_Be_Handled()
     {
@@ -532,7 +524,6 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("string? emptyString = \"\"");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Mixed_Escape_Sequences_Should_Be_Handled()
     {
@@ -576,7 +567,6 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("string? complexString = \"path\\\\to\\\\file with \\\"quotes\\\" and\\nnewlines\\tand tabs\"");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Long_And_ULong_Default_Values_Should_Have_Suffixes()
     {

--- a/src/Refitter.Tests/Scenarios/OptionalParametersWithDefaultValuesEdgeCasesTests.cs
+++ b/src/Refitter.Tests/Scenarios/OptionalParametersWithDefaultValuesEdgeCasesTests.cs
@@ -8,6 +8,7 @@ namespace Refitter.Tests.Scenarios;
 
 public class OptionalParametersWithDefaultValuesEdgeCasesTests
 {
+    [Category("Unit")]
     [Test]
     public async Task String_Default_Values_Should_Be_Escaped()
     {
@@ -71,6 +72,7 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("string? newlineString = \"line1\\nline2\"");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task String_Default_Values_With_All_Escape_Characters_Should_Be_Escaped()
     {
@@ -134,6 +136,7 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("string? allSpecialChars = \"test\\n\\r\\t\\\\\\\"\"");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Float_Default_Values_Should_Have_Type_Suffix()
     {
@@ -178,6 +181,7 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("float? floatValue = 1.5f");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Decimal_Default_Values_Should_Have_Type_Suffix()
     {
@@ -222,6 +226,7 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("decimal? decimalValue = 99.99m");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Escaped_Strings_Should_Build()
     {
@@ -263,6 +268,7 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Generated_Code_With_Float_Decimal_Should_Build()
     {
@@ -315,6 +321,7 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Integer_Default_Values_Should_Not_Have_Suffix()
     {
@@ -370,6 +377,7 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("long? longValue = 9999");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Double_Default_Values_Should_Have_Decimal_Point()
     {
@@ -426,6 +434,7 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("double? doubleIntValue = 10.0");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Boolean_Default_Values_Should_Be_Lowercase()
     {
@@ -479,6 +488,7 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("bool? isDisabled = false");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Empty_String_Default_Value_Should_Be_Handled()
     {
@@ -522,6 +532,7 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("string? emptyString = \"\"");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Mixed_Escape_Sequences_Should_Be_Handled()
     {
@@ -565,6 +576,7 @@ public class OptionalParametersWithDefaultValuesEdgeCasesTests
         generatedCode.Should().Contain("string? complexString = \"path\\\\to\\\\file with \\\"quotes\\\" and\\nnewlines\\tand tabs\"");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Long_And_ULong_Default_Values_Should_Have_Suffixes()
     {

--- a/src/Refitter.Tests/Scenarios/OptionalParametersWithDefaultValuesTests.cs
+++ b/src/Refitter.Tests/Scenarios/OptionalParametersWithDefaultValuesTests.cs
@@ -90,6 +90,7 @@ public class OptionalParametersWithDefaultValuesTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -97,6 +98,7 @@ public class OptionalParametersWithDefaultValuesTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Should_Have_Optional_Parameters_With_Default_Values()
     {
@@ -106,6 +108,7 @@ public class OptionalParametersWithDefaultValuesTests
         generatedCode.Should().Contain("string? filter = \"active\"");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Should_Have_Required_Parameters_Without_Defaults()
     {
@@ -116,6 +119,7 @@ public class OptionalParametersWithDefaultValuesTests
         generatedCode.Should().NotContain("System.DateTimeOffset end =");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {

--- a/src/Refitter.Tests/Scenarios/OptionalParametersWithDefaultValuesTests.cs
+++ b/src/Refitter.Tests/Scenarios/OptionalParametersWithDefaultValuesTests.cs
@@ -90,7 +90,6 @@ public class OptionalParametersWithDefaultValuesTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -98,7 +97,6 @@ public class OptionalParametersWithDefaultValuesTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Should_Have_Optional_Parameters_With_Default_Values()
     {
@@ -108,7 +106,6 @@ public class OptionalParametersWithDefaultValuesTests
         generatedCode.Should().Contain("string? filter = \"active\"");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Should_Have_Required_Parameters_Without_Defaults()
     {

--- a/src/Refitter.Tests/Scenarios/PathParametersTests.cs
+++ b/src/Refitter.Tests/Scenarios/PathParametersTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class PathParametersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/PathParametersTests.cs
+++ b/src/Refitter.Tests/Scenarios/PathParametersTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class PathParametersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/PercentageCharacterTests.cs
+++ b/src/Refitter.Tests/Scenarios/PercentageCharacterTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class PercentageCharacterTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/PercentageCharacterTests.cs
+++ b/src/Refitter.Tests/Scenarios/PercentageCharacterTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class PercentageCharacterTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/PolymorphicSerializationWithCollectionFormatTests.cs
+++ b/src/Refitter.Tests/Scenarios/PolymorphicSerializationWithCollectionFormatTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class PolymorphicSerializationWithCollectionFormatTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/PolymorphicSerializationWithCollectionFormatTests.cs
+++ b/src/Refitter.Tests/Scenarios/PolymorphicSerializationWithCollectionFormatTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class PolymorphicSerializationWithCollectionFormatTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/PoorOperationIdsTests.cs
+++ b/src/Refitter.Tests/Scenarios/PoorOperationIdsTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class PoorOperationIdsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/PoorOperationIdsTests.cs
+++ b/src/Refitter.Tests/Scenarios/PoorOperationIdsTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class PoorOperationIdsTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/PropertyNamingPolicyTests.cs
+++ b/src/Refitter.Tests/Scenarios/PropertyNamingPolicyTests.cs
@@ -209,6 +209,7 @@ public class PropertyNamingPolicyTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Default_PascalCase_Property_Naming()
     {
@@ -216,6 +217,7 @@ public class PropertyNamingPolicyTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Default_PascalCase_Property_Naming_Remains_Unchanged()
     {
@@ -224,6 +226,7 @@ public class PropertyNamingPolicyTests
         generatedCode.Should().Contain("""[JsonPropertyName("node_id")]""");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Default_PascalCase_Minimally_Sanitizes_Invalid_Identifiers()
     {
@@ -231,6 +234,7 @@ public class PropertyNamingPolicyTests
         generatedCode.Should().Contain("public string _1stNode { get; set; }");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Default_PascalCase_Minimally_Sanitizes_Invalid_Identifiers_OpenApi2()
     {
@@ -239,6 +243,7 @@ public class PropertyNamingPolicyTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task PreserveOriginal_Emits_Raw_Valid_Identifiers()
     {
@@ -246,6 +251,7 @@ public class PropertyNamingPolicyTests
         generatedCode.Should().Contain("public int node_id { get; set; }");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task PreserveOriginal_Escapes_Reserved_Keywords()
     {
@@ -253,6 +259,7 @@ public class PropertyNamingPolicyTests
         generatedCode.Should().Contain("public string @class { get; set; }");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task PreserveOriginal_Minimally_Sanitizes_Invalid_Identifiers()
     {
@@ -260,6 +267,7 @@ public class PropertyNamingPolicyTests
         generatedCode.Should().Contain("_1st_node { get; set; }");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task PreserveOriginal_Generated_Code_With_Recursive_Schemas_Can_Build()
     {
@@ -267,6 +275,7 @@ public class PropertyNamingPolicyTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Default_PascalCase_Property_Naming_Prefixes_Digit_Prefixed_Properties()
     {
@@ -275,6 +284,7 @@ public class PropertyNamingPolicyTests
         generatedCode.Should().Contain("_42QuestionField { get; set; }");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Default_PascalCase_Digit_Prefixed_Properties_Can_Build()
     {

--- a/src/Refitter.Tests/Scenarios/PropertyNamingPolicyTests.cs
+++ b/src/Refitter.Tests/Scenarios/PropertyNamingPolicyTests.cs
@@ -209,7 +209,6 @@ public class PropertyNamingPolicyTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_With_Default_PascalCase_Property_Naming()
     {
@@ -217,7 +216,6 @@ public class PropertyNamingPolicyTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Default_PascalCase_Property_Naming_Remains_Unchanged()
     {
@@ -226,7 +224,6 @@ public class PropertyNamingPolicyTests
         generatedCode.Should().Contain("""[JsonPropertyName("node_id")]""");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Default_PascalCase_Minimally_Sanitizes_Invalid_Identifiers()
     {
@@ -243,7 +240,6 @@ public class PropertyNamingPolicyTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task PreserveOriginal_Emits_Raw_Valid_Identifiers()
     {
@@ -251,7 +247,6 @@ public class PropertyNamingPolicyTests
         generatedCode.Should().Contain("public int node_id { get; set; }");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task PreserveOriginal_Escapes_Reserved_Keywords()
     {
@@ -259,7 +254,6 @@ public class PropertyNamingPolicyTests
         generatedCode.Should().Contain("public string @class { get; set; }");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task PreserveOriginal_Minimally_Sanitizes_Invalid_Identifiers()
     {
@@ -275,7 +269,6 @@ public class PropertyNamingPolicyTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Default_PascalCase_Property_Naming_Prefixes_Digit_Prefixed_Properties()
     {

--- a/src/Refitter.Tests/Scenarios/Refit11CompatibilityTests.cs
+++ b/src/Refitter.Tests/Scenarios/Refit11CompatibilityTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class Refit11CompatibilityTests
 {
     private const string Refit11TargetFramework = "net10.0";

--- a/src/Refitter.Tests/Scenarios/Refit11CompatibilityTests.cs
+++ b/src/Refitter.Tests/Scenarios/Refit11CompatibilityTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class Refit11CompatibilityTests
 {
     private const string Refit11TargetFramework = "net10.0";

--- a/src/Refitter.Tests/Scenarios/RefitMultipleInterfaceByTagGeneratorTests.cs
+++ b/src/Refitter.Tests/Scenarios/RefitMultipleInterfaceByTagGeneratorTests.cs
@@ -8,6 +8,7 @@ namespace Refitter.Tests.Scenarios;
 
 public class RefitMultipleInterfaceByTagGeneratorTests
 {
+    [Category("Unit")]
     [Test]
     public async Task RefitMultipleInterfaceByTagGenerator_Creates_Ungrouped_Interface_When_Operation_Has_No_Tags()
     {
@@ -49,6 +50,7 @@ paths:
         Regex.IsMatch(generatedCode, @"interface I\w+Api.*GetUntaggedResource", RegexOptions.Singleline).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task RefitMultipleInterfaceByTagGenerator_Groups_All_Tagged_Operations()
     {
@@ -92,6 +94,7 @@ paths:
         generatedCode.Should().Contain("GetBar");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task RefitMultipleInterfaceByTagGenerator_Generated_Code_Compiles()
     {

--- a/src/Refitter.Tests/Scenarios/RefitMultipleInterfaceByTagGeneratorTests.cs
+++ b/src/Refitter.Tests/Scenarios/RefitMultipleInterfaceByTagGeneratorTests.cs
@@ -8,7 +8,6 @@ namespace Refitter.Tests.Scenarios;
 
 public class RefitMultipleInterfaceByTagGeneratorTests
 {
-    [Category("Unit")]
     [Test]
     public async Task RefitMultipleInterfaceByTagGenerator_Creates_Ungrouped_Interface_When_Operation_Has_No_Tags()
     {
@@ -50,7 +49,6 @@ paths:
         Regex.IsMatch(generatedCode, @"interface I\w+Api.*GetUntaggedResource", RegexOptions.Singleline).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task RefitMultipleInterfaceByTagGenerator_Groups_All_Tagged_Operations()
     {

--- a/src/Refitter.Tests/Scenarios/RequestResponseHeadersTests.cs
+++ b/src/Refitter.Tests/Scenarios/RequestResponseHeadersTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class RequestResponseHeadersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/RequestResponseHeadersTests.cs
+++ b/src/Refitter.Tests/Scenarios/RequestResponseHeadersTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class RequestResponseHeadersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ResponseHeadersTests.cs
+++ b/src/Refitter.Tests/Scenarios/ResponseHeadersTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class ResponseHeadersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ResponseHeadersTests.cs
+++ b/src/Refitter.Tests/Scenarios/ResponseHeadersTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class ResponseHeadersTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/ReturnIObservableEnhancedTests.cs
+++ b/src/Refitter.Tests/Scenarios/ReturnIObservableEnhancedTests.cs
@@ -55,6 +55,7 @@ components:
           type: number
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -62,6 +63,7 @@ components:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_IObservable()
     {
@@ -69,6 +71,7 @@ components:
         generatedCode.Should().Contain("IObservable<");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_IObservable_When_Disabled()
     {
@@ -77,6 +80,7 @@ components:
         generatedCode.Should().Contain("Task<");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code_Without_IObservable()
     {
@@ -84,6 +88,7 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Using_System_Reactive()
     {
@@ -91,6 +96,7 @@ components:
         generatedCode.Should().Contain("using System.Reactive;");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_IObservable_Code_Contains_Multiple_Methods()
     {
@@ -101,6 +107,7 @@ components:
         observableCount.Should().BeGreaterThanOrEqualTo(2);
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Task_Code_Contains_Multiple_Methods()
     {

--- a/src/Refitter.Tests/Scenarios/ReturnIObservableEnhancedTests.cs
+++ b/src/Refitter.Tests/Scenarios/ReturnIObservableEnhancedTests.cs
@@ -55,7 +55,6 @@ components:
           type: number
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -63,7 +62,6 @@ components:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_IObservable()
     {
@@ -71,7 +69,6 @@ components:
         generatedCode.Should().Contain("IObservable<");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_IObservable_When_Disabled()
     {
@@ -88,7 +85,6 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Using_System_Reactive()
     {
@@ -96,7 +92,6 @@ components:
         generatedCode.Should().Contain("using System.Reactive;");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_IObservable_Code_Contains_Multiple_Methods()
     {
@@ -107,7 +102,6 @@ components:
         observableCount.Should().BeGreaterThanOrEqualTo(2);
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Task_Code_Contains_Multiple_Methods()
     {

--- a/src/Refitter.Tests/Scenarios/RuntimeCompatibilityTests.cs
+++ b/src/Refitter.Tests/Scenarios/RuntimeCompatibilityTests.cs
@@ -14,6 +14,7 @@ public class RuntimeCompatibilityTests
     /// Test for issue #1027: RefitInterfaceGenerator NRE when an OpenAPI response has no content.
     /// Ensures that responses with null Content (e.g., 204 No Content) are handled gracefully.
     /// </summary>
+    [Category("Unit")]
     [Test]
     public async Task Can_Handle_Response_With_No_Content()
     {
@@ -68,6 +69,7 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Test for issue #1027: Verify Accept headers are generated for responses with content.
     /// </summary>
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Accept_Headers_For_Valid_Responses()
     {
@@ -123,6 +125,7 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Swagger 2.0 equivalent of Can_Generate_Accept_Headers_For_Valid_Responses.
     /// </summary>
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Accept_Headers_For_Valid_Responses_Swagger2()
     {
@@ -177,6 +180,7 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Test for issue #1026: nullable reference types alone must not silently change contract shapes.
     /// </summary>
+    [Category("Unit")]
     [Test]
     public async Task Does_Not_Auto_Enable_Optional_Properties_As_Nullable_When_NRT_Enabled()
     {
@@ -249,6 +253,7 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Swagger 2.0 equivalent of Does_Not_Auto_Enable_Optional_Properties_As_Nullable_When_NRT_Enabled.
     /// </summary>
+    [Category("Unit")]
     [Test]
     public async Task Does_Not_Auto_Enable_Optional_Properties_As_Nullable_When_NRT_Enabled_Swagger2()
     {
@@ -323,6 +328,7 @@ public class RuntimeCompatibilityTests
     /// Swagger 2.0 optional reference properties should keep pre-#1026 shapes for arrays, custom types and generic collections.
     /// Value types should still retain nullable fallthrough where appropriate.
     /// </summary>
+    [Category("Integration")]
     [Test]
     public async Task Does_Not_Auto_Enable_Optional_Properties_As_Nullable_For_Swagger2_Reference_Shapes()
     {
@@ -424,6 +430,7 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Explicit opt-in should still generate nullable optional properties when desired.
     /// </summary>
+    [Category("Unit")]
     [Test]
     public async Task Honors_Explicit_GenerateOptionalPropertiesAsNullable_When_NRT_Enabled()
     {
@@ -495,6 +502,7 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Swagger 2.0 should still honor explicit opt-in for nullable optional properties.
     /// </summary>
+    [Category("Unit")]
     [Test]
     public async Task Honors_Explicit_GenerateOptionalPropertiesAsNullable_When_NRT_Enabled_Swagger2()
     {
@@ -568,6 +576,7 @@ public class RuntimeCompatibilityTests
     /// Test for issue #1052: Verify duplicate operation ID detection is efficient.
     /// This test ensures the duplicate detection short-circuits on first duplicate found.
     /// </summary>
+    [Category("Unit")]
     [Test]
     public async Task Duplicate_Operation_Id_Detection_Is_Efficient()
     {
@@ -619,6 +628,7 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Swagger 2.0 equivalent of Duplicate_Operation_Id_Detection_Is_Efficient.
     /// </summary>
+    [Category("Unit")]
     [Test]
     public async Task Duplicate_Operation_Id_Detection_Is_Efficient_Swagger2()
     {
@@ -673,6 +683,7 @@ public class RuntimeCompatibilityTests
     /// Test for issue #1055: Verify interface generator is created before GenerateFile().
     /// This ensures operation ID detection works correctly.
     /// </summary>
+    [Category("Unit")]
     [Test]
     public async Task Interface_Generator_Created_Before_Generate_File()
     {
@@ -744,6 +755,7 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Swagger 2.0 equivalent of Interface_Generator_Created_Before_Generate_File.
     /// </summary>
+    [Category("Unit")]
     [Test]
     public async Task Interface_Generator_Created_Before_Generate_File_Swagger2()
     {
@@ -816,6 +828,7 @@ public class RuntimeCompatibilityTests
     /// Test for issue #1049: Verify generated code with async operations.
     /// Note: ConfigureAwait(false) is used internally in library code, not in generated output.
     /// </summary>
+    [Category("Integration")]
     [Test]
     public async Task Can_Generate_Code_With_Async_Operations()
     {
@@ -867,6 +880,7 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Swagger 2.0 equivalent of Can_Generate_Code_With_Async_Operations.
     /// </summary>
+    [Category("Integration")]
     [Test]
     public async Task Can_Generate_Code_With_Async_Operations_Swagger2()
     {

--- a/src/Refitter.Tests/Scenarios/RuntimeCompatibilityTests.cs
+++ b/src/Refitter.Tests/Scenarios/RuntimeCompatibilityTests.cs
@@ -14,7 +14,6 @@ public class RuntimeCompatibilityTests
     /// Test for issue #1027: RefitInterfaceGenerator NRE when an OpenAPI response has no content.
     /// Ensures that responses with null Content (e.g., 204 No Content) are handled gracefully.
     /// </summary>
-    [Category("Unit")]
     [Test]
     public async Task Can_Handle_Response_With_No_Content()
     {
@@ -69,7 +68,6 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Test for issue #1027: Verify Accept headers are generated for responses with content.
     /// </summary>
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Accept_Headers_For_Valid_Responses()
     {
@@ -125,7 +123,6 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Swagger 2.0 equivalent of Can_Generate_Accept_Headers_For_Valid_Responses.
     /// </summary>
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Accept_Headers_For_Valid_Responses_Swagger2()
     {
@@ -180,7 +177,6 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Test for issue #1026: nullable reference types alone must not silently change contract shapes.
     /// </summary>
-    [Category("Unit")]
     [Test]
     public async Task Does_Not_Auto_Enable_Optional_Properties_As_Nullable_When_NRT_Enabled()
     {
@@ -253,7 +249,6 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Swagger 2.0 equivalent of Does_Not_Auto_Enable_Optional_Properties_As_Nullable_When_NRT_Enabled.
     /// </summary>
-    [Category("Unit")]
     [Test]
     public async Task Does_Not_Auto_Enable_Optional_Properties_As_Nullable_When_NRT_Enabled_Swagger2()
     {
@@ -430,7 +425,6 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Explicit opt-in should still generate nullable optional properties when desired.
     /// </summary>
-    [Category("Unit")]
     [Test]
     public async Task Honors_Explicit_GenerateOptionalPropertiesAsNullable_When_NRT_Enabled()
     {
@@ -502,7 +496,6 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Swagger 2.0 should still honor explicit opt-in for nullable optional properties.
     /// </summary>
-    [Category("Unit")]
     [Test]
     public async Task Honors_Explicit_GenerateOptionalPropertiesAsNullable_When_NRT_Enabled_Swagger2()
     {
@@ -576,7 +569,6 @@ public class RuntimeCompatibilityTests
     /// Test for issue #1052: Verify duplicate operation ID detection is efficient.
     /// This test ensures the duplicate detection short-circuits on first duplicate found.
     /// </summary>
-    [Category("Unit")]
     [Test]
     public async Task Duplicate_Operation_Id_Detection_Is_Efficient()
     {
@@ -628,7 +620,6 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Swagger 2.0 equivalent of Duplicate_Operation_Id_Detection_Is_Efficient.
     /// </summary>
-    [Category("Unit")]
     [Test]
     public async Task Duplicate_Operation_Id_Detection_Is_Efficient_Swagger2()
     {
@@ -683,7 +674,6 @@ public class RuntimeCompatibilityTests
     /// Test for issue #1055: Verify interface generator is created before GenerateFile().
     /// This ensures operation ID detection works correctly.
     /// </summary>
-    [Category("Unit")]
     [Test]
     public async Task Interface_Generator_Created_Before_Generate_File()
     {
@@ -755,7 +745,6 @@ public class RuntimeCompatibilityTests
     /// <summary>
     /// Swagger 2.0 equivalent of Interface_Generator_Created_Before_Generate_File.
     /// </summary>
-    [Category("Unit")]
     [Test]
     public async Task Interface_Generator_Created_Before_Generate_File_Swagger2()
     {

--- a/src/Refitter.Tests/Scenarios/SchemaTypeNameSanitizationTests.cs
+++ b/src/Refitter.Tests/Scenarios/SchemaTypeNameSanitizationTests.cs
@@ -101,6 +101,7 @@ public class SchemaTypeNameSanitizationTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Issue1083_Sanitizes_Trailing_Dot_Schema_Name_In_Contract_And_Method_Signature()
     {
@@ -113,6 +114,7 @@ public class SchemaTypeNameSanitizationTests
         generatedCode.Should().Contain($"Task<{SanitizedDtoName}> LookUpErn(");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Issue1083_Dotted_Schema_Name_Generated_Code_Can_Build()
     {
@@ -121,6 +123,7 @@ public class SchemaTypeNameSanitizationTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Issue1083_Preserves_Normal_Schema_Name_When_Malformed_Name_Normalizes_To_Same_Type()
     {

--- a/src/Refitter.Tests/Scenarios/SchemaTypeNameSanitizationTests.cs
+++ b/src/Refitter.Tests/Scenarios/SchemaTypeNameSanitizationTests.cs
@@ -101,7 +101,6 @@ public class SchemaTypeNameSanitizationTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Issue1083_Sanitizes_Trailing_Dot_Schema_Name_In_Contract_And_Method_Signature()
     {

--- a/src/Refitter.Tests/Scenarios/SettingsFileOutputPathTests.cs
+++ b/src/Refitter.Tests/Scenarios/SettingsFileOutputPathTests.cs
@@ -37,7 +37,6 @@ public class SettingsFileOutputPathTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public void SettingsFile_WithoutOutputFilename_UsesRefitterFilenameFallback()
     {
@@ -73,7 +72,6 @@ public class SettingsFileOutputPathTests
         }
     }
 
-    [Category("Unit")]
     [Test]
     public void SettingsFile_WithExplicitDefaultOutputFolder_RootsToSettingsFileDirectory()
     {

--- a/src/Refitter.Tests/Scenarios/SettingsFileOutputPathTests.cs
+++ b/src/Refitter.Tests/Scenarios/SettingsFileOutputPathTests.cs
@@ -37,6 +37,7 @@ public class SettingsFileOutputPathTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public void SettingsFile_WithoutOutputFilename_UsesRefitterFilenameFallback()
     {
@@ -72,6 +73,7 @@ public class SettingsFileOutputPathTests
         }
     }
 
+    [Category("Unit")]
     [Test]
     public void SettingsFile_WithExplicitDefaultOutputFolder_RootsToSettingsFileDirectory()
     {
@@ -106,6 +108,7 @@ public class SettingsFileOutputPathTests
         }
     }
 
+    [Category("Integration")]
     [Test]
     public async Task SettingsFile_PreservesNamingInterfaceName()
     {

--- a/src/Refitter.Tests/Scenarios/SymbolsInDescriptionTests.cs
+++ b/src/Refitter.Tests/Scenarios/SymbolsInDescriptionTests.cs
@@ -7,6 +7,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class SymbolsInDescriptionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/SymbolsInDescriptionTests.cs
+++ b/src/Refitter.Tests/Scenarios/SymbolsInDescriptionTests.cs
@@ -8,7 +8,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class SymbolsInDescriptionTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/SystemPropertyInContractTests.cs
+++ b/src/Refitter.Tests/Scenarios/SystemPropertyInContractTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class SystemPropertyInContractTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/SystemPropertyInContractTests.cs
+++ b/src/Refitter.Tests/Scenarios/SystemPropertyInContractTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class SystemPropertyInContractTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/TrimSchemaWithIncludeTagsTests.cs
+++ b/src/Refitter.Tests/Scenarios/TrimSchemaWithIncludeTagsTests.cs
@@ -103,6 +103,7 @@ components:
           type: string
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -110,6 +111,7 @@ components:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {
@@ -117,6 +119,7 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Included_Tag_Endpoints()
     {
@@ -125,6 +128,7 @@ components:
         generatedCode.Should().Contain("GetPetById");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_Excluded_Tag_Endpoints()
     {
@@ -133,6 +137,7 @@ components:
         generatedCode.Should().NotContain("GetOwnerById");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_Unused_Schemas()
     {

--- a/src/Refitter.Tests/Scenarios/TrimSchemaWithIncludeTagsTests.cs
+++ b/src/Refitter.Tests/Scenarios/TrimSchemaWithIncludeTagsTests.cs
@@ -103,7 +103,6 @@ components:
           type: string
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -119,7 +118,6 @@ components:
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Contains_Included_Tag_Endpoints()
     {
@@ -128,7 +126,6 @@ components:
         generatedCode.Should().Contain("GetPetById");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_Excluded_Tag_Endpoints()
     {
@@ -137,7 +134,6 @@ components:
         generatedCode.Should().NotContain("GetOwnerById");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Generated_Code_Does_Not_Contain_Unused_Schemas()
     {

--- a/src/Refitter.Tests/Scenarios/TrimUnusedSchemaAliasRegressionTests.cs
+++ b/src/Refitter.Tests/Scenarios/TrimUnusedSchemaAliasRegressionTests.cs
@@ -187,7 +187,6 @@ public class TrimUnusedSchemaAliasRegressionTests
         }
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_When_TrimUnusedSchema_Uses_Aliased_Component_Schemas()
     {

--- a/src/Refitter.Tests/Scenarios/TrimUnusedSchemaAliasRegressionTests.cs
+++ b/src/Refitter.Tests/Scenarios/TrimUnusedSchemaAliasRegressionTests.cs
@@ -187,6 +187,7 @@ public class TrimUnusedSchemaAliasRegressionTests
         }
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_When_TrimUnusedSchema_Uses_Aliased_Component_Schemas()
     {
@@ -194,6 +195,7 @@ public class TrimUnusedSchemaAliasRegressionTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task TrimUnusedSchema_With_Aliased_Component_Schemas_Can_Build()
     {
@@ -202,6 +204,7 @@ public class TrimUnusedSchemaAliasRegressionTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Combined_Alias_Trim_And_Digit_Prefixed_Property_Regression_Can_Build()
     {
@@ -212,6 +215,7 @@ public class TrimUnusedSchemaAliasRegressionTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Combined_Regression_Can_Generate_From_Settings_File_Content()
     {

--- a/src/Refitter.Tests/Scenarios/TrimUnusedSchemaAliasWithLeadingDigitPropertyTests.cs
+++ b/src/Refitter.Tests/Scenarios/TrimUnusedSchemaAliasWithLeadingDigitPropertyTests.cs
@@ -159,7 +159,6 @@ public class TrimUnusedSchemaAliasWithLeadingDigitPropertyTests
                 type: number
         """;
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -175,7 +174,6 @@ public class TrimUnusedSchemaAliasWithLeadingDigitPropertyTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_OpenApi2()
     {

--- a/src/Refitter.Tests/Scenarios/TrimUnusedSchemaAliasWithLeadingDigitPropertyTests.cs
+++ b/src/Refitter.Tests/Scenarios/TrimUnusedSchemaAliasWithLeadingDigitPropertyTests.cs
@@ -159,6 +159,7 @@ public class TrimUnusedSchemaAliasWithLeadingDigitPropertyTests
                 type: number
         """;
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -166,6 +167,7 @@ public class TrimUnusedSchemaAliasWithLeadingDigitPropertyTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {
@@ -173,6 +175,7 @@ public class TrimUnusedSchemaAliasWithLeadingDigitPropertyTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code_OpenApi2()
     {
@@ -180,6 +183,7 @@ public class TrimUnusedSchemaAliasWithLeadingDigitPropertyTests
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code_OpenApi2()
     {
@@ -187,6 +191,7 @@ public class TrimUnusedSchemaAliasWithLeadingDigitPropertyTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Generated_Identifier_Is_Valid_And_Compilable()
     {

--- a/src/Refitter.Tests/Scenarios/TrimUnusedSchemaTests.cs
+++ b/src/Refitter.Tests/Scenarios/TrimUnusedSchemaTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class TrimUnusedSchemaTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/TrimUnusedSchemaTests.cs
+++ b/src/Refitter.Tests/Scenarios/TrimUnusedSchemaTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class TrimUnusedSchemaTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/UnderscoresToPascalCaseTests.cs
+++ b/src/Refitter.Tests/Scenarios/UnderscoresToPascalCaseTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class HandleUnderscoresTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/UnderscoresToPascalCaseTests.cs
+++ b/src/Refitter.Tests/Scenarios/UnderscoresToPascalCaseTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class HandleUnderscoresTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/UseIsoDateFormatTests.cs
+++ b/src/Refitter.Tests/Scenarios/UseIsoDateFormatTests.cs
@@ -46,7 +46,6 @@ paths:
           description: No response was specified
 ";
 
-    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -54,7 +53,6 @@ paths:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_Contains_Date_Format_String()
     {
@@ -63,7 +61,6 @@ paths:
         generatedCode.Should().Contain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset valid_to");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_NotContains_DateTime_Format_String()
     {
@@ -72,7 +69,6 @@ paths:
         generatedCode.Should().NotContain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset time_datetime");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_Contains_TimeSpan_Parameter()
     {
@@ -80,7 +76,6 @@ paths:
         generatedCode.Should().Contain("[Query] System.TimeSpan");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_Contains_Date_Format_String_With_Empty_Settings()
     {
@@ -89,7 +84,6 @@ paths:
         generatedCode.Should().Contain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset valid_to");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_NotContains_DateTime_Format_String_With_Empty_Settings()
     {
@@ -98,7 +92,6 @@ paths:
         generatedCode.Should().NotContain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset time_datetime");
     }
 
-    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_Contains_TimeSpan_Parameter_With_Empty_Settings()
     {
@@ -106,7 +99,6 @@ paths:
         generatedCode.Should().Contain("[Query] System.TimeSpan");
     }
 
-    [Category("Unit")]
     [Test]
     [Arguments("dd/MM/yyyy", "yyyy-MM-ddTHH:mm:ss")]
     [Arguments("MM-dd-yyyy", "HH:mm:ss")]
@@ -127,7 +119,6 @@ paths:
         generatedCode.Should().Contain(@$"[Query] System.TimeSpan test_time");
     }
 
-    [Category("Unit")]
     [Test]
     [Arguments("dd/MM/yyyy")]
     [Arguments("MM-dd-yyyy")]
@@ -138,7 +129,6 @@ paths:
         generatedCode.Should().NotContain(@$"[Query(Format = ""{format}"")] System.DateTimeOffset time_datetime");
     }
 
-    [Category("Unit")]
     [Test]
     [Arguments("dd/MM/yyyy")]
     [Arguments("MM-dd-yyyy")]

--- a/src/Refitter.Tests/Scenarios/UseIsoDateFormatTests.cs
+++ b/src/Refitter.Tests/Scenarios/UseIsoDateFormatTests.cs
@@ -46,6 +46,7 @@ paths:
           description: No response was specified
 ";
 
+    [Category("Unit")]
     [Test]
     public async Task Can_Generate_Code()
     {
@@ -53,6 +54,7 @@ paths:
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_Contains_Date_Format_String()
     {
@@ -61,6 +63,7 @@ paths:
         generatedCode.Should().Contain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset valid_to");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_NotContains_DateTime_Format_String()
     {
@@ -69,6 +72,7 @@ paths:
         generatedCode.Should().NotContain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset time_datetime");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_Contains_TimeSpan_Parameter()
     {
@@ -76,6 +80,7 @@ paths:
         generatedCode.Should().Contain("[Query] System.TimeSpan");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_Contains_Date_Format_String_With_Empty_Settings()
     {
@@ -84,6 +89,7 @@ paths:
         generatedCode.Should().Contain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset valid_to");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_NotContains_DateTime_Format_String_With_Empty_Settings()
     {
@@ -92,6 +98,7 @@ paths:
         generatedCode.Should().NotContain(@"[Query(Format = ""yyyy-MM-dd"")] System.DateTimeOffset time_datetime");
     }
 
+    [Category("Unit")]
     [Test]
     public async Task GeneratedCode_Contains_TimeSpan_Parameter_With_Empty_Settings()
     {
@@ -99,6 +106,7 @@ paths:
         generatedCode.Should().Contain("[Query] System.TimeSpan");
     }
 
+    [Category("Unit")]
     [Test]
     [Arguments("dd/MM/yyyy", "yyyy-MM-ddTHH:mm:ss")]
     [Arguments("MM-dd-yyyy", "HH:mm:ss")]
@@ -119,6 +127,7 @@ paths:
         generatedCode.Should().Contain(@$"[Query] System.TimeSpan test_time");
     }
 
+    [Category("Unit")]
     [Test]
     [Arguments("dd/MM/yyyy")]
     [Arguments("MM-dd-yyyy")]
@@ -129,6 +138,7 @@ paths:
         generatedCode.Should().NotContain(@$"[Query(Format = ""{format}"")] System.DateTimeOffset time_datetime");
     }
 
+    [Category("Unit")]
     [Test]
     [Arguments("dd/MM/yyyy")]
     [Arguments("MM-dd-yyyy")]
@@ -138,6 +148,7 @@ paths:
         generatedCode.Should().Contain("[Query] System.TimeSpan");
     }
 
+    [Category("Integration")]
     [Test]
     public async Task Can_Build_Generated_Code()
     {

--- a/src/Refitter.Tests/Scenarios/UsePolymorphicSerializationAndCustomTemplatesTests.cs
+++ b/src/Refitter.Tests/Scenarios/UsePolymorphicSerializationAndCustomTemplatesTests.cs
@@ -6,7 +6,6 @@ using Refitter.Tests.TestUtilities;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class UsePolymorphicSerializationAndCustomTemplatesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/UsePolymorphicSerializationAndCustomTemplatesTests.cs
+++ b/src/Refitter.Tests/Scenarios/UsePolymorphicSerializationAndCustomTemplatesTests.cs
@@ -5,6 +5,8 @@ using Refitter.Tests.TestUtilities;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class UsePolymorphicSerializationAndCustomTemplatesTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/UsePolymorphicSerializationTests.cs
+++ b/src/Refitter.Tests/Scenarios/UsePolymorphicSerializationTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests.Scenarios;
 
 
-[Category("Unit")]
 public class UsePolymorphicSerializationTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/Scenarios/UsePolymorphicSerializationTests.cs
+++ b/src/Refitter.Tests/Scenarios/UsePolymorphicSerializationTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
+
+[Category("Unit")]
 public class UsePolymorphicSerializationTests
 {
     private const string OpenApiSpec = @"

--- a/src/Refitter.Tests/SchemaCleanerTests.cs
+++ b/src/Refitter.Tests/SchemaCleanerTests.cs
@@ -6,6 +6,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class SchemaCleanerTests
 {
     [Test]

--- a/src/Refitter.Tests/SchemaCleanerTests.cs
+++ b/src/Refitter.Tests/SchemaCleanerTests.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class SchemaCleanerTests
 {
     [Test]

--- a/src/Refitter.Tests/SettingsFile/RefitterSettingsLoaderTests.cs
+++ b/src/Refitter.Tests/SettingsFile/RefitterSettingsLoaderTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.SettingsFile;
 
 
-[Category("Unit")]
 public class RefitterSettingsLoaderTests
 {
     private static readonly string BaseDirectory = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "refitter-loader-tests"));

--- a/src/Refitter.Tests/SettingsFile/RefitterSettingsLoaderTests.cs
+++ b/src/Refitter.Tests/SettingsFile/RefitterSettingsLoaderTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.SettingsFile;
 
+
+[Category("Unit")]
 public class RefitterSettingsLoaderTests
 {
     private static readonly string BaseDirectory = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "refitter-loader-tests"));

--- a/src/Refitter.Tests/SettingsFile/SerializerTests.cs
+++ b/src/Refitter.Tests/SettingsFile/SerializerTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.SettingsFile;
 
+
+[Category("Unit")]
 public class SerializerTests
 {
     private static RefitGeneratorSettings CreateTestSettings() => new()

--- a/src/Refitter.Tests/SettingsFile/SerializerTests.cs
+++ b/src/Refitter.Tests/SettingsFile/SerializerTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.SettingsFile;
 
 
-[Category("Unit")]
 public class SerializerTests
 {
     private static RefitGeneratorSettings CreateTestSettings() => new()

--- a/src/Refitter.Tests/SettingsFile/SettingsTests.cs
+++ b/src/Refitter.Tests/SettingsFile/SettingsTests.cs
@@ -5,6 +5,8 @@ using Spectre.Console.Cli;
 
 namespace Refitter.Tests.SettingsFile;
 
+
+[Category("Unit")]
 public class SettingsTests
 {
     [Test]

--- a/src/Refitter.Tests/SettingsFile/SettingsTests.cs
+++ b/src/Refitter.Tests/SettingsFile/SettingsTests.cs
@@ -6,7 +6,6 @@ using Spectre.Console.Cli;
 namespace Refitter.Tests.SettingsFile;
 
 
-[Category("Unit")]
 public class SettingsTests
 {
     [Test]

--- a/src/Refitter.Tests/SettingsFile/SettingsValidatorTests.cs
+++ b/src/Refitter.Tests/SettingsFile/SettingsValidatorTests.cs
@@ -4,6 +4,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.SettingsFile;
 
+
+[Category("Unit")]
 public class SettingsValidatorTests
 {
     [Test]

--- a/src/Refitter.Tests/SettingsFile/SettingsValidatorTests.cs
+++ b/src/Refitter.Tests/SettingsFile/SettingsValidatorTests.cs
@@ -5,7 +5,6 @@ using Refitter.Core;
 namespace Refitter.Tests.SettingsFile;
 
 
-[Category("Unit")]
 public class SettingsValidatorTests
 {
     [Test]

--- a/src/Refitter.Tests/SettingsFile/WriteRefitterSettingsFileTests.cs
+++ b/src/Refitter.Tests/SettingsFile/WriteRefitterSettingsFileTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.SettingsFile;
 
+
+[Category("Unit")]
 public class WriteRefitterSettingsFileTests
 {
     [Test]

--- a/src/Refitter.Tests/SettingsFile/WriteRefitterSettingsFileTests.cs
+++ b/src/Refitter.Tests/SettingsFile/WriteRefitterSettingsFileTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.SettingsFile;
 
 
-[Category("Unit")]
 public class WriteRefitterSettingsFileTests
 {
     [Test]

--- a/src/Refitter.Tests/SettingsMapperTests.cs
+++ b/src/Refitter.Tests/SettingsMapperTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class SettingsMapperTests
 {
     [Test]

--- a/src/Refitter.Tests/SettingsMapperTests.cs
+++ b/src/Refitter.Tests/SettingsMapperTests.cs
@@ -6,7 +6,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class SettingsMapperTests
 {
     [Test]

--- a/src/Refitter.Tests/SimpleGenerationReporterTests.cs
+++ b/src/Refitter.Tests/SimpleGenerationReporterTests.cs
@@ -11,6 +11,8 @@ namespace Refitter.Tests;
 /// redirecting Console.Out (TUnit0055). The methods only write to Console so they
 /// don't throw — a clean run is the success criterion.
 /// </summary>
+
+[Category("Unit")]
 public class SimpleGenerationReporterTests
 {
     [Test]

--- a/src/Refitter.Tests/SimpleGenerationReporterTests.cs
+++ b/src/Refitter.Tests/SimpleGenerationReporterTests.cs
@@ -12,7 +12,6 @@ namespace Refitter.Tests;
 /// don't throw — a clean run is the success criterion.
 /// </summary>
 
-[Category("Unit")]
 public class SimpleGenerationReporterTests
 {
     [Test]

--- a/src/Refitter.Tests/SourceGeneratorFileWriterTests.cs
+++ b/src/Refitter.Tests/SourceGeneratorFileWriterTests.cs
@@ -4,6 +4,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class SourceGeneratorFileWriterTests
 {
     [Test]

--- a/src/Refitter.Tests/SourceGeneratorFileWriterTests.cs
+++ b/src/Refitter.Tests/SourceGeneratorFileWriterTests.cs
@@ -5,7 +5,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class SourceGeneratorFileWriterTests
 {
     [Test]

--- a/src/Refitter.Tests/StringCasingExtensionTests.cs
+++ b/src/Refitter.Tests/StringCasingExtensionTests.cs
@@ -4,6 +4,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class StringCasingExtensionTests
 {
     [Test]

--- a/src/Refitter.Tests/StringCasingExtensionTests.cs
+++ b/src/Refitter.Tests/StringCasingExtensionTests.cs
@@ -5,7 +5,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class StringCasingExtensionTests
 {
     [Test]

--- a/src/Refitter.Tests/SwaggerPetstoreMultipleFileTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreMultipleFileTests.cs
@@ -6,7 +6,6 @@ using Refitter.Tests.Resources;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class SwaggerPetstoreMultipleFileTests
 {
     [Test]

--- a/src/Refitter.Tests/SwaggerPetstoreMultipleFileTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreMultipleFileTests.cs
@@ -5,6 +5,8 @@ using Refitter.Tests.Resources;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class SwaggerPetstoreMultipleFileTests
 {
     [Test]

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -8,6 +8,8 @@ using TUnit.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class SwaggerPetstoreTests
 {
     [Test]

--- a/src/Refitter.Tests/SwaggerPetstoreTests.cs
+++ b/src/Refitter.Tests/SwaggerPetstoreTests.cs
@@ -9,7 +9,6 @@ using TUnit.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class SwaggerPetstoreTests
 {
     [Test]

--- a/src/Refitter.Tests/Telemetry/AnalyticsTests.cs
+++ b/src/Refitter.Tests/Telemetry/AnalyticsTests.cs
@@ -3,6 +3,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests.Telemetry;
 
+
+[Category("Unit")]
 public class AnalyticsTests
 {
     [Test]

--- a/src/Refitter.Tests/Telemetry/AnalyticsTests.cs
+++ b/src/Refitter.Tests/Telemetry/AnalyticsTests.cs
@@ -4,7 +4,6 @@ using Refitter.Core;
 namespace Refitter.Tests.Telemetry;
 
 
-[Category("Unit")]
 public class AnalyticsTests
 {
     [Test]

--- a/src/Refitter.Tests/Telemetry/SupportInformationTests.cs
+++ b/src/Refitter.Tests/Telemetry/SupportInformationTests.cs
@@ -2,6 +2,8 @@ using FluentAssertions;
 
 namespace Refitter.Tests.Telemetry;
 
+
+[Category("Unit")]
 public class SupportInformationTests
 {
     [Test]

--- a/src/Refitter.Tests/Telemetry/SupportInformationTests.cs
+++ b/src/Refitter.Tests/Telemetry/SupportInformationTests.cs
@@ -3,7 +3,6 @@ using FluentAssertions;
 namespace Refitter.Tests.Telemetry;
 
 
-[Category("Unit")]
 public class SupportInformationTests
 {
     [Test]

--- a/src/Refitter.Tests/XmlDocumentationGeneratorTests.cs
+++ b/src/Refitter.Tests/XmlDocumentationGeneratorTests.cs
@@ -8,7 +8,6 @@ using Refitter.Core;
 namespace Refitter.Tests;
 
 
-[Category("Unit")]
 public class XmlDocumentationGeneratorTests
 {
     private readonly XmlDocumentationGenerator generator = new(new RefitGeneratorSettings { GenerateXmlDocCodeComments = true });

--- a/src/Refitter.Tests/XmlDocumentationGeneratorTests.cs
+++ b/src/Refitter.Tests/XmlDocumentationGeneratorTests.cs
@@ -7,6 +7,8 @@ using Refitter.Core;
 
 namespace Refitter.Tests;
 
+
+[Category("Unit")]
 public class XmlDocumentationGeneratorTests
 {
     private readonly XmlDocumentationGenerator generator = new(new RefitGeneratorSettings { GenerateXmlDocCodeComments = true });


### PR DESCRIPTION
This pull request introduces a clear separation between fast unit tests and the full test suite in both the CI workflow and documentation. It also standardizes the use of `[Category("Unit")]` attributes across all test classes to enable category-based test filtering. The main goal is to improve test feedback speed and maintainability.

**Testing workflow improvements:**

* The CI workflow in `.github/workflows/build.yml` now runs a fast "unit tests" gate using the `--treenode-filter "/*/*/*/*[Category=Unit]"` option, followed by the full test suite. This enables quicker feedback for changes that only affect unit tests.

**Documentation updates:**

* The `AGENTS.md` documentation now explains the use of TUnit's `--treenode-filter` for fast feedback, provides example commands for running unit and integration tests separately, and documents the convention that all tests must be categorized as either "Unit" or "Integration".

**Test codebase standardization:**

* All test classes in `src/Refitter.SourceGenerator.Tests` and `src/Refitter.Tests/Apizr` now have the `[Category("Unit")]` attribute, ensuring they are properly picked up by the new filtering mechanism. [[1]](diffhunk://#diff-d3f1f2a908201e58a6df9cd889915fc251db8adf09c08e54304f7e8361a25446R8-R9) [[2]](diffhunk://#diff-25bf233d03eebeecb6e7e7c4038722de65bde6748d1699c2544e51a59f8af908R8-R9) [[3]](diffhunk://#diff-c1a3b0eb25fcaea47984b2c5e6258f6c5f6aeac34ed1b8c78df6091f0e5e59fdR8-R9) [[4]](diffhunk://#diff-14f7e7ec6a36f24c52c1a585a0904d7a02e0fbbd6819d744560e8144f5d0ba3aR8-R9) [[5]](diffhunk://#diff-be000994c35ec42e4a32572ccf63c544f54ca68fe621d7b1436420e3bd96fe41R8-R9) [[6]](diffhunk://#diff-803ddc82107dfc97e58300ff979c1cbc842b8bec5b39730fadd71bc710be0d9bR8-R9) [[7]](diffhunk://#diff-a46ed676c9c215680733816b51476cf0e0e070487e89b8fa7871781372eb984dR8-R9) [[8]](diffhunk://#diff-9c70d78248ccf0ba1267366908494c7c041cf4fb1061da13b4c93b04e25329bdR7-R8) [[9]](diffhunk://#diff-714f0572fe76178ff08e4e3f0c39d662ce1b9bbfe833e48e768a769c941fd9cbR8-R9) [[10]](diffhunk://#diff-eb64bf42344554d2ea74f25cb84f87e07c88408db7fc2a3f24241779e72bde11R6-R7) [[11]](diffhunk://#diff-753ee4eda3d00908f585b4a8428b693350c186973a5fb8f34a1df608be892482R6-R7) [[12]](diffhunk://#diff-82614f690107247e561a7219f3d36a70318169ad71a3b0c5dc09fce6d999dc88R6-R7) [[13]](diffhunk://#diff-edd4216b475a0737a3dc674847b1a2e3840312c23abecc10b19f5149b4bd49b6R6-R7) [[14]](diffhunk://#diff-e9aeeef00e6fa886159fceddd995b51655835a548f5ae97b93cb2f69ce33c9beR6-R7) [[15]](diffhunk://#diff-ac3f9d9b7ba45bd0a14b4df07bf93d8e576fbade42a83bfe9d20593476826816R8-R9) [[16]](diffhunk://#diff-a246dbfbf723f1376ce567ebbdb8049b1beadbb2ea14b28824572152bc5ec63fR8-R9) [[17]](diffhunk://#diff-bbabb7b23efc11bd8cdf2f962ad83dd6b714bc28bc3ad18069ab572dbdad6fcbR6-R7) [[18]](diffhunk://#diff-a589b828d85de6bce09848fce3f07a6f596f5fbe8da6c277a16e9d1206b9d37fR6-R7)

**Key benefits:**

* Faster CI feedback for PRs affecting only unit tests.
* Clear documentation and conventions for test categorization.
* Improved maintainability and scalability of the test suite.