### PR TITLE
Add Windows Authentication option for DI clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ The following is an example `.refitter` file using a single OpenAPI specificatio
         "TelemetryMessageHandler"
     ],
     "usePolly": true, // DEPRECATED - Use "transientErrorHandler": "None|Polly|HttpResilience" instead
+    "useWindowsAuthentication": true, // Optional. Default=false
     "transientErrorHandler": "HttpResilience", // Optional. Set this to configure transient error handling with a retry policy that uses a jittered backoff. May be one of None, Polly, HttpResilience
     "maxRetryCount": 3, // Optional. Default=6
     "firstBackoffRetryInSeconds": 0.5 // Optional. Default=1.0
@@ -397,7 +398,7 @@ The following is an example `.refitter` file using multiple OpenAPI specificatio
 - `usePolymorphicSerialization`: Set to `true` to use System.Text.Json polymorphic serialization. Replaces NSwag `JsonInheritanceConverter` attributes with `System.Text.Json` `JsonPolymorphicAttributes`. Default is `false`. See <https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism>
 - `collectionFormat` - The collection format for array query parameters. Possible values: `Multi`, `Csv`, `Ssv`, `Tsv`, `Pipes`. Default is `Multi`
 - `contractTypeSuffix` - An optional suffix to append to all generated contract type names. For example, setting this to `Dto` would rename `Pet` to `PetDto`. Default is `null` (no suffix)
-- `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
+- `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients, including optional Windows Authentication support
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL
   - `httpMessageHandlers` - A collection of `HttpMessageHandler` that is added to the HttpClient pipeline
   - `usePolly` - Set this to `true` to configure the HttpClient to use Polly using a retry policy with a jittered backoff.  This is **DEPRECATED**, use `transientErrorHandler` instead

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -75,6 +75,7 @@ The following is an example `.refitter` file
         "TelemetryMessageHandler"
     ],
     "usePolly": true, // DEPRECATED - Use "transientErrorHandler": "None|Polly|HttpResilience" instead
+    "useWindowsAuthentication": true, // Optional. Default=false
     "transientErrorHandler": "HttpResilience", // Optional. Set this to configure transient error handling with a retry policy that uses a jittered backoff. May be one of None, Polly, HttpResilience
     "maxRetryCount": 3, // Optional. Default=6
     "firstBackoffRetryInSeconds": 0.5 // Optional. Default=1.0
@@ -189,7 +190,7 @@ When using `openApiPaths`, the documents are merged into a single generated clie
 - `useDynamicQuerystringParameters`: Set to `true` to wrap multiple query parameters into a single complex one. Default is `false` (no wrapping). See <https://github.com/reactiveui/refit?tab=readme-ov-file#dynamic-querystring-parameters> for more information.
 - `usePolymorphicSerialization`: Set to `true` to use `System.Text.Json` polymorphic serialization.
 - `generateMultipleFiles`: Set to `true` to generate multiple files. This is automatically set to `true` when `ContractsOutputFolder` is specified. Refit interface(s) are written to a file called `RefitInterfaces.cs`, Contracts are written to a file called `Contracts.cs`, and Dependency Injection is written to a file called `DependencyInjection.cs`
-- `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
+- `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients, including optional Windows Authentication support
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL
   - `httpMessageHandlers` - A collection of `HttpMessageHandler` that is added to the HttpClient pipeline
   - `usePolly` - Set this to `true` to configure the HttpClient to use Polly using a retry policy with a jittered backoff.  This is **DEPRECATED**, use `transientErrorHandler` instead

--- a/docs/docfx_project/articles/using-the-generated-code.md
+++ b/docs/docfx_project/articles/using-the-generated-code.md
@@ -122,6 +122,7 @@ This is enabled through the `.refitter` settings file like this:
   "dependencyInjectionSettings": {
     "baseUrl": "https://petstore3.swagger.io/api/v3",
     "httpMessageHandlers": [ "TelemetryDelegatingHandler" ],
+    "useWindowsAuthentication": true,
     "transientErrorHandler": "Polly",
     "maxRetryCount": 3,
     "firstBackoffRetryInSeconds": 0.5

--- a/docs/json-schema.json
+++ b/docs/json-schema.json
@@ -211,6 +211,10 @@
             "type": "string"
           }
         },
+        "useWindowsAuthentication": {
+          "description": "Set this to true to use the current Windows user's credentials for HTTP authentication.",
+          "type": "boolean"
+        },
         "usePolly": {
           "description": "Set this to true to use Polly for transient fault handling.\nThis is deprecated. Use TransientErrorHandler instead.",
           "type": "boolean"

--- a/src/Refitter.Core/Pipeline/DependencyInjectionGenerator.cs
+++ b/src/Refitter.Core/Pipeline/DependencyInjectionGenerator.cs
@@ -61,9 +61,9 @@ internal static class DependencyInjectionGenerator
             _
                 => """
                     using System;
-                        using System.Net.Http;
-                        using Microsoft.Extensions.DependencyInjection;
-                        using Refit;
+                    using System.Net.Http;
+                    using Microsoft.Extensions.DependencyInjection;
+                    using Refit;
                     """
         };
 
@@ -93,7 +93,7 @@ internal static class DependencyInjectionGenerator
                 $$"""
                               var {{clientBuilderName}} = services
                                   .AddRefitClient<{{interfaceName}}>(settings)
-                  {{(iocSettings.UseWindowsAuthentication ? ".ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseDefaultCredentials = true })" : "")}}
+                                  {{(iocSettings.UseWindowsAuthentication ? ".ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseDefaultCredentials = true })" : "")}}
                                   {{configureRefitClient}}
                   """);
 

--- a/src/Refitter.Core/Pipeline/DependencyInjectionGenerator.cs
+++ b/src/Refitter.Core/Pipeline/DependencyInjectionGenerator.cs
@@ -43,6 +43,7 @@ internal static class DependencyInjectionGenerator
             TransientErrorHandler.Polly
                 => """
                     using System;
+                        using System.Net.Http;
                         using Microsoft.Extensions.DependencyInjection;
                         using Polly;
                         using Polly.Contrib.WaitAndRetry;
@@ -52,6 +53,7 @@ internal static class DependencyInjectionGenerator
             TransientErrorHandler.HttpResilience
                 => """
                     using System;
+                        using System.Net.Http;
                         using Microsoft.Extensions.DependencyInjection;
                         using Microsoft.Extensions.Http.Resilience;
                         using Refit;
@@ -59,6 +61,7 @@ internal static class DependencyInjectionGenerator
             _
                 => """
                     using System;
+                        using System.Net.Http;
                         using Microsoft.Extensions.DependencyInjection;
                         using Refit;
                     """
@@ -90,6 +93,7 @@ internal static class DependencyInjectionGenerator
                 $$"""
                               var {{clientBuilderName}} = services
                                   .AddRefitClient<{{interfaceName}}>(settings)
+                  {{(iocSettings.UseWindowsAuthentication ? ".ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseDefaultCredentials = true })" : "")}}
                                   {{configureRefitClient}}
                   """);
 

--- a/src/Refitter.Core/Settings/DependencyInjectionSettings.cs
+++ b/src/Refitter.Core/Settings/DependencyInjectionSettings.cs
@@ -34,6 +34,12 @@ public class DependencyInjectionSettings
     public string[] HttpMessageHandlers { get; set; } = Array.Empty<string>();
 
     /// <summary>
+    /// Set this to true to use the current Windows user's credentials for HTTP authentication.
+    /// </summary>
+    [Description("Set this to true to use the current Windows user's credentials for HTTP authentication.")]
+    public bool UseWindowsAuthentication { get; set; }
+
+    /// <summary>
     /// Set this to true to use Polly for transient fault handling.
     /// This is deprecated. Use TransientErrorHandler instead.
     /// </summary>

--- a/src/Refitter.MSBuild/README.md
+++ b/src/Refitter.MSBuild/README.md
@@ -150,6 +150,7 @@ The following is an example `.refitter` file
         "AuthorizationMessageHandler",
         "TelemetryMessageHandler"
     ],
+    "useWindowsAuthentication": true, // Optional. Default=false
     "transientErrorHandler": "Polly", // Optional. Value=None|Polly|HttpResilience
     "maxRetryCount": 3, // Optional. Default=6
     "firstBackoffRetryInSeconds": 0.5 // Optional. Default=1.0
@@ -256,7 +257,7 @@ The following is an example `.refitter` file using multiple OpenAPI specificatio
 - `useDynamicQuerystringParameters`: Set to `true` to wrap multiple query parameters into a single complex one. Default is `false` (no wrapping). See <https://github.com/reactiveui/refit?tab=readme-ov-file#dynamic-querystring-parameters> for more information.
 - `usePolymorphicSerialization`: Set to `true` to use `System.Text.Json` polymorphic serialization. Default is `false`
 - `generateDisposableClients`: Set to `true` to generate Refit clients that implement `IDisposable`. Default is `false`
-- `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
+- `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients, including optional Windows Authentication support
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL
   - `httpMessageHandlers` - A collection of `HttpMessageHandler` that is added to the HttpClient pipeline
   - `transientErrorHandler` - This is the transient error handler to use. Possible values are `None`, `Polly`, and `HttpResilience`. Default is `None`

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net.Http;
 
 using Refitter.Tests.AdditionalFiles.SingeInterface;
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
@@ -7,6 +7,7 @@ using Refit;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using System.Net.Http;
 
 #nullable enable annotations
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
@@ -7,6 +7,7 @@ using Refit;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using System.Net.Http;
 
 #nullable enable annotations
 
@@ -467,6 +468,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterface
         {
             var clientBuilderISwaggerPetstoreInterface = services
                 .AddRefitClient<ISwaggerPetstoreInterface>(settings)
+                .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseDefaultCredentials = true })
                 .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"))
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/SwaggerPetstoreSingleInterfaceWithPolly.refitter
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/SwaggerPetstoreSingleInterfaceWithPolly.refitter
@@ -12,6 +12,7 @@
     "transientErrorHandler": "Polly",
     "maxRetryCount": 3,
     "firstBackoffRetryInSeconds": 0.5,
+    "useWindowsAuthentication": true,
     "httpMessageHandlers": [
       "EmptyMessageHandler",
       "AnotherEmptyMessageHandler"

--- a/src/Refitter.SourceGenerator/README.md
+++ b/src/Refitter.SourceGenerator/README.md
@@ -98,6 +98,7 @@ The following is an example `.refitter` file
         "AuthorizationMessageHandler",
         "TelemetryMessageHandler"
     ],
+    "useWindowsAuthentication": true, // Optional. Default=false
     "transientErrorHandler": "Polly", // Optional. Value=None|Polly|HttpResilience
     "maxRetryCount": 3, // Optional. Default=6
     "firstBackoffRetryInSeconds": 0.5 // Optional. Default=1.0
@@ -205,7 +206,7 @@ The following is an example `.refitter` file using multiple OpenAPI specificatio
 - `operationNameGenerator`: The NSwag `IOperationNameGenerator` implementation to use. See <https://refitter.github.io/api/Refitter.Core.OperationNameGeneratorTypes.html>
 - `immutableRecords`: Set to `true` to generate contracts as immutable records instead of classes. Default is `false`
 - `useDynamicQuerystringParameters`: Set to `true` to wrap multiple query parameters into a single complex one. Default is `false` (no wrapping). See <https://github.com/reactiveui/refit?tab=readme-ov-file#dynamic-querystring-parameters> for more information.
-- `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
+- `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients, including optional Windows Authentication support
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL
   - `httpMessageHandlers` - A collection of `HttpMessageHandler` that is added to the HttpClient pipeline
   - `transientErrorHandler` - This is the transient error handler to use. Possible values are `None`, `Polly`, and `HttpResilience`. Default is `None`

--- a/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorBranchTests.cs
+++ b/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorBranchTests.cs
@@ -243,4 +243,25 @@ public class DependencyInjectionGeneratorBranchTests
         code.Should().Contain("using Microsoft.Extensions.Http.Resilience");
         code.Should().Contain("AddStandardResilienceHandler");
     }
+
+    [Test]
+    public void Does_Not_Generate_Windows_Authentication_By_Default()
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            DependencyInjectionSettings = new DependencyInjectionSettings
+            {
+                BaseUrl = "https://petstore3.swagger.io/api/v3",
+                HttpMessageHandlers = Array.Empty<string>(),
+                TransientErrorHandler = TransientErrorHandler.None
+            }
+        };
+
+        string code = DependencyInjectionGenerator.Generate(
+            settings,
+            new[] { "IPetApi" });
+
+        code.Should().NotContain("ConfigurePrimaryHttpMessageHandler");
+        code.Should().NotContain("HttpClientHandler { UseDefaultCredentials = true }");
+    }
 }

--- a/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorBranchTests.cs
+++ b/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorBranchTests.cs
@@ -264,4 +264,26 @@ public class DependencyInjectionGeneratorBranchTests
         code.Should().NotContain("ConfigurePrimaryHttpMessageHandler");
         code.Should().NotContain("HttpClientHandler { UseDefaultCredentials = true }");
     }
+
+    [Test]
+    public void Can_Generate_Windows_Authentication_For_TransientErrorHandler_None()
+    {
+        var settings = new RefitGeneratorSettings
+        {
+            DependencyInjectionSettings = new DependencyInjectionSettings
+            {
+                BaseUrl = "https://petstore3.swagger.io/api/v3",
+                HttpMessageHandlers = Array.Empty<string>(),
+                TransientErrorHandler = TransientErrorHandler.None,
+                UseWindowsAuthentication = true
+            }
+        };
+
+        string code = DependencyInjectionGenerator.Generate(
+            settings,
+            new[] { "IPetApi" });
+
+        code.Should().Contain("using System.Net.Http");
+        code.Should().Contain(".ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseDefaultCredentials = true })");
+    }
 }

--- a/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorWithPollyTests.cs
+++ b/src/Refitter.Tests/DependencyInjection/DependencyInjectionGeneratorWithPollyTests.cs
@@ -69,6 +69,30 @@ public class DependencyInjectionGeneratorWithPollyTests
     }
 
     [Test]
+    public void Can_Generate_With_Windows_Authentication_And_Polly()
+    {
+        settings.DependencyInjectionSettings!.UseWindowsAuthentication = true;
+
+        string code = DependencyInjectionGenerator.Generate(
+            settings,
+            new[]
+            {
+                "IPetApi",
+                "IStoreApi"
+            });
+
+        code.Should().Contain("using System.Net.Http");
+        code.Should().Contain(".ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseDefaultCredentials = true })");
+        code.Should().Contain(".ConfigureHttpClient(c => c.BaseAddress = new Uri(\"https://petstore3.swagger.io/api/v3\"))");
+        code.IndexOf(".ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseDefaultCredentials = true })")
+            .Should().BeLessThan(code.IndexOf(".ConfigureHttpClient(c => c.BaseAddress = new Uri(\"https://petstore3.swagger.io/api/v3\"))"));
+        code.IndexOf(".ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseDefaultCredentials = true })")
+            .Should().BeLessThan(code.IndexOf(".AddHttpMessageHandler<AuthorizationMessageHandler>()"));
+        code.IndexOf(".AddHttpMessageHandler<DiagnosticMessageHandler>()")
+            .Should().BeLessThan(code.IndexOf(".AddPolicyHandler("));
+    }
+
+    [Test]
     public void Can_Generate_Without_Polly()
     {
         settings.DependencyInjectionSettings!.TransientErrorHandler = TransientErrorHandler.None;

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -197,6 +197,7 @@ The following is an example `.refitter` file
         "AuthorizationMessageHandler",
         "TelemetryMessageHandler"
     ],
+    "useWindowsAuthentication": true, // Optional. Default=false
     "transientErrorHandler": "Polly", // Optional. Value=None|Polly|HttpResilience
     "maxRetryCount": 3, // Optional. Default=6
     "firstBackoffRetryInSeconds": 0.5 // Optional. Default=1.0
@@ -303,7 +304,7 @@ The following is an example `.refitter` file using multiple OpenAPI specificatio
 - `immutableRecords`: Set to `true` to generate contracts as immutable records instead of classes. Default is `false`
 - `useDynamicQuerystringParameters`: Set to `true` to wrap multiple query parameters into a single complex one. Default is `false` (no wrapping). See <https://github.com/reactiveui/refit?tab=readme-ov-file#dynamic-querystring-parameters> for more information.
 - `usePolymorphicSerialization`: Set to `true` to use `System.Text.Json` polymorphic serialization.
-- `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients
+- `dependencyInjectionSettings` - Setting this will generated extension methods to `IServiceCollection` for configuring Refit clients, including optional Windows Authentication support
   - `baseUrl` - Used as the HttpClient base address. Leave this blank to manually set the base URL
   - `httpMessageHandlers` - A collection of `HttpMessageHandler` that is added to the HttpClient pipeline
   - `transientErrorHandler` - This is the transient error handler to use. Possible values are `None`, `Polly`, and `HttpResilience`. Default is `None`

--- a/test/MinimalApi/petstore.refitter
+++ b/test/MinimalApi/petstore.refitter
@@ -7,7 +7,8 @@
     "httpMessageHandlers": [ "TelemetryDelegatingHandler" ],
     "transientErrorHandler": "Polly",
     "maxRetryCount": 3,
-    "firstBackoffRetryInSeconds": 0.5
+    "firstBackoffRetryInSeconds": 0.5,
+    "useWindowsAuthentication": true
   },  
   "codeGeneratorSettings": {
     "dateType": "System.DateTime",

--- a/test/MultipleFiles/petstore.refitter
+++ b/test/MultipleFiles/petstore.refitter
@@ -13,7 +13,8 @@
     "baseUrl": "https://petstore3.swagger.io/api/v3",
     "transientErrorHandler": "HttpResilience",
     "maxRetryCount": 3,
-    "firstBackoffRetryInSeconds": 0.5
+    "firstBackoffRetryInSeconds": 0.5,
+    "useWindowsAuthentication": true
   },
   "codeGeneratorSettings": {
     "dateType": "System.DateTime",

--- a/test/petstore.refitter
+++ b/test/petstore.refitter
@@ -14,7 +14,8 @@
     "baseUrl": "https://petstore3.swagger.io/api/v3",
     "transientErrorHandler": "Polly",
     "maxRetryCount": 3,
-    "firstBackoffRetryInSeconds": 0.5
+    "firstBackoffRetryInSeconds": 0.5,
+    "useWindowsAuthentication": true
   },
   "codeGeneratorSettings": {
     "dateType": "System.DateTime",


### PR DESCRIPTION
Closes #1170 

Adds `UseWindowsAuthentication` to `DependencyInjectionSettings` and generates `ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseDefaultCredentials = true })` for `ConfigureRefitClients()`.

Includes generator tests, source-generator snapshots, `.refitter` fixtures, schema/docs, and README examples.

Validation: `dotnet build -c Release src/Refitter.slnx`; `dotnet test src/Refitter.Tests/Refitter.Tests.csproj -c Release --no-build`; `dotnet test src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj -c Release --no-build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `dependencyInjectionSettings.useWindowsAuthentication` to enable Windows Authentication when configuring generated HTTP clients.

* **Bug Fixes**
  * When enabled, generated registrations now correctly set up the primary HTTP message handler with default Windows credentials (and keep existing retry/policy wiring intact).

* **Tests**
  * Added unit tests covering default behavior (off) and Windows Authentication (on), including ordering with retry/policy configuration.

* **Documentation**
  * Updated README and article examples, plus the JSON schema, to document the new option and its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->