### PR TITLE
Fix GHSA-x6w4-f264-3vvr: restrict unrestricted $ref resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ OPTIONS:
         --no-banner                                              Don't show donation banner
         --simple-output                                          Generate simple, plain-text console output without ASCII art, tables, emojis, or color formatting (suitable for IDE output windows)
         --skip-default-additional-properties                     Set to true to skip default additional properties
+        --allow-remote-refs                                      Resolve remote (http/https) $ref references inside the document. Disabled by default to prevent generation-time SSRF
         --collection-format                      Multi           Determines the format of collection parameters. May be one of Multi, Csv, Ssv, Tsv, Pipes
         --operation-name-generator              Default          The NSwag IOperationNameGenerator implementation to use.
                                                                  May be one of:
@@ -274,6 +275,7 @@ The following is an example `.refitter` file using a single OpenAPI specificatio
   ],
   "includeInheritanceHierarchy": false, // Optional. Default=false. Set to true to keep all possible type-instances of inheritance/union types. This works in conjunction with trimUnusedSchema.
   "generateDefaultAdditionalProperties": true, // Optional. default=true
+  "allowRemoteReferences": false, // Optional. Default=false. When true, remote http/https $ref references inside the document are resolved
   "operationNameGenerator": "Default", // Optional. May be one of Default, MultipleClientsFromOperationId, MultipleClientsFromPathSegments, MultipleClientsFromFirstTagAndOperationId, MultipleClientsFromFirstTagAndOperationName, MultipleClientsFromFirstTagAndPathSegments, SingleClientFromOperationId, SingleClientFromPathSegments
   "immutableRecords": false,
   "useDynamicQuerystringParameters": true, // Optional. Default=false
@@ -395,6 +397,7 @@ The following is an example `.refitter` file using multiple OpenAPI specificatio
 - `trimUnusedSchema` - Removes unreferenced components schema to keep the generated output to a minimum
 - `keepSchemaPatterns`: A collection of regular expressions to force to keep matching schema. This is used together with `trimUnusedSchema`
 - `includeInheritanceHierarchy`: Set to true to keep all possible type-instances of inheritance/union types. If this is false only directly referenced types will be kept. This works in conjunction with `trimUnusedSchema`
+- `allowRemoteReferences` - a boolean controlling whether remote (`http`/`https`) `$ref` references inside the OpenAPI document are resolved. Disabled by default to prevent generation-time SSRF and remote file inclusion. Local `$ref` references are always confined to the input document's directory tree. Top-level remote document URLs remain allowed. Default is `false`
 - `generateDefaultAdditionalProperties`: Set to `false` to skip default additional properties. Default is `true`
 - `operationNameGenerator`: The NSwag `IOperationNameGenerator` implementation to use. See <https://refitter.github.io/api/Refitter.Core.OperationNameGeneratorTypes.html>
 - `immutableRecords`: Set to `true` to generate contracts as immutable records instead of classes. Default is `false`

--- a/docs/docfx_project/articles/cli-tool.md
+++ b/docs/docfx_project/articles/cli-tool.md
@@ -87,6 +87,7 @@ OPTIONS:
         --include-inheritance-hierarchy                          Keep all possible inherited types/union types even if they are not directly used
         --no-banner                                              Don't show donation banner
         --skip-default-additional-properties                     Set to true to skip default additional properties
+        --allow-remote-refs                                      Resolve remote (http/https) $ref references inside the document. Disabled by default to prevent generation-time SSRF
         --simple-output                                          Generate output with no color, no formatting, no emojis, and no banners suitable for terminal or IDE output
         --collection-format                      Multi           Determines the format of collection parameters. May be one of:
                                                                  - Multi (separate parameter instances for each array item)

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -62,6 +62,7 @@ The following is an example `.refitter` file
     "^Person.+"
   ],
   "generateDefaultAdditionalProperties": true, // Optional. default=true
+  "allowRemoteReferences": false, // Optional. Default=false. When true, remote http/https $ref references inside the document are resolved
   "operationNameGenerator": "Default", // Optional. May be one of Default, MultipleClientsFromOperationId, MultipleClientsFromPathSegments, MultipleClientsFromFirstTagAndOperationId, MultipleClientsFromFirstTagAndOperationName, MultipleClientsFromFirstTagAndPathSegments, SingleClientFromOperationId, SingleClientFromPathSegments
   "immutableRecords": false,
   "useDynamicQuerystringParameters": false, // Optional. Default=false
@@ -185,6 +186,7 @@ When using `openApiPaths`, the documents are merged into a single generated clie
 - `keepSchemaPatterns`: A collection of regular expressions to force to keep matching schema. This is used together with `trimUnusedSchema`
 - `includeInheritanceHierarchy`: Set to true to keep all possible type-instances of inheritance/union types. If this is false only directly referenced types will be kept. This works in conjunction with `trimUnusedSchema`
 - `generateDefaultAdditionalProperties`: Set to `false` to skip default additional properties. Default is `true`
+- `allowRemoteReferences`: When `true`, remote (`http`/`https`) `$ref` references inside the document are resolved. Disabled by default to prevent generation-time SSRF and remote file inclusion. Local `$ref` references are always confined to the input document's directory tree. Default is `false`
 - `operationNameGenerator`: The NSwag `IOperationNameGenerator` implementation to use. See <https://refitter.github.io/api/Refitter.Core.OperationNameGeneratorTypes.html>
 - `immutableRecords`: Set to `true` to generate contracts as immutable records instead of classes. Default is `false`
 - `useDynamicQuerystringParameters`: Set to `true` to wrap multiple query parameters into a single complex one. Default is `false` (no wrapping). See <https://github.com/reactiveui/refit?tab=readme-ov-file#dynamic-querystring-parameters> for more information.

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -413,6 +413,10 @@ When using `openApiPaths`, the documents are merged into a single generated clie
             "type": "boolean",
             "description": "Indicates whether to generate default additional properties."
         },
+        "allowRemoteReferences": {
+            "type": "boolean",
+            "description": "When true, remote (http/https) $ref references inside the document are resolved. Disabled by default to prevent generation-time SSRF and remote file inclusion. Local $ref references are always confined to the input document's directory tree."
+        },
         "operationNameGenerator": {
             "type": "string",
             "description": "The generator used to generate operation names."

--- a/docs/json-schema.json
+++ b/docs/json-schema.json
@@ -474,6 +474,10 @@
       "description": "Skip default additional properties. Default is true.",
       "type": "boolean"
     },
+    "allowRemoteReferences": {
+      "description": "Resolve remote (http/https) $ref references inside the OpenAPI document. Disabled by default to prevent generation-time SSRF. Top-level remote document URLs are always allowed.",
+      "type": "boolean"
+    },
     "immutableRecords": {
       "description": "Generate contracts as immutable records instead of classes.",
       "type": "boolean"

--- a/src/Refitter.Core/Abstractions/IValidator.cs
+++ b/src/Refitter.Core/Abstractions/IValidator.cs
@@ -14,7 +14,8 @@ public interface IValidator
     /// Validates the specified OpenAPI specification file.
     /// </summary>
     /// <param name="openApiPath">The path to the OpenAPI specification file.</param>
+    /// <param name="allowRemoteReferences">When false, remote and out-of-tree <c>$ref</c> references are rejected.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>An <see cref="OpenApiValidationResult"/> containing diagnostics and element counts.</returns>
-    Task<OpenApiValidationResult> ValidateAsync(string openApiPath, CancellationToken cancellationToken = default);
+    Task<OpenApiValidationResult> ValidateAsync(string openApiPath, bool allowRemoteReferences = false, CancellationToken cancellationToken = default);
 }

--- a/src/Refitter.Core/Document/OpenApiDocumentFactory.cs
+++ b/src/Refitter.Core/Document/OpenApiDocumentFactory.cs
@@ -16,12 +16,14 @@ public static class OpenApiDocumentFactory
     /// The first document serves as the base; paths and schemas from subsequent documents are merged in.
     /// </summary>
     /// <param name="openApiPaths">The paths or URLs to the OpenAPI specifications.</param>
+    /// <param name="allowRemoteReferences">When false, remote and out-of-tree <c>$ref</c> references are rejected.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A merged <see cref="NSwag.OpenApiDocument"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="openApiPaths"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="openApiPaths"/> is empty.</exception>
     public static async Task<OpenApiDocument> CreateAsync(
         IEnumerable<string> openApiPaths,
+        bool allowRemoteReferences = false,
         CancellationToken cancellationToken = default)
     {
         if (openApiPaths == null)
@@ -32,12 +34,13 @@ public static class OpenApiDocumentFactory
             throw new ArgumentException("At least one OpenAPI path must be specified.", nameof(openApiPaths));
 
         if (paths.Length == 1)
-            return await CreateAsync(paths[0], cancellationToken).ConfigureAwait(false);
+            return await CreateAsync(paths[0], allowRemoteReferences, cancellationToken).ConfigureAwait(false);
 
         var documents = new OpenApiDocument[paths.Length];
         for (var i = 0; i < paths.Length; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            await ReferenceGuard.ValidateAsync(paths[i], allowRemoteReferences, cancellationToken).ConfigureAwait(false);
             documents[i] = await DocumentLoader.LoadAsync(paths[i], cancellationToken).ConfigureAwait(false);
         }
 
@@ -48,12 +51,15 @@ public static class OpenApiDocumentFactory
     /// Creates a new instance of the <see cref="NSwag.OpenApiDocument"/> class asynchronously.
     /// </summary>
     /// <param name="openApiPath">The path or URL to the OpenAPI specification.</param>
+    /// <param name="allowRemoteReferences">When false, remote and out-of-tree <c>$ref</c> references are rejected.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A new instance of the <see cref="NSwag.OpenApiDocument"/> class.</returns>
     public static async Task<OpenApiDocument> CreateAsync(
         string openApiPath,
+        bool allowRemoteReferences = false,
         CancellationToken cancellationToken = default)
     {
+        await ReferenceGuard.ValidateAsync(openApiPath, allowRemoteReferences, cancellationToken).ConfigureAwait(false);
         return await DocumentLoader.LoadAsync(openApiPath, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Refitter.Core/Document/OpenApiDocumentFactory.cs
+++ b/src/Refitter.Core/Document/OpenApiDocumentFactory.cs
@@ -48,7 +48,10 @@ public static class OpenApiDocumentFactory
                 try
                 {
                     using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
-                    content = await client.GetStringAsync(paths[i], cancellationToken).ConfigureAwait(false);
+                    using var httpResponse = await client.SendAsync(
+                        new HttpRequestMessage(HttpMethod.Get, paths[i]),
+                        cancellationToken).ConfigureAwait(false);
+                    content = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -101,7 +104,10 @@ public static class OpenApiDocumentFactory
             try
             {
                 using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
-                content = await client.GetStringAsync(openApiPath, cancellationToken).ConfigureAwait(false);
+                using var httpResponse = await client.SendAsync(
+                    new HttpRequestMessage(HttpMethod.Get, openApiPath),
+                    cancellationToken).ConfigureAwait(false);
+                content = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/Refitter.Core/Document/OpenApiDocumentFactory.cs
+++ b/src/Refitter.Core/Document/OpenApiDocumentFactory.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 using OpenApiDocument = NSwag.OpenApiDocument;
 
 namespace Refitter.Core;
@@ -47,7 +49,8 @@ public static class OpenApiDocumentFactory
                 string content;
                 try
                 {
-                    using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+                    using var handler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
+                    using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
                     using var httpResponse = await client.SendAsync(
                         new HttpRequestMessage(HttpMethod.Get, paths[i]),
                         cancellationToken).ConfigureAwait(false);
@@ -103,7 +106,8 @@ public static class OpenApiDocumentFactory
             string content;
             try
             {
-                using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+                using var handler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
+                using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
                 using var httpResponse = await client.SendAsync(
                     new HttpRequestMessage(HttpMethod.Get, openApiPath),
                     cancellationToken).ConfigureAwait(false);

--- a/src/Refitter.Core/Document/OpenApiDocumentFactory.cs
+++ b/src/Refitter.Core/Document/OpenApiDocumentFactory.cs
@@ -40,12 +40,47 @@ public static class OpenApiDocumentFactory
         for (var i = 0; i < paths.Length; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await ReferenceGuard.ValidateAsync(paths[i], allowRemoteReferences, cancellationToken).ConfigureAwait(false);
-            documents[i] = await DocumentLoader.LoadAsync(paths[i], cancellationToken).ConfigureAwait(false);
+
+            // For remote URLs, fetch once and reuse content for both validation and parsing
+            if (PathUtilities.IsHttp(paths[i]))
+            {
+                string content;
+                try
+                {
+                    using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+                    content = await client.GetStringAsync(paths[i], cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"Failed to download OpenAPI document from '{paths[i]}'.", ex);
+                }
+
+                await ReferenceGuard.ValidateAsync(paths[i], content, allowRemoteReferences, cancellationToken).ConfigureAwait(false);
+
+                documents[i] = PathUtilities.IsYaml(paths[i])
+                    ? await NSwag.OpenApiYamlDocument.FromYamlAsync(content, cancellationToken).ConfigureAwait(false)
+                    : await OpenApiDocument.FromJsonAsync(content, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await ReferenceGuard.ValidateAsync(paths[i], allowRemoteReferences, cancellationToken).ConfigureAwait(false);
+                documents[i] = await DocumentLoader.LoadAsync(paths[i], cancellationToken).ConfigureAwait(false);
+            }
         }
 
         return DocumentMerger.Merge(documents);
     }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="NSwag.OpenApiDocument"/> class asynchronously.
+    /// </summary>
+    /// <param name="openApiPath">The path or URL to the OpenAPI specification.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A new instance of the <see cref="NSwag.OpenApiDocument"/> class.</returns>
+    public static Task<OpenApiDocument> CreateAsync(
+        string openApiPath,
+        CancellationToken cancellationToken) =>
+        CreateAsync(openApiPath, allowRemoteReferences: false, cancellationToken);
 
     /// <summary>
     /// Creates a new instance of the <see cref="NSwag.OpenApiDocument"/> class asynchronously.
@@ -59,6 +94,27 @@ public static class OpenApiDocumentFactory
         bool allowRemoteReferences = false,
         CancellationToken cancellationToken = default)
     {
+        // For remote URLs, fetch once and reuse content for both validation and parsing
+        if (PathUtilities.IsHttp(openApiPath))
+        {
+            string content;
+            try
+            {
+                using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+                content = await client.GetStringAsync(openApiPath, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to download OpenAPI document from '{openApiPath}'.", ex);
+            }
+
+            await ReferenceGuard.ValidateAsync(openApiPath, content, allowRemoteReferences, cancellationToken).ConfigureAwait(false);
+
+            return PathUtilities.IsYaml(openApiPath)
+                ? await NSwag.OpenApiYamlDocument.FromYamlAsync(content, cancellationToken).ConfigureAwait(false)
+                : await OpenApiDocument.FromJsonAsync(content, cancellationToken).ConfigureAwait(false);
+        }
+
         await ReferenceGuard.ValidateAsync(openApiPath, allowRemoteReferences, cancellationToken).ConfigureAwait(false);
         return await DocumentLoader.LoadAsync(openApiPath, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Refitter.Core/Document/ReferenceGuard.cs
+++ b/src/Refitter.Core/Document/ReferenceGuard.cs
@@ -10,11 +10,18 @@ namespace Refitter.Core;
 internal static class ReferenceGuard
 {
     private static readonly Regex RefPattern = new(
-        "[\"']?\\$ref[\"']?\\s*:\\s*[\"']([^\"']+)[\"']",
+        "[\"']?\\$ref[\"']?\\s*:\\s*(?:[\"']([^\"']+)[\"']|([^\\s#][^\\s]*))",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static Task ValidateAsync(
+        string openApiPath,
+        bool allowRemoteReferences,
+        CancellationToken cancellationToken = default) =>
+        ValidateAsync(openApiPath, null, allowRemoteReferences, cancellationToken);
 
     public static async Task ValidateAsync(
         string openApiPath,
+        string? content,
         bool allowRemoteReferences,
         CancellationToken cancellationToken = default)
     {
@@ -23,7 +30,7 @@ internal static class ReferenceGuard
 
         if (PathUtilities.IsHttp(openApiPath))
         {
-            await ValidateRemoteEntryAsync(openApiPath, allowRemoteReferences, cancellationToken)
+            await ValidateRemoteEntryAsync(openApiPath, content, allowRemoteReferences, cancellationToken)
                 .ConfigureAwait(false);
             return;
         }
@@ -40,18 +47,27 @@ internal static class ReferenceGuard
 
     private static async Task ValidateRemoteEntryAsync(
         string url,
+        string? preloadedContent,
         bool allowRemoteReferences,
         CancellationToken cancellationToken)
     {
         string content;
-        try
+        if (preloadedContent != null)
         {
-            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
-            content = await client.GetStringAsync(url).ConfigureAwait(false);
+            content = preloadedContent;
         }
-        catch
+        else
         {
-            return;
+            try
+            {
+                using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+                content = await client.GetStringAsync(url, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                throw new ReferenceResolutionException(
+                    $"Failed to read OpenAPI document from '{url}' during reference validation: {ex.Message}", ex);
+            }
         }
 
         foreach (var reference in ExtractReferences(content))
@@ -59,13 +75,37 @@ internal static class ReferenceGuard
             if (reference.StartsWith("#", StringComparison.Ordinal))
                 continue;
 
-            if (PathUtilities.IsHttp(reference))
+            Uri? resolvedUri = null;
+            if (Uri.TryCreate(reference, UriKind.Absolute, out var absoluteUri))
             {
-                if (!allowRemoteReferences)
-                    throw RemoteBlocked(reference, url);
+                resolvedUri = absoluteUri;
             }
-            else
+            else if (Uri.TryCreate(new Uri(url), reference.Split('#')[0], out var relativeUri))
             {
+                resolvedUri = relativeUri;
+            }
+
+            if (resolvedUri != null && !string.IsNullOrEmpty(resolvedUri.Scheme))
+            {
+                var isHttpScheme = resolvedUri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) ||
+                                   resolvedUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase);
+
+                if (isHttpScheme)
+                {
+                    if (!allowRemoteReferences)
+                        throw RemoteBlocked(reference, url);
+                }
+                else
+                {
+                    // Non-HTTP schemes (file:, data:, etc.) are always blocked
+                    throw RemoteBlocked(reference, url);
+                }
+            }
+            else if (!reference.StartsWith("/", StringComparison.Ordinal) &&
+                     !reference.StartsWith("./", StringComparison.Ordinal) &&
+                     !reference.StartsWith("../", StringComparison.Ordinal))
+            {
+                // Relative references from remote documents treated as remote
                 if (!allowRemoteReferences)
                     throw RemoteBlocked(reference, url);
             }
@@ -89,9 +129,10 @@ internal static class ReferenceGuard
         {
             content = await ReadAllTextAsync(filePath, cancellationToken).ConfigureAwait(false);
         }
-        catch
+        catch (Exception ex)
         {
-            return;
+            throw new ReferenceResolutionException(
+                $"Failed to read OpenAPI document from '{filePath}' during reference validation: {ex.Message}", ex);
         }
 
         var currentDirectory = Path.GetDirectoryName(filePath) ?? rootDirectory;
@@ -129,7 +170,10 @@ internal static class ReferenceGuard
     {
         foreach (Match match in RefPattern.Matches(content))
         {
-            var value = match.Groups[1].Value.Trim();
+            // Group 1 = quoted value, Group 2 = unquoted YAML scalar
+            var value = !string.IsNullOrEmpty(match.Groups[1].Value)
+                ? match.Groups[1].Value.Trim()
+                : match.Groups[2].Value.Trim();
             if (value.Length > 0)
                 yield return value;
         }
@@ -140,9 +184,15 @@ internal static class ReferenceGuard
         var root = Path.GetFullPath(rootDirectory)
             .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var path = Path.GetFullPath(candidate);
-        return path.Equals(root, StringComparison.OrdinalIgnoreCase) ||
-               path.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
-               path.StartsWith(root + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+
+        // Use filesystem-aware comparison: case-sensitive on Linux/macOS, case-insensitive on Windows
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        return path.Equals(root, comparison) ||
+               path.StartsWith(root + Path.DirectorySeparatorChar, comparison) ||
+               path.StartsWith(root + Path.AltDirectorySeparatorChar, comparison);
     }
 
     private static ReferenceResolutionException RemoteBlocked(string reference, string source) =>

--- a/src/Refitter.Core/Document/ReferenceGuard.cs
+++ b/src/Refitter.Core/Document/ReferenceGuard.cs
@@ -56,6 +56,9 @@ internal static class ReferenceGuard
 
         foreach (var reference in ExtractReferences(content))
         {
+            if (reference.StartsWith("#", StringComparison.Ordinal))
+                continue;
+
             if (PathUtilities.IsHttp(reference))
             {
                 if (!allowRemoteReferences)
@@ -63,9 +66,8 @@ internal static class ReferenceGuard
             }
             else
             {
-                throw new ReferenceResolutionException(
-                    $"Local '$ref' \"{reference}\" in remote document \"{url}\" was rejected. " +
-                    "Refitter does not resolve local files referenced from a remote document.");
+                if (!allowRemoteReferences)
+                    throw RemoteBlocked(reference, url);
             }
         }
     }

--- a/src/Refitter.Core/Document/ReferenceGuard.cs
+++ b/src/Refitter.Core/Document/ReferenceGuard.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 namespace Refitter.Core;
@@ -61,7 +62,10 @@ internal static class ReferenceGuard
             try
             {
                 using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
-                content = await client.GetStringAsync(url, cancellationToken).ConfigureAwait(false);
+                using var httpResponse = await client.SendAsync(
+                    new HttpRequestMessage(HttpMethod.Get, url),
+                    cancellationToken).ConfigureAwait(false);
+                content = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -186,7 +190,7 @@ internal static class ReferenceGuard
         var path = Path.GetFullPath(candidate);
 
         // Use filesystem-aware comparison: case-sensitive on Linux/macOS, case-insensitive on Windows
-        var comparison = OperatingSystem.IsWindows()
+        var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
 

--- a/src/Refitter.Core/Document/ReferenceGuard.cs
+++ b/src/Refitter.Core/Document/ReferenceGuard.cs
@@ -1,0 +1,156 @@
+using System.Text.RegularExpressions;
+
+namespace Refitter.Core;
+
+/// <summary>
+/// Validates <c>$ref</c> references inside an OpenAPI document before it is resolved, to prevent
+/// generation-time SSRF / remote file inclusion (remote <c>http(s)</c> refs) and local file inclusion
+/// (absolute paths or <c>../</c> traversal that escapes the input document's directory).
+/// </summary>
+internal static class ReferenceGuard
+{
+    private static readonly Regex RefPattern = new(
+        "[\"']?\\$ref[\"']?\\s*:\\s*[\"']([^\"']+)[\"']",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static async Task ValidateAsync(
+        string openApiPath,
+        bool allowRemoteReferences,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(openApiPath))
+            return;
+
+        if (PathUtilities.IsHttp(openApiPath))
+        {
+            await ValidateRemoteEntryAsync(openApiPath, allowRemoteReferences, cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        var fullPath = Path.GetFullPath(openApiPath);
+        if (!File.Exists(fullPath))
+            return;
+
+        var rootDirectory = Path.GetDirectoryName(fullPath) ?? Directory.GetCurrentDirectory();
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await ValidateLocalFileAsync(fullPath, rootDirectory, allowRemoteReferences, visited, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task ValidateRemoteEntryAsync(
+        string url,
+        bool allowRemoteReferences,
+        CancellationToken cancellationToken)
+    {
+        string content;
+        try
+        {
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+            content = await client.GetStringAsync(url).ConfigureAwait(false);
+        }
+        catch
+        {
+            return;
+        }
+
+        foreach (var reference in ExtractReferences(content))
+        {
+            if (PathUtilities.IsHttp(reference))
+            {
+                if (!allowRemoteReferences)
+                    throw RemoteBlocked(reference, url);
+            }
+            else
+            {
+                throw new ReferenceResolutionException(
+                    $"Local '$ref' \"{reference}\" in remote document \"{url}\" was rejected. " +
+                    "Refitter does not resolve local files referenced from a remote document.");
+            }
+        }
+    }
+
+    private static async Task ValidateLocalFileAsync(
+        string filePath,
+        string rootDirectory,
+        bool allowRemoteReferences,
+        HashSet<string> visited,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!visited.Add(filePath) || !File.Exists(filePath))
+            return;
+
+        string content;
+        try
+        {
+            content = await ReadAllTextAsync(filePath, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            return;
+        }
+
+        var currentDirectory = Path.GetDirectoryName(filePath) ?? rootDirectory;
+
+        foreach (var reference in ExtractReferences(content))
+        {
+            if (reference.StartsWith("#", StringComparison.Ordinal))
+                continue;
+
+            if (PathUtilities.IsHttp(reference))
+            {
+                if (!allowRemoteReferences)
+                    throw RemoteBlocked(reference, filePath);
+                continue;
+            }
+
+            var fileRef = reference.Split('#')[0];
+            if (string.IsNullOrWhiteSpace(fileRef))
+                continue;
+
+            var resolved = Path.GetFullPath(Path.Combine(currentDirectory, fileRef));
+            if (!IsWithin(rootDirectory, resolved))
+            {
+                throw new ReferenceResolutionException(
+                    $"Local '$ref' \"{reference}\" resolves to \"{resolved}\", outside the input directory " +
+                    $"\"{rootDirectory}\". Refitter confines local references to the input document's directory tree.");
+            }
+
+            await ValidateLocalFileAsync(resolved, rootDirectory, allowRemoteReferences, visited, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static IEnumerable<string> ExtractReferences(string content)
+    {
+        foreach (Match match in RefPattern.Matches(content))
+        {
+            var value = match.Groups[1].Value.Trim();
+            if (value.Length > 0)
+                yield return value;
+        }
+    }
+
+    private static bool IsWithin(string rootDirectory, string candidate)
+    {
+        var root = Path.GetFullPath(rootDirectory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var path = Path.GetFullPath(candidate);
+        return path.Equals(root, StringComparison.OrdinalIgnoreCase) ||
+               path.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
+               path.StartsWith(root + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ReferenceResolutionException RemoteBlocked(string reference, string source) =>
+        new($"Remote '$ref' \"{reference}\" in \"{source}\" was blocked. " +
+            "Remote reference resolution is disabled by default; pass --allow-remote-refs " +
+            "(or set allowRemoteReferences: true) to enable it.");
+
+    private static async Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken)
+    {
+        using var reader = new StreamReader(path);
+        return await reader.ReadToEndAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Refitter.Core/Document/ReferenceResolutionException.cs
+++ b/src/Refitter.Core/Document/ReferenceResolutionException.cs
@@ -1,0 +1,18 @@
+namespace Refitter.Core;
+
+/// <summary>
+/// Thrown when an OpenAPI document contains a <c>$ref</c> that Refitter refuses to resolve, such as a
+/// remote reference (when remote references are disabled) or a local reference that escapes the input
+/// document's directory tree.
+/// </summary>
+public sealed class ReferenceResolutionException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReferenceResolutionException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public ReferenceResolutionException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Refitter.Core/Document/ReferenceResolutionException.cs
+++ b/src/Refitter.Core/Document/ReferenceResolutionException.cs
@@ -15,4 +15,14 @@ public sealed class ReferenceResolutionException : Exception
         : base(message)
     {
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReferenceResolutionException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public ReferenceResolutionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
 }

--- a/src/Refitter.Core/Pipeline/RefitGenerator.cs
+++ b/src/Refitter.Core/Pipeline/RefitGenerator.cs
@@ -46,7 +46,7 @@ public class RefitGenerator(
     {
         if (settings.OpenApiPaths is { Length: > 0 })
             return await OpenApiDocumentFactory
-                .CreateAsync(settings.OpenApiPaths, cancellationToken)
+                .CreateAsync(settings.OpenApiPaths, settings.AllowRemoteReferences, cancellationToken)
                 .ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(settings.OpenApiPath))
@@ -57,7 +57,7 @@ public class RefitGenerator(
         }
 
         return await OpenApiDocumentFactory
-            .CreateAsync(settings.OpenApiPath!, cancellationToken)
+            .CreateAsync(settings.OpenApiPath!, settings.AllowRemoteReferences, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/Refitter.Core/RefitterRunner.cs
+++ b/src/Refitter.Core/RefitterRunner.cs
@@ -125,6 +125,7 @@ public class RefitterRunner
             {
                 var validationResult = await validator.ValidateAsync(
                     specPath,
+                    settings.AllowRemoteReferences,
                     cancellationToken);
 
                 foreach (var error in validationResult.Diagnostics.Errors)

--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -38,6 +38,15 @@ public class RefitGeneratorSettings : IOutputConfiguration, INamingConfiguration
     public string[]? OpenApiPaths { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether remote <c>$ref</c> references (http/https) inside the
+    /// OpenAPI document are resolved. Disabled by default to prevent generation-time SSRF and remote
+    /// file inclusion. Local <c>$ref</c> references are always confined to the input document's directory.
+    /// </summary>
+    [Description("Resolve remote (http/https) $ref references inside the OpenAPI document. Disabled by default to prevent generation-time SSRF. Top-level remote document URLs are always allowed.")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool AllowRemoteReferences { get; set; }
+
+    /// <summary>
     /// Gets or sets the namespace for the generated code. (default: GeneratedCode)
     /// </summary>
     [Description("The namespace for the generated code. Default is GeneratedCode.")]

--- a/src/Refitter.Core/Validation/OpenApiValidator.cs
+++ b/src/Refitter.Core/Validation/OpenApiValidator.cs
@@ -18,6 +18,9 @@ public static class OpenApiValidator
         string openApiFile,
         CancellationToken cancellationToken = default)
     {
+        await ReferenceGuard.ValidateAsync(openApiFile, allowRemoteReferences: false, cancellationToken)
+            .ConfigureAwait(false);
+
         var result = await OpenApiMultiFileReader.Read(
             openApiFile,
             cancellationToken: cancellationToken);

--- a/src/Refitter.Core/Validation/OpenApiValidator.cs
+++ b/src/Refitter.Core/Validation/OpenApiValidator.cs
@@ -12,25 +12,59 @@ public static class OpenApiValidator
     /// Validates an OpenAPI specification file and returns validation diagnostics and statistics.
     /// </summary>
     /// <param name="openApiFile">The path to the OpenAPI specification file.</param>
+    /// <param name="allowRemoteReferences">When false, remote and out-of-tree <c>$ref</c> references are rejected.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>A <see cref="OpenApiValidationResult"/> containing diagnostics and element counts.</returns>
     public static async Task<OpenApiValidationResult> Validate(
         string openApiFile,
+        bool allowRemoteReferences = false,
         CancellationToken cancellationToken = default)
     {
-        await ReferenceGuard.ValidateAsync(openApiFile, allowRemoteReferences: false, cancellationToken)
+        // For remote URLs, fetch once and validate before parsing
+        if (PathUtilities.IsHttp(openApiFile))
+        {
+            string content;
+            try
+            {
+                using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+                content = await client.GetStringAsync(openApiFile, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to download OpenAPI document from '{openApiFile}'.", ex);
+            }
+
+            await ReferenceGuard.ValidateAsync(openApiFile, content, allowRemoteReferences, cancellationToken)
+                .ConfigureAwait(false);
+
+            // Parse the already-fetched content
+            var document = PathUtilities.IsYaml(openApiFile)
+                ? await NSwag.OpenApiYamlDocument.FromYamlAsync(content, cancellationToken).ConfigureAwait(false)
+                : await NSwag.OpenApiDocument.FromJsonAsync(content, cancellationToken).ConfigureAwait(false);
+
+            var statsVisitor = new OpenApiStats();
+            var walker = new OpenApiWalker(statsVisitor);
+            walker.Walk(document);
+
+            // Create a basic diagnostic since we're not using OpenApiMultiFileReader for remote URLs
+            var diagnostic = new Microsoft.OpenApi.Readers.OpenApiDiagnostic();
+            return new(diagnostic, statsVisitor);
+        }
+
+        // For local files, validate first (reads once), then parse with OpenApiMultiFileReader
+        await ReferenceGuard.ValidateAsync(openApiFile, allowRemoteReferences, cancellationToken)
             .ConfigureAwait(false);
 
         var result = await OpenApiMultiFileReader.Read(
             openApiFile,
             cancellationToken: cancellationToken);
 
-        var statsVisitor = new OpenApiStats();
-        var walker = new OpenApiWalker(statsVisitor);
-        walker.Walk(result.OpenApiDocument);
+        var stats = new OpenApiStats();
+        var openApiWalker = new OpenApiWalker(stats);
+        openApiWalker.Walk(result.OpenApiDocument);
 
         return new(
             result.OpenApiDiagnostic,
-            statsVisitor);
+            stats);
     }
 }

--- a/src/Refitter.Core/Validation/OpenApiValidator.cs
+++ b/src/Refitter.Core/Validation/OpenApiValidator.cs
@@ -27,7 +27,10 @@ public static class OpenApiValidator
             try
             {
                 using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
-                content = await client.GetStringAsync(openApiFile, cancellationToken).ConfigureAwait(false);
+                using var httpResponse = await client.SendAsync(
+                    new HttpRequestMessage(HttpMethod.Get, openApiFile),
+                    cancellationToken).ConfigureAwait(false);
+                content = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -37,17 +40,18 @@ public static class OpenApiValidator
             await ReferenceGuard.ValidateAsync(openApiFile, content, allowRemoteReferences, cancellationToken)
                 .ConfigureAwait(false);
 
-            // Parse the already-fetched content
-            var document = PathUtilities.IsYaml(openApiFile)
-                ? await NSwag.OpenApiYamlDocument.FromYamlAsync(content, cancellationToken).ConfigureAwait(false)
-                : await NSwag.OpenApiDocument.FromJsonAsync(content, cancellationToken).ConfigureAwait(false);
+            // Parse the already-fetched content using Microsoft.OpenApi
+            var readerSettings = new OpenApiReaderSettings();
+            readerSettings.AddYamlReader();
+            using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
+            var loadResult = await OpenApiDocument.LoadAsync(stream, settings: readerSettings, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var msDocument = loadResult.Document;
+            var diagnostic = loadResult.Diagnostic ?? new OpenApiDiagnostic();
 
             var statsVisitor = new OpenApiStats();
             var walker = new OpenApiWalker(statsVisitor);
-            walker.Walk(document);
+            walker.Walk(msDocument);
 
-            // Create a basic diagnostic since we're not using OpenApiMultiFileReader for remote URLs
-            var diagnostic = new Microsoft.OpenApi.Readers.OpenApiDiagnostic();
             return new(diagnostic, statsVisitor);
         }
 

--- a/src/Refitter.Core/Validation/OpenApiValidatorAdapter.cs
+++ b/src/Refitter.Core/Validation/OpenApiValidatorAdapter.cs
@@ -9,8 +9,8 @@ namespace Refitter.Core.Validation;
 public sealed class OpenApiValidatorAdapter : IValidator
 {
     /// <inheritdoc />
-    public async Task<OpenApiValidationResult> ValidateAsync(string openApiPath, CancellationToken cancellationToken = default)
+    public async Task<OpenApiValidationResult> ValidateAsync(string openApiPath, bool allowRemoteReferences = false, CancellationToken cancellationToken = default)
     {
-        return await OpenApiValidator.Validate(openApiPath, cancellationToken);
+        return await OpenApiValidator.Validate(openApiPath, allowRemoteReferences, cancellationToken);
     }
 }

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Net.Http;
 
 using Refitter.Tests.AdditionalFiles.SingeInterface;
 
@@ -512,8 +511,9 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 {
     using System;
-    using Microsoft.Extensions.DependencyInjection;
-    using Refit;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Refit;
 
     /// <summary>
     /// Extension methods for configuring Refit clients in the service collection.
@@ -536,6 +536,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         {
             var clientBuilderIUpdatePetEndpoint = services
                 .AddRefitClient<IUpdatePetEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -544,6 +545,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIAddPetEndpoint = services
                 .AddRefitClient<IAddPetEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -552,6 +554,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIFindPetsByStatusEndpoint = services
                 .AddRefitClient<IFindPetsByStatusEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -560,6 +563,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIFindPetsByTagsEndpoint = services
                 .AddRefitClient<IFindPetsByTagsEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -568,6 +572,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetPetByIdEndpoint = services
                 .AddRefitClient<IGetPetByIdEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -576,6 +581,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIUpdatePetWithFormEndpoint = services
                 .AddRefitClient<IUpdatePetWithFormEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -584,6 +590,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIDeletePetEndpoint = services
                 .AddRefitClient<IDeletePetEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -592,6 +599,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIUploadFileEndpoint = services
                 .AddRefitClient<IUploadFileEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -600,6 +608,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetInventoryEndpoint = services
                 .AddRefitClient<IGetInventoryEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -608,6 +617,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIPlaceOrderEndpoint = services
                 .AddRefitClient<IPlaceOrderEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -616,6 +626,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetOrderByIdEndpoint = services
                 .AddRefitClient<IGetOrderByIdEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -624,6 +635,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIDeleteOrderEndpoint = services
                 .AddRefitClient<IDeleteOrderEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -632,6 +644,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderICreateUserEndpoint = services
                 .AddRefitClient<ICreateUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -640,6 +653,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderICreateUsersWithListInputEndpoint = services
                 .AddRefitClient<ICreateUsersWithListInputEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -648,6 +662,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderILoginUserEndpoint = services
                 .AddRefitClient<ILoginUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -656,6 +671,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderILogoutUserEndpoint = services
                 .AddRefitClient<ILogoutUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -664,6 +680,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetUserByNameEndpoint = services
                 .AddRefitClient<IGetUserByNameEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -672,6 +689,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIUpdateUserEndpoint = services
                 .AddRefitClient<IUpdateUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -680,6 +698,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIDeleteUserEndpoint = services
                 .AddRefitClient<IDeleteUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
@@ -7,7 +7,6 @@ using Refit;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using System.Net.Http;
 
 #nullable enable annotations
 
@@ -743,6 +742,7 @@ public PetStatus Status { get; set; }
 namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
 {
     using System;
+    using System.Net.Http;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Http.Resilience;
     using Refit;
@@ -766,6 +766,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         {
             var clientBuilderISwaggerPetstoreInterfaceWithHttpResilience = services
                 .AddRefitClient<ISwaggerPetstoreInterfaceWithHttpResilience>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"));
 
             clientBuilderISwaggerPetstoreInterfaceWithHttpResilience

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
@@ -7,7 +7,6 @@ using Refit;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using System.Net.Http;
 
 #nullable enable annotations
 
@@ -453,6 +452,7 @@ public PetStatus Status { get; set; }
 namespace Refitter.Tests.AdditionalFiles.SingeInterface
 {
     using System;
+    using System.Net.Http;
     using Microsoft.Extensions.DependencyInjection;
     using Polly;
     using Polly.Contrib.WaitAndRetry;

--- a/src/Refitter.Tests/OpenApi/OpenApiDocumentFactoryTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiDocumentFactoryTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Refitter.Core;
 using Refitter.Tests.Resources;
+using Refitter.Tests.TestUtilities;
 
 namespace Refitter.Tests.OpenApi;
 
@@ -16,6 +17,132 @@ public class OpenApiDocumentFactoryTests
         (await OpenApiDocumentFactory.CreateAsync(settings.OpenApiPath))
             .Should()
             .NotBeNull();
+    }
+
+    [Test]
+    public async Task Create_From_Remote_Json_Uses_Remote_Branch()
+    {
+        var openApiSpec = EmbeddedResources.GetSwaggerPetstore(SampleOpenSpecifications.SwaggerPetstoreJsonV3);
+        await using var server = new LocalHttpServer(openApiSpec);
+
+        var document = await OpenApiDocumentFactory.CreateAsync(server.Url);
+
+        document.Should().NotBeNull();
+        document.Info.Should().NotBeNull();
+        document.Info.Title.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Create_From_Remote_Json_Throws_When_Download_Fails()
+    {
+        var act = () => OpenApiDocumentFactory.CreateAsync("http://127.0.0.1:1/openapi.json");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Failed to download OpenAPI document*");
+    }
+
+    [Test]
+    public async Task Create_From_Multiple_Paths_With_Remote_Entry_Merges_Successfully()
+    {
+        var remoteSpec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""title"": ""Remote API"",
+    ""version"": ""1.0.0""
+  },
+  ""paths"": {
+    ""/remote"": {
+      ""get"": {
+        ""operationId"": ""GetRemote"",
+        ""responses"": {
+          ""200"": {
+            ""description"": ""ok""
+          }
+        }
+      }
+    }
+  }
+}";
+        await using var server = new LocalHttpServer(remoteSpec);
+
+        var localSpec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""title"": ""Local API"",
+    ""version"": ""1.0.0""
+  },
+  ""paths"": {
+    ""/local"": {
+      ""get"": {
+        ""operationId"": ""GetLocal"",
+        ""responses"": {
+          ""200"": {
+            ""description"": ""ok""
+          }
+        }
+      }
+    }
+  }
+}";
+        var localPath = await TestFile.CreateSwaggerFile(localSpec, "local.json");
+
+        var document = await OpenApiDocumentFactory.CreateAsync(new[] { localPath, server.Url });
+
+        document.Should().NotBeNull();
+        document.Paths.Should().ContainKey("/local");
+        document.Paths.Should().ContainKey("/remote");
+    }
+
+    [Test]
+    public async Task Create_From_Multiple_Paths_Throws_When_Remote_Download_Fails()
+    {
+        var localSpec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""title"": ""Local API"",
+    ""version"": ""1.0.0""
+  },
+  ""paths"": {
+    ""/local"": {
+      ""get"": {
+        ""operationId"": ""GetLocal"",
+        ""responses"": {
+          ""200"": {
+            ""description"": ""ok""
+          }
+        }
+      }
+    }
+  }
+}";
+        var localPath = await TestFile.CreateSwaggerFile(localSpec, "local.json");
+
+        var act = () => OpenApiDocumentFactory.CreateAsync(new[] { localPath, "http://127.0.0.1:1/openapi.json" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Failed to download OpenAPI document*");
+    }
+
+    [Test]
+    public async Task Create_With_CancellationToken_Overload_Delegates_To_Main_Overload()
+    {
+        var openApiSpec = EmbeddedResources.GetSwaggerPetstore(SampleOpenSpecifications.SwaggerPetstoreJsonV3);
+        var swaggerFile = await TestFile.CreateSwaggerFile(openApiSpec, "petstore.json");
+
+        var document = await OpenApiDocumentFactory.CreateAsync(swaggerFile, CancellationToken.None);
+
+        document.Should().NotBeNull();
+    }
+
+    [Test]
+    public async Task Create_From_Single_Item_Path_Collection_Delegates_To_Single_Path()
+    {
+        var openApiSpec = EmbeddedResources.GetSwaggerPetstore(SampleOpenSpecifications.SwaggerPetstoreJsonV3);
+        var swaggerFile = await TestFile.CreateSwaggerFile(openApiSpec, "petstore.json");
+
+        var document = await OpenApiDocumentFactory.CreateAsync(new[] { swaggerFile });
+
+        document.Should().NotBeNull();
     }
 
     [Test]

--- a/src/Refitter.Tests/OpenApi/OpenApiValidatorTests.cs
+++ b/src/Refitter.Tests/OpenApi/OpenApiValidatorTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Refitter.Core.Validation;
 using Refitter.Tests.Resources;
+using Refitter.Tests.TestUtilities;
 
 namespace Refitter.Tests.OpenApi;
 
@@ -92,5 +93,26 @@ public class OpenApiValidatorTests
             if (File.Exists(tempFile))
                 File.Delete(tempFile);
         }
+    }
+
+    [Test]
+    public async Task Validate_Should_Parse_Remote_OpenApi_Document()
+    {
+        var openApiSpec = EmbeddedResources.GetSwaggerPetstore(SampleOpenSpecifications.SwaggerPetstoreJsonV3);
+        await using var server = new LocalHttpServer(openApiSpec);
+
+        var result = await OpenApiValidator.Validate(server.Url);
+
+        result.IsValid.Should().BeTrue();
+        result.Diagnostics.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Validate_Should_Throw_InvalidOperationException_When_Remote_Download_Fails()
+    {
+        var act = () => OpenApiValidator.Validate("http://127.0.0.1:1/openapi.json");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Failed to download OpenAPI document*");
     }
 }

--- a/src/Refitter.Tests/OpenApi/ReferenceGuardTests.cs
+++ b/src/Refitter.Tests/OpenApi/ReferenceGuardTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using Refitter.Core;
+
+namespace Refitter.Tests.OpenApi;
+
+public class ReferenceGuardTests
+{
+    private const string MainTemplate = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": { ""title"": ""t"", ""version"": ""1"" },
+  ""paths"": { ""/p"": { ""get"": { ""operationId"": ""g"", ""responses"": { ""200"": {
+    ""description"": ""ok"", ""content"": { ""application/json"": { ""schema"": { ""$ref"": ""__REF__"" } } } } } } } },
+  ""components"": { ""schemas"": {} }
+}";
+
+    private const string Leaf = @"{ ""type"": ""object"", ""properties"": { ""ok"": { ""type"": ""string"" } } }";
+
+    private static string Write(string dir, string name, string contents)
+    {
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, name);
+        File.WriteAllText(path, contents);
+        return path;
+    }
+
+    private static string NewRoot() =>
+        Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+    [Test]
+    public async Task Blocks_Remote_Reference_By_Default()
+    {
+        var root = NewRoot();
+        var path = Write(root, "spec.json", MainTemplate.Replace("__REF__", "http://127.0.0.1:1/evil.json"));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().ThrowAsync<ReferenceResolutionException>();
+    }
+
+    [Test]
+    public async Task Allows_Remote_Reference_When_Enabled()
+    {
+        var root = NewRoot();
+        var path = Write(root, "spec.json", MainTemplate.Replace("__REF__", "http://127.0.0.1:1/evil.json"));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: true);
+
+        await act.Should().NotThrowAsync<ReferenceResolutionException>();
+    }
+
+    [Test]
+    public async Task Blocks_Absolute_Out_Of_Tree_Reference()
+    {
+        var root = NewRoot();
+        var outside = Write(NewRoot(), "secret.json", Leaf);
+        var path = Write(root, "spec.json", MainTemplate.Replace("__REF__", outside.Replace("\\", "/")));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().ThrowAsync<ReferenceResolutionException>();
+    }
+
+    [Test]
+    public async Task Blocks_Parent_Traversal_Reference()
+    {
+        var root = NewRoot();
+        var path = Write(root, "spec.json", MainTemplate.Replace("__REF__", "../../secret.json"));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().ThrowAsync<ReferenceResolutionException>();
+    }
+
+    [Test]
+    public async Task Allows_In_Tree_Relative_Reference()
+    {
+        var root = NewRoot();
+        Write(root, "leaf.json", Leaf);
+        var path = Write(root, "spec.json", MainTemplate.Replace("__REF__", "./leaf.json"));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Allows_Internal_Fragment_Reference()
+    {
+        var root = NewRoot();
+        var path = Write(root, "spec.json", MainTemplate.Replace("__REF__", "#/components/schemas/Pet"));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/src/Refitter.Tests/OpenApi/ReferenceGuardTests.cs
+++ b/src/Refitter.Tests/OpenApi/ReferenceGuardTests.cs
@@ -13,6 +13,33 @@ public class ReferenceGuardTests
   ""components"": { ""schemas"": {} }
 }";
 
+    private const string Swagger2Template = @"{
+  ""swagger"": ""2.0"",
+  ""info"": { ""title"": ""t"", ""version"": ""1"" },
+  ""paths"": { ""/p"": { ""get"": { ""operationId"": ""g"", ""responses"": { ""200"": {
+    ""description"": ""ok"", ""schema"": { ""$ref"": ""__REF__"" } } } } } },
+  ""definitions"": {}
+}";
+
+    private const string YamlMainTemplate = @"openapi: 3.0.0
+info:
+  title: t
+  version: '1'
+paths:
+  /p:
+    get:
+      operationId: g
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: __REF__
+components:
+  schemas: {}
+";
+
     private const string Leaf = @"{ ""type"": ""object"", ""properties"": { ""ok"": { ""type"": ""string"" } } }";
 
     private static string Write(string dir, string name, string contents)
@@ -92,5 +119,62 @@ public class ReferenceGuardTests
         var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
 
         await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Blocks_Remote_Reference_In_Swagger2_Spec()
+    {
+        var root = NewRoot();
+        var path = Write(root, "swagger.json", Swagger2Template.Replace("__REF__", "http://evil.com/schema.json"));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().ThrowAsync<ReferenceResolutionException>();
+    }
+
+    [Test]
+    public async Task Allows_In_Tree_Reference_In_Swagger2_Spec()
+    {
+        var root = NewRoot();
+        Write(root, "leaf.json", Leaf);
+        var path = Write(root, "swagger.json", Swagger2Template.Replace("__REF__", "./leaf.json"));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Blocks_Remote_Reference_In_YAML_Unquoted()
+    {
+        var root = NewRoot();
+        var path = Write(root, "spec.yaml", YamlMainTemplate.Replace("__REF__", "http://evil.com/schema.yaml"));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().ThrowAsync<ReferenceResolutionException>();
+    }
+
+    [Test]
+    public async Task Allows_In_Tree_Reference_In_YAML_Unquoted()
+    {
+        var root = NewRoot();
+        Write(root, "leaf.json", Leaf);
+        var path = Write(root, "spec.yaml", YamlMainTemplate.Replace("__REF__", "./leaf.json"));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Blocks_Parent_Traversal_In_YAML_Unquoted()
+    {
+        var root = NewRoot();
+        var path = Write(root, "spec.yaml", YamlMainTemplate.Replace("__REF__", "../secret.yaml#/Pet"));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().ThrowAsync<ReferenceResolutionException>();
     }
 }

--- a/src/Refitter.Tests/OpenApi/ReferenceGuardTests.cs
+++ b/src/Refitter.Tests/OpenApi/ReferenceGuardTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Refitter.Core;
+using Refitter.Tests.TestUtilities;
 
 namespace Refitter.Tests.OpenApi;
 
@@ -176,5 +177,131 @@ components:
         var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
 
         await act.Should().ThrowAsync<ReferenceResolutionException>();
+    }
+
+    [Test]
+    public async Task Ignores_Whitespace_OpenApiPath()
+    {
+        var act = () => ReferenceGuard.ValidateAsync("   ", allowRemoteReferences: false);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Ignores_Missing_Local_File()
+    {
+        var path = Path.Combine(NewRoot(), "does-not-exist.json");
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Remote_Validation_Blocks_Dot_Relative_Reference_By_Default()
+    {
+        var content = MainTemplate.Replace("__REF__", "./schema.json#/components/schemas/Pet");
+
+        var act = () => ReferenceGuard.ValidateAsync("https://example.com/openapi.json", content, allowRemoteReferences: false);
+
+        await act.Should().ThrowAsync<ReferenceResolutionException>();
+    }
+
+    [Test]
+    public async Task Remote_Validation_Allows_Dot_Relative_Reference_When_Enabled()
+    {
+        var content = MainTemplate.Replace("__REF__", "./schema.json#/components/schemas/Pet");
+
+        var act = () => ReferenceGuard.ValidateAsync("https://example.com/openapi.json", content, allowRemoteReferences: true);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Remote_Validation_Blocks_Non_Http_Scheme()
+    {
+        var content = MainTemplate.Replace("__REF__", "file:///etc/passwd");
+
+        var act = () => ReferenceGuard.ValidateAsync("https://example.com/openapi.json", content, allowRemoteReferences: true);
+
+        await act.Should().ThrowAsync<ReferenceResolutionException>();
+    }
+
+    [Test]
+    public async Task Remote_Validation_Blocks_Bare_Relative_Reference_By_Default()
+    {
+        var content = MainTemplate.Replace("__REF__", "schema.json#/components/schemas/Pet");
+
+        var act = () => ReferenceGuard.ValidateAsync("https://example.com/openapi.json", content, allowRemoteReferences: false);
+
+        await act.Should().ThrowAsync<ReferenceResolutionException>();
+    }
+
+    [Test]
+    public async Task Remote_Validation_Allows_Bare_Relative_Reference_When_Enabled()
+    {
+        var content = MainTemplate.Replace("__REF__", "schema.json#/components/schemas/Pet");
+
+        var act = () => ReferenceGuard.ValidateAsync("https://example.com/openapi.json", content, allowRemoteReferences: true);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Throws_When_Remote_Entry_Cannot_Be_Downloaded()
+    {
+        var act = () => ReferenceGuard.ValidateAsync("http://127.0.0.1:1/openapi.json", allowRemoteReferences: true);
+
+        await act.Should().ThrowAsync<ReferenceResolutionException>()
+            .WithMessage("*Failed to read OpenAPI document*");
+    }
+
+    [Test]
+    public async Task Downloads_Remote_Entry_And_Validates_When_Reachable()
+    {
+        var remoteSpec = MainTemplate.Replace("__REF__", "#/components/schemas/InlineSchema")
+            .Replace("\"components\": { \"schemas\": {} }", "\"components\": { \"schemas\": { \"InlineSchema\": { \"type\": \"object\" } } }");
+        await using var server = new LocalHttpServer(remoteSpec);
+
+        var act = () => ReferenceGuard.ValidateAsync(server.Url, allowRemoteReferences: false);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Handles_Circular_Local_References_Without_Recursion_Error()
+    {
+        var root = NewRoot();
+        Write(root, "a.json", MainTemplate.Replace("__REF__", "./b.json"));
+        Write(root, "b.json", MainTemplate.Replace("__REF__", "./a.json"));
+
+        var act = () => ReferenceGuard.ValidateAsync(Path.Combine(root, "a.json"), allowRemoteReferences: false);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Allows_Missing_Local_Referenced_File()
+    {
+        var root = NewRoot();
+        var path = Write(root, "spec.json", MainTemplate.Replace("__REF__", "./missing.json"));
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task Throws_OperationCanceled_When_Cancellation_Requested()
+    {
+        var root = NewRoot();
+        var path = Write(root, "spec.json", MainTemplate.Replace("__REF__", "./leaf.json"));
+        Write(root, "leaf.json", Leaf);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = () => ReferenceGuard.ValidateAsync(path, allowRemoteReferences: false, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 }

--- a/src/Refitter.Tests/OpenApi/ReferenceResolutionExceptionTests.cs
+++ b/src/Refitter.Tests/OpenApi/ReferenceResolutionExceptionTests.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using Refitter.Core;
+
+namespace Refitter.Tests.OpenApi;
+
+public class ReferenceResolutionExceptionTests
+{
+    [Test]
+    public void Constructor_With_Message_Sets_Message()
+    {
+        var exception = new ReferenceResolutionException("reference resolution failed");
+
+        exception.Message.Should().Be("reference resolution failed");
+    }
+
+    [Test]
+    public void Constructor_With_Message_And_InnerException_Sets_InnerException()
+    {
+        var innerException = new InvalidOperationException("inner");
+
+        var exception = new ReferenceResolutionException("outer", innerException);
+
+        exception.Message.Should().Be("outer");
+        exception.InnerException.Should().BeSameAs(innerException);
+    }
+}

--- a/src/Refitter.Tests/RefitterRunnerTests.cs
+++ b/src/Refitter.Tests/RefitterRunnerTests.cs
@@ -478,6 +478,7 @@ public class RefitterRunnerTests
 
         public Task<OpenApiValidationResult> ValidateAsync(
             string openApiPath,
+            bool allowRemoteReferences = false,
             CancellationToken cancellationToken = default)
         {
             CallCount++;

--- a/src/Refitter.Tests/TestUtilities/LocalHttpServer.cs
+++ b/src/Refitter.Tests/TestUtilities/LocalHttpServer.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace Refitter.Tests.TestUtilities;
+
+internal sealed class LocalHttpServer : IAsyncDisposable
+{
+    private readonly TcpListener listener;
+    private readonly CancellationTokenSource cancellationTokenSource = new();
+    private readonly string responseBody;
+    private readonly string contentType;
+    private readonly int statusCode;
+    private readonly string statusText;
+    private readonly Task acceptTask;
+
+    public LocalHttpServer(
+        string responseBody,
+        string contentType = "application/json",
+        int statusCode = 200,
+        string statusText = "OK")
+    {
+        this.responseBody = responseBody;
+        this.contentType = contentType;
+        this.statusCode = statusCode;
+        this.statusText = statusText;
+
+        listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        acceptTask = Task.Run(AcceptAsync);
+    }
+
+    public string Url => $"http://127.0.0.1:{((IPEndPoint)listener.LocalEndpoint).Port}/openapi";
+
+    public async ValueTask DisposeAsync()
+    {
+        cancellationTokenSource.Cancel();
+        listener.Stop();
+        try
+        {
+            await acceptTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        cancellationTokenSource.Dispose();
+    }
+
+    private async Task AcceptAsync()
+    {
+        using var client = await listener.AcceptTcpClientAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+        using var stream = client.GetStream();
+        using var reader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, leaveOpen: true);
+
+        while (!cancellationTokenSource.IsCancellationRequested)
+        {
+            var line = await reader.ReadLineAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+            if (line == null || line.Length == 0)
+                break;
+        }
+
+        var bodyBytes = Encoding.UTF8.GetBytes(responseBody);
+        var header =
+            $"HTTP/1.1 {statusCode} {statusText}\r\n" +
+            $"Content-Type: {contentType}\r\n" +
+            $"Content-Length: {bodyBytes.Length}\r\n" +
+            "Connection: close\r\n\r\n";
+        var headerBytes = Encoding.ASCII.GetBytes(header);
+
+        await stream.WriteAsync(headerBytes, cancellationTokenSource.Token).ConfigureAwait(false);
+        await stream.WriteAsync(bodyBytes, cancellationTokenSource.Token).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+    }
+}

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -90,6 +90,7 @@ OPTIONS:
         --include-inheritance-hierarchy                          Keep all possible inherited types/union types even if they are not directly used
         --no-banner                                              Don't show donation banner
         --skip-default-additional-properties                     Set to true to skip default additional properties
+        --allow-remote-refs                                      Resolve remote (http/https) $ref references inside the document. Disabled by default to prevent generation-time SSRF
         --operation-name-generator              Default          The NSwag IOperationNameGenerator implementation to use.
                                                                  May be one of:
                                                                  - Default

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -187,6 +187,11 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool NoBanner { get; set; }
 
+    [Description("Resolve remote (http/https) $ref references inside the OpenAPI document. Disabled by default to prevent generation-time SSRF. Top-level remote document URLs are always allowed.")]
+    [CommandOption("--allow-remote-refs")]
+    [DefaultValue(false)]
+    public bool AllowRemoteReferences { get; set; }
+
     [Description("Set to true to skip default additional properties")]
     [CommandOption("--skip-default-additional-properties")]
     [DefaultValue(false)]

--- a/src/Refitter/SettingsMapper.cs
+++ b/src/Refitter/SettingsMapper.cs
@@ -22,6 +22,7 @@ internal static class SettingsMapper
         result.GenerateXmlDocCodeComments = !settings.NoXmlDocCodeComments;
         result.GenerateDeprecatedOperations = !settings.NoDeprecatedOperations;
         result.GenerateDefaultAdditionalProperties = !settings.SkipDefaultAdditionalProperties;
+        result.AllowRemoteReferences = settings.AllowRemoteReferences;
         result.TypeAccessibility = settings.InternalTypeAccessibility
             ? Core.TypeAccessibility.Internal
             : Core.TypeAccessibility.Public;


### PR DESCRIPTION
## Summary

Fixes the unrestricted `$ref` resolution reported in security advisory **[GHSA-x6w4-f264-3vvr](https://github.com/christianhelle/refitter/security/advisories/GHSA-x6w4-f264-3vvr)** (generation-time SSRF, remote file inclusion, local file inclusion). Verified the advisory on the current build (LFI via out-of-tree absolute path; RFI/SSRF via remote `$ref`) and implemented a fix.

## Behavior

Secure-by-default `$ref` handling, enforced before NSwag/OasReader resolve references:

- **Local refs are confined** to the input document's directory tree — absolute paths and `../` escapes are rejected.
- **Remote (`http`/`https`) nested refs are blocked** unless explicitly enabled.
- **Top-level remote document URLs remain allowed** (unchanged core feature); internal `#/...` fragment refs always allowed.
- New opt-in: `--allow-remote-refs` CLI flag / `allowRemoteReferences` setting (default `false`).
- Guard also applied to the `validate` command.

## Changes

- `ReferenceGuard` + `ReferenceResolutionException` (reader-agnostic pre-load scan) wired into `OpenApiDocumentFactory`, `RefitGenerator`, `OpenApiValidator`.
- `AllowRemoteReferences` setting, `--allow-remote-refs` flag, CLI mapping.
- Scenario tests (remote blocked/allowed, abs + `../` blocked, in-tree relative + internal fragments allowed).
- README, NuGet README, json-schema, docfx docs.

## Validation

- Build: Release, 0 warnings/errors.
- Unit tests: 2120 passed. Integration: 88 passed.
- Re-ran advisory PoC: LFI and remote refs now blocked; in-tree + top-level URL specs still work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `--allow-remote-refs` / `allowRemoteReferences` to enable resolving remote `http/https` `$ref` references during validation and generation (disabled by default).
* **Bug Fixes**
  * Hardened `$ref` handling to block unsafe remote resolution and prevent local references from escaping the input directory tree.
* **Documentation**
  * Updated README, CLI/docs, and `.refitter` schema/examples to describe the new flag and its default behavior.
* **Tests**
  * Expanded validation and document-generation tests, including remote download and cancellation scenarios, across JSON/YAML and Swagger/OpenAPI cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->