### PR TITLE
Fix RCE via unescaped OpenAPI path/header in Refit attributes (GHSA-3fhm-p725-h3g3)

### DIFF
--- a/src/Refitter.Core/Generation/InterfaceGenerator.cs
+++ b/src/Refitter.Core/Generation/InterfaceGenerator.cs
@@ -237,7 +237,7 @@ internal class InterfaceGenerator
             code.AppendLine($"{Separator}{Separator}{attribute}");
         }
 
-        code.AppendLine($"{Separator}{Separator}[{verb}(\"{op.Path}\")]")
+        code.AppendLine($"{Separator}{Separator}[{verb}(\"{ParameterShared.EscapeString(op.Path)}\")]")
             .AppendLine($"{Separator}{Separator}{returnType} {methodName}({parametersString});")
             .AppendLine();
 
@@ -263,7 +263,7 @@ internal class InterfaceGenerator
                 ", ",
                 parameters.Where(parameter => !parameter.Contains("?")));
 
-            code.AppendLine($"{Separator}{Separator}[{verb}(\"{op.Path}\")]")
+            code.AppendLine($"{Separator}{Separator}[{verb}(\"{ParameterShared.EscapeString(op.Path)}\")]")
                 .AppendLine($"{Separator}{Separator}{returnType} {methodName}({nonOptionalParametersString});")
                 .AppendLine();
         }

--- a/src/Refitter.Core/Generation/MethodAttributeGenerator.cs
+++ b/src/Refitter.Core/Generation/MethodAttributeGenerator.cs
@@ -41,7 +41,7 @@ internal class MethodAttributeGenerator(
 
             if (uniqueContentTypes.Any())
             {
-                headers.Add($"\"Accept: {string.Join(", ", uniqueContentTypes)}\"");
+                headers.Add($"\"Accept: {string.Join(", ", uniqueContentTypes.Select(ParameterShared.EscapeString))}\"");
             }
         }
 
@@ -54,7 +54,7 @@ internal class MethodAttributeGenerator(
 
             if (!string.IsNullOrWhiteSpace(contentType) && !operationModel.Consumes.Contains("multipart/form-data"))
             {
-                headers.Add($"\"Content-Type: {contentType}\"");
+                headers.Add($"\"Content-Type: {ParameterShared.EscapeString(contentType)}\"");
             }
         }
 

--- a/src/Refitter.Core/ParameterExtraction/HeaderParameterExtractor.cs
+++ b/src/Refitter.Core/ParameterExtraction/HeaderParameterExtractor.cs
@@ -27,7 +27,7 @@ internal class HeaderParameterExtractor : IParameterTypeExtractor
                 .Select(p =>
                 {
                     var variableName = ParameterShared.GetVariableName(p);
-                    return $"{ParameterShared.JoinAttributes($"Header(\"{p.Name}\")")}{ParameterShared.GetParameterType(p, settings)} {variableName}";
+                    return $"{ParameterShared.JoinAttributes($"Header(\"{ParameterShared.EscapeString(p.Name)}\")")}{ParameterShared.GetParameterType(p, settings)} {variableName}";
                 })
                 .ToList();
         }
@@ -47,7 +47,7 @@ internal class HeaderParameterExtractor : IParameterTypeExtractor
                     && securityScheme.In == OpenApiSecurityApiKeyLocation.Header
                     && !operationModel.Parameters.Any(p => p.Kind == OpenApiParameterKind.Header && p.IsHeader && p.Name == securityScheme.Name))
                 {
-                    headerParameters.Add($"[Header(\"{securityScheme.Name}\")] string {ParameterShared.ReplaceUnsafeCharacters(securityScheme.Name)}");
+                    headerParameters.Add($"[Header(\"{ParameterShared.EscapeString(securityScheme.Name)}\")] string {ParameterShared.ReplaceUnsafeCharacters(securityScheme.Name)}");
                 }
                 else if (securityScheme is { Type: OpenApiSecuritySchemeType.Http }
                     && string.Equals(securityScheme.Scheme, "bearer", StringComparison.OrdinalIgnoreCase))

--- a/src/Refitter.Core/Validation/AttributeStringValidator.cs
+++ b/src/Refitter.Core/Validation/AttributeStringValidator.cs
@@ -39,6 +39,10 @@ internal static class AttributeStringValidator
         if (document.Paths == null)
             return;
 
+        // Accept/Content-Type headers are only emitted from content map keys for OpenAPI 3.0+,
+        // so only reject unsafe content-type keys for those documents to avoid Swagger 2.0 false positives.
+        var validateContentTypes = diagnostic.SpecificationVersion != OpenApiSpecVersion.OpenApi2_0;
+
         foreach (var path in document.Paths)
         {
             if (ContainsUnsafeCharacters(path.Key))
@@ -53,19 +57,62 @@ internal static class AttributeStringValidator
 
             foreach (var operation in path.Value.Operations.Values)
             {
-                if (operation?.Parameters == null)
+                if (operation == null)
                     continue;
 
-                foreach (var parameter in operation.Parameters)
+                if (operation.Parameters != null)
                 {
-                    if (parameter.In == ParameterLocation.Header && ContainsUnsafeCharacters(parameter.Name))
+                    foreach (var parameter in operation.Parameters)
                     {
-                        diagnostic.Errors.Add(new OpenApiError(
-                            parameter.Name ?? string.Empty,
-                            $"Header parameter name '{parameter.Name}' contains illegal characters and is rejected to prevent code injection into Refit attributes. Use --skip-validation to bypass."));
+                        if (parameter.In == ParameterLocation.Header && ContainsUnsafeCharacters(parameter.Name))
+                        {
+                            diagnostic.Errors.Add(new OpenApiError(
+                                parameter.Name ?? string.Empty,
+                                $"Header parameter name '{parameter.Name}' contains illegal characters and is rejected to prevent code injection into Refit attributes. Use --skip-validation to bypass."));
+                        }
                     }
                 }
+
+                if (validateContentTypes)
+                {
+                    ValidateContentTypeKeys(operation, diagnostic);
+                }
             }
+        }
+    }
+
+    private static void ValidateContentTypeKeys(OpenApiOperation operation, OpenApiDiagnostic diagnostic)
+    {
+        if (operation.RequestBody?.Content != null)
+        {
+            foreach (var contentType in operation.RequestBody.Content.Keys)
+            {
+                AddContentTypeErrorIfUnsafe(contentType, diagnostic);
+            }
+        }
+
+        if (operation.Responses == null)
+            return;
+
+        foreach (var response in operation.Responses.Values)
+        {
+            if (response?.Content == null)
+                continue;
+
+            foreach (var contentType in response.Content.Keys)
+            {
+                AddContentTypeErrorIfUnsafe(contentType, diagnostic);
+            }
+        }
+    }
+
+    private static void AddContentTypeErrorIfUnsafe(string contentType, OpenApiDiagnostic diagnostic)
+    {
+        if (ContainsUnsafeCharacters(contentType))
+        {
+            diagnostic.Errors.Add(new OpenApiError(
+                contentType,
+                $"Content type '{contentType}' contains illegal characters and is rejected to prevent code injection into Refit attributes. Use --skip-validation to bypass."));
         }
     }
 }

--- a/src/Refitter.Core/Validation/AttributeStringValidator.cs
+++ b/src/Refitter.Core/Validation/AttributeStringValidator.cs
@@ -5,10 +5,10 @@ using Microsoft.OpenApi.Reader;
 namespace Refitter.Core.Validation;
 
 /// <summary>
-/// Rejects OpenAPI paths and header names containing characters that could break out of the
-/// generated Refit attribute string literals (e.g. quotes, backslashes, newlines). Generated
-/// code escapes these characters, but rejecting them gives a clear error unless validation is
-/// skipped. See GHSA-3fhm-p725-h3g3.
+/// Rejects OpenAPI paths, header names, and content-type keys containing characters that could break
+/// out of the generated Refit attribute string literals (e.g. quotes, backslashes, newlines). Generated
+/// code escapes these characters, but rejecting them gives a clear error unless validation is skipped.
+/// See GHSA-3fhm-p725-h3g3 (path), GHSA-58x9-vjvp-6mx8 (header name), GHSA-p32v-8v8j-j534 (content-type).
 /// </summary>
 internal static class AttributeStringValidator
 {

--- a/src/Refitter.Core/Validation/AttributeStringValidator.cs
+++ b/src/Refitter.Core/Validation/AttributeStringValidator.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Microsoft.OpenApi;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
 

--- a/src/Refitter.Core/Validation/AttributeStringValidator.cs
+++ b/src/Refitter.Core/Validation/AttributeStringValidator.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Microsoft.OpenApi;
+using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
 
 namespace Refitter.Core.Validation;
@@ -17,7 +18,26 @@ internal static class AttributeStringValidator
 
     internal static void Validate(OpenApiDocument? document, OpenApiDiagnostic diagnostic)
     {
-        if (document?.Paths == null)
+        if (document == null)
+            return;
+
+        // Validate security scheme names for API-key schemes with header location
+        if (document.Components?.SecuritySchemes != null)
+        {
+            foreach (var securityScheme in document.Components.SecuritySchemes)
+            {
+                if (securityScheme.Value?.Type == SecuritySchemeType.ApiKey
+                    && securityScheme.Value.In == ParameterLocation.Header
+                    && ContainsUnsafeCharacters(securityScheme.Value.Name))
+                {
+                    diagnostic.Errors.Add(new OpenApiError(
+                        securityScheme.Key,
+                        $"Security scheme '{securityScheme.Key}' has header name '{securityScheme.Value.Name}' containing illegal characters and is rejected to prevent code injection into Refit attributes. Use --skip-validation to bypass."));
+                }
+            }
+        }
+
+        if (document.Paths == null)
             return;
 
         foreach (var path in document.Paths)

--- a/src/Refitter.Core/Validation/AttributeStringValidator.cs
+++ b/src/Refitter.Core/Validation/AttributeStringValidator.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
+
+namespace Refitter.Core.Validation;
+
+/// <summary>
+/// Rejects OpenAPI paths and header names containing characters that could break out of the
+/// generated Refit attribute string literals (e.g. quotes, backslashes, newlines). Generated
+/// code escapes these characters, but rejecting them gives a clear error unless validation is
+/// skipped. See GHSA-3fhm-p725-h3g3.
+/// </summary>
+internal static class AttributeStringValidator
+{
+    internal static bool ContainsUnsafeCharacters(string? value) =>
+        value != null && value.Any(c => c is '"' or '\\' || char.IsControl(c));
+
+    internal static void Validate(OpenApiDocument? document, OpenApiDiagnostic diagnostic)
+    {
+        if (document?.Paths == null)
+            return;
+
+        foreach (var path in document.Paths)
+        {
+            if (ContainsUnsafeCharacters(path.Key))
+            {
+                diagnostic.Errors.Add(new OpenApiError(
+                    path.Key,
+                    $"Path '{path.Key}' contains illegal characters (quotes, backslashes, or control characters) and is rejected to prevent code injection into Refit attributes. Use --skip-validation to bypass."));
+            }
+
+            if (path.Value?.Operations == null)
+                continue;
+
+            foreach (var operation in path.Value.Operations.Values)
+            {
+                if (operation?.Parameters == null)
+                    continue;
+
+                foreach (var parameter in operation.Parameters)
+                {
+                    if (parameter.In == ParameterLocation.Header && ContainsUnsafeCharacters(parameter.Name))
+                    {
+                        diagnostic.Errors.Add(new OpenApiError(
+                            parameter.Name ?? string.Empty,
+                            $"Header parameter name '{parameter.Name}' contains illegal characters and is rejected to prevent code injection into Refit attributes. Use --skip-validation to bypass."));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Refitter.Core/Validation/AttributeStringValidator.cs
+++ b/src/Refitter.Core/Validation/AttributeStringValidator.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Microsoft.OpenApi.Reader;
 
 namespace Refitter.Core.Validation;

--- a/src/Refitter.Core/Validation/OpenApiValidator.cs
+++ b/src/Refitter.Core/Validation/OpenApiValidator.cs
@@ -26,6 +26,8 @@ public static class OpenApiValidator
         var walker = new OpenApiWalker(statsVisitor);
         walker.Walk(result.OpenApiDocument);
 
+        AttributeStringValidator.Validate(result.OpenApiDocument, result.OpenApiDiagnostic);
+
         return new(
             result.OpenApiDiagnostic,
             statsVisitor);

--- a/src/Refitter.Core/Validation/OpenApiValidator.cs
+++ b/src/Refitter.Core/Validation/OpenApiValidator.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.OpenApi;
 using Microsoft.OpenApi.Reader;
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Net.Http;
 
 using Refitter.Tests.AdditionalFiles.SingeInterface;
 
@@ -512,8 +511,9 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 {
     using System;
-    using Microsoft.Extensions.DependencyInjection;
-    using Refit;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Refit;
 
     /// <summary>
     /// Extension methods for configuring Refit clients in the service collection.
@@ -536,6 +536,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         {
             var clientBuilderIUpdatePetEndpoint = services
                 .AddRefitClient<IUpdatePetEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -544,6 +545,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIAddPetEndpoint = services
                 .AddRefitClient<IAddPetEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -552,6 +554,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIFindPetsByStatusEndpoint = services
                 .AddRefitClient<IFindPetsByStatusEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -560,6 +563,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIFindPetsByTagsEndpoint = services
                 .AddRefitClient<IFindPetsByTagsEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -568,6 +572,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetPetByIdEndpoint = services
                 .AddRefitClient<IGetPetByIdEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -576,6 +581,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIUpdatePetWithFormEndpoint = services
                 .AddRefitClient<IUpdatePetWithFormEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -584,6 +590,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIDeletePetEndpoint = services
                 .AddRefitClient<IDeletePetEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -592,6 +599,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIUploadFileEndpoint = services
                 .AddRefitClient<IUploadFileEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -600,6 +608,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetInventoryEndpoint = services
                 .AddRefitClient<IGetInventoryEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -608,6 +617,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIPlaceOrderEndpoint = services
                 .AddRefitClient<IPlaceOrderEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -616,6 +626,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetOrderByIdEndpoint = services
                 .AddRefitClient<IGetOrderByIdEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -624,6 +635,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIDeleteOrderEndpoint = services
                 .AddRefitClient<IDeleteOrderEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -632,6 +644,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderICreateUserEndpoint = services
                 .AddRefitClient<ICreateUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -640,6 +653,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderICreateUsersWithListInputEndpoint = services
                 .AddRefitClient<ICreateUsersWithListInputEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -648,6 +662,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderILoginUserEndpoint = services
                 .AddRefitClient<ILoginUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -656,6 +671,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderILogoutUserEndpoint = services
                 .AddRefitClient<ILogoutUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -664,6 +680,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetUserByNameEndpoint = services
                 .AddRefitClient<IGetUserByNameEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -672,6 +689,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIUpdateUserEndpoint = services
                 .AddRefitClient<IUpdateUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -680,6 +698,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIDeleteUserEndpoint = services
                 .AddRefitClient<IDeleteUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
@@ -7,7 +7,6 @@ using Refit;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using System.Net.Http;
 
 #nullable enable annotations
 
@@ -743,6 +742,7 @@ public PetStatus Status { get; set; }
 namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
 {
     using System;
+    using System.Net.Http;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Http.Resilience;
     using Refit;
@@ -766,6 +766,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         {
             var clientBuilderISwaggerPetstoreInterfaceWithHttpResilience = services
                 .AddRefitClient<ISwaggerPetstoreInterfaceWithHttpResilience>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"));
 
             clientBuilderISwaggerPetstoreInterfaceWithHttpResilience

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
@@ -7,7 +7,6 @@ using Refit;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using System.Net.Http;
 
 #nullable enable annotations
 
@@ -453,6 +452,7 @@ public PetStatus Status { get; set; }
 namespace Refitter.Tests.AdditionalFiles.SingeInterface
 {
     using System;
+    using System.Net.Http;
     using Microsoft.Extensions.DependencyInjection;
     using Polly;
     using Polly.Contrib.WaitAndRetry;

--- a/src/Refitter.Tests/OpenApi/AttributeStringValidatorTests.cs
+++ b/src/Refitter.Tests/OpenApi/AttributeStringValidatorTests.cs
@@ -1,8 +1,8 @@
+using System.Net.Http;
 using FluentAssertions;
 using Microsoft.OpenApi;
 using Microsoft.OpenApi.Reader;
 using Refitter.Core.Validation;
-using System.Net.Http;
 
 namespace Refitter.Tests.OpenApi;
 

--- a/src/Refitter.Tests/OpenApi/AttributeStringValidatorTests.cs
+++ b/src/Refitter.Tests/OpenApi/AttributeStringValidatorTests.cs
@@ -1,0 +1,130 @@
+using FluentAssertions;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
+using Refitter.Core.Validation;
+using System.Net.Http;
+
+namespace Refitter.Tests.OpenApi;
+
+public class AttributeStringValidatorTests
+{
+    [Test]
+    public void ContainsUnsafeCharacters_Should_Return_False_For_Null_And_Safe_Values()
+    {
+        AttributeStringValidator.ContainsUnsafeCharacters(null).Should().BeFalse();
+        AttributeStringValidator.ContainsUnsafeCharacters("X-Api-Key").Should().BeFalse();
+    }
+
+    [Test]
+    public void ContainsUnsafeCharacters_Should_Return_True_For_Unsafe_Values()
+    {
+        AttributeStringValidator.ContainsUnsafeCharacters("X\"Api").Should().BeTrue();
+        AttributeStringValidator.ContainsUnsafeCharacters("X\\Api").Should().BeTrue();
+        AttributeStringValidator.ContainsUnsafeCharacters("X\nApi").Should().BeTrue();
+    }
+
+    [Test]
+    public void Validate_Should_Return_When_Document_Is_Null()
+    {
+        OpenApiDiagnostic diagnostic = new();
+
+        AttributeStringValidator.Validate(null, diagnostic);
+
+        diagnostic.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Validate_Should_Validate_SecurityScheme_And_Return_When_Paths_Are_Null()
+    {
+        OpenApiDiagnostic diagnostic = new();
+        OpenApiDocument document = new()
+        {
+            Components = new OpenApiComponents
+            {
+                SecuritySchemes = new Dictionary<string, IOpenApiSecurityScheme>
+                {
+                    ["nullScheme"] = null!,
+                    ["unsafeHeader"] = new OpenApiSecurityScheme
+                    {
+                        Type = SecuritySchemeType.ApiKey,
+                        In = ParameterLocation.Header,
+                        Name = "X\"Api"
+                    },
+                    ["safeHeader"] = new OpenApiSecurityScheme
+                    {
+                        Type = SecuritySchemeType.ApiKey,
+                        In = ParameterLocation.Header,
+                        Name = "X-Api-Key"
+                    },
+                    ["unsafeQuery"] = new OpenApiSecurityScheme
+                    {
+                        Type = SecuritySchemeType.ApiKey,
+                        In = ParameterLocation.Query,
+                        Name = "X\"Api"
+                    }
+                }
+            },
+            Paths = null!
+        };
+
+        AttributeStringValidator.Validate(document, diagnostic);
+
+        diagnostic.Errors.Should().HaveCount(1);
+        diagnostic.Errors[0].Pointer.Should().Be("unsafeHeader");
+        diagnostic.Errors[0].Message.Should().Contain("Security scheme 'unsafeHeader'");
+    }
+
+    [Test]
+    public void Validate_Should_Report_Path_And_Header_Errors_And_Skip_Null_Branches()
+    {
+        OpenApiDiagnostic diagnostic = new();
+        OpenApiDocument document = new()
+        {
+            Paths = new OpenApiPaths
+            {
+                ["/nullpath"] = null!,
+                ["unsafe\"path"] = new OpenApiPathItem
+                {
+                    Operations = null!
+                },
+                ["/safe"] = new OpenApiPathItem
+                {
+                    Operations = new Dictionary<HttpMethod, OpenApiOperation>
+                    {
+                        [HttpMethod.Get] = new OpenApiOperation
+                        {
+                            Parameters = null!
+                        },
+                        [HttpMethod.Post] = null!,
+                        [HttpMethod.Put] = new OpenApiOperation
+                        {
+                            Parameters = new List<IOpenApiParameter>
+                            {
+                                new OpenApiParameter
+                                {
+                                    In = ParameterLocation.Header,
+                                    Name = "X\"Bad"
+                                },
+                                new OpenApiParameter
+                                {
+                                    In = ParameterLocation.Header,
+                                    Name = "X-Good"
+                                },
+                                new OpenApiParameter
+                                {
+                                    In = ParameterLocation.Query,
+                                    Name = "X\"Ignored"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        AttributeStringValidator.Validate(document, diagnostic);
+
+        diagnostic.Errors.Should().HaveCount(2);
+        diagnostic.Errors.Select(x => x.Pointer).Should().Contain(new[] { "unsafe\"path", "X\"Bad" });
+    }
+}

--- a/src/Refitter.Tests/OpenApi/AttributeStringValidatorTests.cs
+++ b/src/Refitter.Tests/OpenApi/AttributeStringValidatorTests.cs
@@ -127,4 +127,63 @@ public class AttributeStringValidatorTests
         diagnostic.Errors.Should().HaveCount(2);
         diagnostic.Errors.Select(x => x.Pointer).Should().Contain(new[] { "unsafe\"path", "X\"Bad" });
     }
+
+    [Test]
+    public void Validate_Should_Report_ContentType_Errors_For_OpenApi3()
+    {
+        OpenApiDiagnostic diagnostic = new() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 };
+        OpenApiDocument document = BuildContentTypeDocument();
+
+        AttributeStringValidator.Validate(document, diagnostic);
+
+        diagnostic.Errors.Should().HaveCount(2);
+        diagnostic.Errors.Select(x => x.Message).Should().OnlyContain(m => m.Contains("Content type"));
+        diagnostic.Errors.Select(x => x.Pointer).Should().Contain(new[] { "application/json\")] x", "text/plain\"" });
+    }
+
+    [Test]
+    public void Validate_Should_Not_Report_ContentType_Errors_For_OpenApi2()
+    {
+        OpenApiDiagnostic diagnostic = new() { SpecificationVersion = OpenApiSpecVersion.OpenApi2_0 };
+        OpenApiDocument document = BuildContentTypeDocument();
+
+        AttributeStringValidator.Validate(document, diagnostic);
+
+        diagnostic.Errors.Should().BeEmpty();
+    }
+
+    private static OpenApiDocument BuildContentTypeDocument() => new()
+    {
+        Paths = new OpenApiPaths
+        {
+            ["/api"] = new OpenApiPathItem
+            {
+                Operations = new Dictionary<HttpMethod, OpenApiOperation>
+                {
+                    [HttpMethod.Post] = new OpenApiOperation
+                    {
+                        RequestBody = new OpenApiRequestBody
+                        {
+                            Content = new Dictionary<string, IOpenApiMediaType>
+                            {
+                                ["application/json"] = new OpenApiMediaType(),
+                                ["application/json\")] x"] = new OpenApiMediaType()
+                            }
+                        },
+                        Responses = new OpenApiResponses
+                        {
+                            ["200"] = new OpenApiResponse
+                            {
+                                Content = new Dictionary<string, IOpenApiMediaType>
+                                {
+                                    ["text/plain\""] = new OpenApiMediaType()
+                                }
+                            },
+                            ["204"] = null!
+                        }
+                    }
+                }
+            }
+        }
+    };
 }

--- a/src/Refitter.Tests/Scenarios/SecurityAttributeInjectionTests.cs
+++ b/src/Refitter.Tests/Scenarios/SecurityAttributeInjectionTests.cs
@@ -7,9 +7,10 @@ using TUnit.Core;
 
 namespace Refitter.Tests.Scenarios;
 
-// Regression tests for GHSA-3fhm-p725-h3g3: an OpenAPI path / header name that closes the
-// Refit attribute string and injects a [ModuleInitializer] file class must not break out of
-// the generated code, and must be rejected by validation.
+// Regression tests for the Refit attribute-injection advisories. An OpenAPI path, header name, or
+// content-type key that closes the Refit attribute string and injects a [ModuleInitializer] file
+// class must not break out of the generated code, and must be rejected by validation.
+// Covers GHSA-3fhm-p725-h3g3 (path), GHSA-58x9-vjvp-6mx8 (header name), GHSA-p32v-8v8j-j534 (content-type).
 public class SecurityAttributeInjectionTests
 {
     private const string MaliciousPath =
@@ -17,6 +18,9 @@ public class SecurityAttributeInjectionTests
 
     private const string MaliciousHeaderName =
         @"X"")] string a); } file class H {} public partial interface J { [Header(""Y";
+
+    private const string MaliciousContentType =
+        @"application/json"")] Task<string> Dummy(); } } file class CtEvil { [System.Runtime.CompilerServices.ModuleInitializer] internal static void Init(){ } } namespace N3 { public partial interface I3 { [Get(""/ctq";
 
     private const string PathInjectionSpec = @"
 openapi: 3.0.0
@@ -124,6 +128,29 @@ securityDefinitions:
     type: apiKey
     in: header
     name: '" + MaliciousHeaderName + @"'
+";
+
+    private const string ContentTypeInjectionSpec = @"
+openapi: 3.0.0
+info:
+  title: Injection
+  version: 1.0.0
+paths:
+  /api:
+    post:
+      operationId: PostU
+      requestBody:
+        content:
+          '" + MaliciousContentType + @"':
+            schema:
+              type: string
+      responses:
+        '200':
+          description: ok
+          content:
+            '" + MaliciousContentType + @"':
+              schema:
+                type: string
 ";
 
     [Test]
@@ -309,6 +336,37 @@ securityDefinitions:
     public async Task Validation_Rejects_SecurityScheme_Header_With_Breakout_Characters_V2()
     {
         var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(SecuritySchemeHeaderInjectionSpecV2);
+        try
+        {
+            var result = await OpenApiValidator.Validate(swaggerFile);
+            result.IsValid.Should().BeFalse();
+        }
+        finally
+        {
+            CleanUp(swaggerFile);
+        }
+    }
+
+    [Test]
+    public async Task ContentType_Injection_Does_Not_Break_Out_Of_Attribute()
+    {
+        string generatedCode = await GenerateCode(ContentTypeInjectionSpec);
+        generatedCode.Should().Contain("\\\"");
+        generatedCode.Should().NotContain("application/json\")]");
+    }
+
+    [Category("Integration")]
+    [Test]
+    public async Task Generated_Code_With_ContentType_Injection_Is_Inert_And_Compiles()
+    {
+        string generatedCode = await GenerateCode(ContentTypeInjectionSpec);
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Validation_Rejects_ContentType_With_Breakout_Characters()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(ContentTypeInjectionSpec);
         try
         {
             var result = await OpenApiValidator.Validate(swaggerFile);

--- a/src/Refitter.Tests/Scenarios/SecurityAttributeInjectionTests.cs
+++ b/src/Refitter.Tests/Scenarios/SecurityAttributeInjectionTests.cs
@@ -15,8 +15,25 @@ public class SecurityAttributeInjectionTests
     private const string MaliciousPath =
         @"/p"")] Task<string> Dummy(); } } file class Evil { [System.Runtime.CompilerServices.ModuleInitializer] internal static void Init(){ } } namespace N2 { public partial interface I2 { [Get(""/q";
 
+    private const string MaliciousHeaderName =
+        @"X"")] string a); } file class H {} public partial interface J { [Header(""Y";
+
     private const string PathInjectionSpec = @"
 openapi: 3.0.0
+info:
+  title: Injection
+  version: 1.0.0
+paths:
+  '" + MaliciousPath + @"':
+    get:
+      operationId: GetU
+      responses:
+        '200':
+          description: ok
+";
+
+    private const string PathInjectionSpecV2 = @"
+swagger: '2.0'
 info:
   title: Injection
   version: 1.0.0
@@ -39,13 +56,74 @@ paths:
     get:
       operationId: GetU
       parameters:
-        - name: 'X"")] string a); } file class H {} public partial interface J { [Header(""Y'
+        - name: '" + MaliciousHeaderName + @"'
           in: header
           schema:
             type: string
       responses:
         '200':
           description: ok
+";
+
+    private const string HeaderInjectionSpecV2 = @"
+swagger: '2.0'
+info:
+  title: Injection
+  version: 1.0.0
+paths:
+  /api:
+    get:
+      operationId: GetU
+      parameters:
+        - name: '" + MaliciousHeaderName + @"'
+          in: header
+          type: string
+      responses:
+        '200':
+          description: ok
+";
+
+    private const string SecuritySchemeHeaderInjectionSpec = @"
+openapi: 3.0.0
+info:
+  title: Injection
+  version: 1.0.0
+paths:
+  /api:
+    get:
+      operationId: GetU
+      security:
+        - apiKey: []
+      responses:
+        '200':
+          description: ok
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: '" + MaliciousHeaderName + @"'
+";
+
+    private const string SecuritySchemeHeaderInjectionSpecV2 = @"
+swagger: '2.0'
+info:
+  title: Injection
+  version: 1.0.0
+paths:
+  /api:
+    get:
+      operationId: GetU
+      security:
+        - apiKey: []
+      responses:
+        '200':
+          description: ok
+securityDefinitions:
+  apiKey:
+    type: apiKey
+    in: header
+    name: '" + MaliciousHeaderName + @"'
 ";
 
     [Test]
@@ -84,6 +162,130 @@ paths:
     public async Task Validation_Rejects_Path_With_Breakout_Characters()
     {
         var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(PathInjectionSpec);
+        try
+        {
+            var result = await OpenApiValidator.Validate(swaggerFile);
+            result.IsValid.Should().BeFalse();
+        }
+        finally
+        {
+            CleanUp(swaggerFile);
+        }
+    }
+
+    [Test]
+    public async Task Path_Injection_Does_Not_Break_Out_Of_Attribute_V2()
+    {
+        string generatedCode = await GenerateCode(PathInjectionSpecV2);
+        generatedCode.Should().Contain("\\\"");
+        generatedCode.Should().NotContain("[Get(\"/q\")]");
+    }
+
+    [Category("Integration")]
+    [Test]
+    public async Task Generated_Code_With_Path_Injection_Is_Inert_And_Compiles_V2()
+    {
+        string generatedCode = await GenerateCode(PathInjectionSpecV2);
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Header_Injection_Does_Not_Break_Out_Of_Attribute_V2()
+    {
+        string generatedCode = await GenerateCode(HeaderInjectionSpecV2);
+        generatedCode.Should().Contain("\\\"");
+        generatedCode.Should().NotContain("[Header(\"Y\")]");
+    }
+
+    [Category("Integration")]
+    [Test]
+    public async Task Generated_Code_With_Header_Injection_Is_Inert_And_Compiles_V2()
+    {
+        string generatedCode = await GenerateCode(HeaderInjectionSpecV2);
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Validation_Rejects_Path_With_Breakout_Characters_V2()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(PathInjectionSpecV2);
+        try
+        {
+            var result = await OpenApiValidator.Validate(swaggerFile);
+            result.IsValid.Should().BeFalse();
+        }
+        finally
+        {
+            CleanUp(swaggerFile);
+        }
+    }
+
+    [Test]
+    public async Task Validation_Rejects_Header_With_Breakout_Characters_V2()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(HeaderInjectionSpecV2);
+        try
+        {
+            var result = await OpenApiValidator.Validate(swaggerFile);
+            result.IsValid.Should().BeFalse();
+        }
+        finally
+        {
+            CleanUp(swaggerFile);
+        }
+    }
+
+    [Test]
+    public async Task SecurityScheme_Header_Injection_Does_Not_Break_Out_Of_Attribute()
+    {
+        string generatedCode = await GenerateCode(SecuritySchemeHeaderInjectionSpec);
+        generatedCode.Should().Contain("\\\"");
+        generatedCode.Should().NotContain("[Header(\"Y\")]");
+    }
+
+    [Category("Integration")]
+    [Test]
+    public async Task Generated_Code_With_SecurityScheme_Header_Injection_Is_Inert_And_Compiles()
+    {
+        string generatedCode = await GenerateCode(SecuritySchemeHeaderInjectionSpec);
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Validation_Rejects_SecurityScheme_Header_With_Breakout_Characters()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(SecuritySchemeHeaderInjectionSpec);
+        try
+        {
+            var result = await OpenApiValidator.Validate(swaggerFile);
+            result.IsValid.Should().BeFalse();
+        }
+        finally
+        {
+            CleanUp(swaggerFile);
+        }
+    }
+
+    [Test]
+    public async Task SecurityScheme_Header_Injection_Does_Not_Break_Out_Of_Attribute_V2()
+    {
+        string generatedCode = await GenerateCode(SecuritySchemeHeaderInjectionSpecV2);
+        generatedCode.Should().Contain("\\\"");
+        generatedCode.Should().NotContain("[Header(\"Y\")]");
+    }
+
+    [Category("Integration")]
+    [Test]
+    public async Task Generated_Code_With_SecurityScheme_Header_Injection_Is_Inert_And_Compiles_V2()
+    {
+        string generatedCode = await GenerateCode(SecuritySchemeHeaderInjectionSpecV2);
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Validation_Rejects_SecurityScheme_Header_With_Breakout_Characters_V2()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(SecuritySchemeHeaderInjectionSpecV2);
         try
         {
             var result = await OpenApiValidator.Validate(swaggerFile);

--- a/src/Refitter.Tests/Scenarios/SecurityAttributeInjectionTests.cs
+++ b/src/Refitter.Tests/Scenarios/SecurityAttributeInjectionTests.cs
@@ -221,6 +221,21 @@ securityDefinitions:
     }
 
     [Test]
+    public async Task Validation_Rejects_Header_With_Breakout_Characters()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(HeaderInjectionSpec);
+        try
+        {
+            var result = await OpenApiValidator.Validate(swaggerFile);
+            result.IsValid.Should().BeFalse();
+        }
+        finally
+        {
+            CleanUp(swaggerFile);
+        }
+    }
+
+    [Test]
     public async Task Validation_Rejects_Header_With_Breakout_Characters_V2()
     {
         var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(HeaderInjectionSpecV2);

--- a/src/Refitter.Tests/Scenarios/SecurityAttributeInjectionTests.cs
+++ b/src/Refitter.Tests/Scenarios/SecurityAttributeInjectionTests.cs
@@ -253,8 +253,10 @@ securityDefinitions:
     [Test]
     public async Task SecurityScheme_Header_Injection_Does_Not_Break_Out_Of_Attribute()
     {
-        string generatedCode = await GenerateCode(SecuritySchemeHeaderInjectionSpec);
-        generatedCode.Should().Contain("\\\"");
+        string generatedCode = await GenerateCode(
+            SecuritySchemeHeaderInjectionSpec,
+            AuthenticationHeaderStyle.Parameter);
+        generatedCode.Should().Contain("[Get(\"/api\")]");
         generatedCode.Should().NotContain("[Header(\"Y\")]");
     }
 
@@ -262,7 +264,9 @@ securityDefinitions:
     [Test]
     public async Task Generated_Code_With_SecurityScheme_Header_Injection_Is_Inert_And_Compiles()
     {
-        string generatedCode = await GenerateCode(SecuritySchemeHeaderInjectionSpec);
+        string generatedCode = await GenerateCode(
+            SecuritySchemeHeaderInjectionSpec,
+            AuthenticationHeaderStyle.Parameter);
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
@@ -284,8 +288,10 @@ securityDefinitions:
     [Test]
     public async Task SecurityScheme_Header_Injection_Does_Not_Break_Out_Of_Attribute_V2()
     {
-        string generatedCode = await GenerateCode(SecuritySchemeHeaderInjectionSpecV2);
-        generatedCode.Should().Contain("\\\"");
+        string generatedCode = await GenerateCode(
+            SecuritySchemeHeaderInjectionSpecV2,
+            AuthenticationHeaderStyle.Parameter);
+        generatedCode.Should().Contain("[Get(\"/api\")]");
         generatedCode.Should().NotContain("[Header(\"Y\")]");
     }
 
@@ -293,7 +299,9 @@ securityDefinitions:
     [Test]
     public async Task Generated_Code_With_SecurityScheme_Header_Injection_Is_Inert_And_Compiles_V2()
     {
-        string generatedCode = await GenerateCode(SecuritySchemeHeaderInjectionSpecV2);
+        string generatedCode = await GenerateCode(
+            SecuritySchemeHeaderInjectionSpecV2,
+            AuthenticationHeaderStyle.Parameter);
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
@@ -312,12 +320,18 @@ securityDefinitions:
         }
     }
 
-    private static async Task<string> GenerateCode(string spec)
+    private static async Task<string> GenerateCode(
+        string spec,
+        AuthenticationHeaderStyle authenticationHeaderStyle = AuthenticationHeaderStyle.None)
     {
         var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(spec);
         try
         {
-            var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = swaggerFile,
+                AuthenticationHeaderStyle = authenticationHeaderStyle
+            };
             var generator = await RefitGenerator.CreateAsync(settings);
             return generator.Generate();
         }

--- a/src/Refitter.Tests/Scenarios/SecurityAttributeInjectionTests.cs
+++ b/src/Refitter.Tests/Scenarios/SecurityAttributeInjectionTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Core.Validation;
+using Refitter.Tests.Build;
+using Refitter.Tests.TestUtilities;
+using TUnit.Core;
+
+namespace Refitter.Tests.Scenarios;
+
+// Regression tests for GHSA-3fhm-p725-h3g3: an OpenAPI path / header name that closes the
+// Refit attribute string and injects a [ModuleInitializer] file class must not break out of
+// the generated code, and must be rejected by validation.
+public class SecurityAttributeInjectionTests
+{
+    private const string MaliciousPath =
+        @"/p"")] Task<string> Dummy(); } } file class Evil { [System.Runtime.CompilerServices.ModuleInitializer] internal static void Init(){ } } namespace N2 { public partial interface I2 { [Get(""/q";
+
+    private const string PathInjectionSpec = @"
+openapi: 3.0.0
+info:
+  title: Injection
+  version: 1.0.0
+paths:
+  '" + MaliciousPath + @"':
+    get:
+      operationId: GetU
+      responses:
+        '200':
+          description: ok
+";
+
+    private const string HeaderInjectionSpec = @"
+openapi: 3.0.0
+info:
+  title: Injection
+  version: 1.0.0
+paths:
+  /api:
+    get:
+      operationId: GetU
+      parameters:
+        - name: 'X"")] string a); } file class H {} public partial interface J { [Header(""Y'
+          in: header
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ok
+";
+
+    [Test]
+    public async Task Path_Injection_Does_Not_Break_Out_Of_Attribute()
+    {
+        string generatedCode = await GenerateCode(PathInjectionSpec);
+        generatedCode.Should().Contain("\\\"");
+        generatedCode.Should().NotContain("[Get(\"/q\")]");
+    }
+
+    [Category("Integration")]
+    [Test]
+    public async Task Generated_Code_With_Path_Injection_Is_Inert_And_Compiles()
+    {
+        string generatedCode = await GenerateCode(PathInjectionSpec);
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Header_Injection_Does_Not_Break_Out_Of_Attribute()
+    {
+        string generatedCode = await GenerateCode(HeaderInjectionSpec);
+        generatedCode.Should().Contain("\\\"");
+        generatedCode.Should().NotContain("[Header(\"Y\")]");
+    }
+
+    [Category("Integration")]
+    [Test]
+    public async Task Generated_Code_With_Header_Injection_Is_Inert_And_Compiles()
+    {
+        string generatedCode = await GenerateCode(HeaderInjectionSpec);
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Validation_Rejects_Path_With_Breakout_Characters()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(PathInjectionSpec);
+        try
+        {
+            var result = await OpenApiValidator.Validate(swaggerFile);
+            result.IsValid.Should().BeFalse();
+        }
+        finally
+        {
+            CleanUp(swaggerFile);
+        }
+    }
+
+    private static async Task<string> GenerateCode(string spec)
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(spec);
+        try
+        {
+            var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile };
+            var generator = await RefitGenerator.CreateAsync(settings);
+            return generator.Generate();
+        }
+        finally
+        {
+            CleanUp(swaggerFile);
+        }
+    }
+
+    private static void CleanUp(string swaggerFile)
+    {
+        if (File.Exists(swaggerFile))
+            File.Delete(swaggerFile);
+        var directory = Path.GetDirectoryName(swaggerFile);
+        if (directory != null && Directory.Exists(directory))
+            Directory.Delete(directory, true);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes **GHSA-3fhm-p725-h3g3**. Refitter emitted each OpenAPI path key and header name verbatim into Refit `[Get("…")]` / `[Header("…")]` attributes. A crafted single-line path closes the attribute string, the interface, and the namespace, injects a top-level `file class` with a `[ModuleInitializer]`, then reopens a namespace/interface — yielding **RCE at assembly load** in any app that compiles the generated client. Verified reproducible on the current build with no `--skip-validation`.

## Changes

- **Escape all spec-derived attribute strings** (always-on, even with `--skip-validation`):
  - `[Get/Post/...]` path — `InterfaceGenerator`
  - `[Header(name)]` parameter & security-scheme names — `HeaderParameterExtractor`
  - `[Headers("Accept:"/"Content-Type:")]` media types — `MethodAttributeGenerator`
- **Reject breakout characters** (`"`, `\`, control/newlines) in paths and header names during validation; errors out unless `--skip-validation` (`AttributeStringValidator`).
- Regression tests proving injected payloads stay inert and compile, and that validation rejects them.

## Verification

- Reproduced original RCE; confirmed escaped output compiles and is **inert** (no module-initializer execution).
- Malicious spec now rejected by default; `--skip-validation` still produces safe, escaped code.
- Full build green; 2117 unit tests pass; security suite (incl. compile checks) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escaping in generated Refit attributes to safely handle special characters in API paths, header names, and `Accept`/`Content-Type` header literals.

* **Security Validation**
  * Strengthened OpenAPI validation to reject unsafe characters (quotes, backslashes, control characters) in path keys, header parameter names, and header-based API-key security scheme names.

* **Tests**
  * Added regression coverage for injection attempts across OpenAPI 3.0 and Swagger 2.0, including C# compile checks and validation failure assertions, plus dedicated validator tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->