### PR TITLE
Verify compatibility with Refit v13.1.0

### DIFF
--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreMultipleInterfaces.g.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Net.Http;
 
 using Refitter.Tests.AdditionalFiles.SingeInterface;
 
@@ -512,8 +511,9 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 {
     using System;
-    using Microsoft.Extensions.DependencyInjection;
-    using Refit;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Refit;
 
     /// <summary>
     /// Extension methods for configuring Refit clients in the service collection.
@@ -536,6 +536,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
         {
             var clientBuilderIUpdatePetEndpoint = services
                 .AddRefitClient<IUpdatePetEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -544,6 +545,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIAddPetEndpoint = services
                 .AddRefitClient<IAddPetEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -552,6 +554,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIFindPetsByStatusEndpoint = services
                 .AddRefitClient<IFindPetsByStatusEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -560,6 +563,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIFindPetsByTagsEndpoint = services
                 .AddRefitClient<IFindPetsByTagsEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -568,6 +572,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetPetByIdEndpoint = services
                 .AddRefitClient<IGetPetByIdEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -576,6 +581,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIUpdatePetWithFormEndpoint = services
                 .AddRefitClient<IUpdatePetWithFormEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -584,6 +590,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIDeletePetEndpoint = services
                 .AddRefitClient<IDeletePetEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -592,6 +599,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIUploadFileEndpoint = services
                 .AddRefitClient<IUploadFileEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -600,6 +608,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetInventoryEndpoint = services
                 .AddRefitClient<IGetInventoryEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -608,6 +617,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIPlaceOrderEndpoint = services
                 .AddRefitClient<IPlaceOrderEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -616,6 +626,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetOrderByIdEndpoint = services
                 .AddRefitClient<IGetOrderByIdEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -624,6 +635,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIDeleteOrderEndpoint = services
                 .AddRefitClient<IDeleteOrderEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -632,6 +644,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderICreateUserEndpoint = services
                 .AddRefitClient<ICreateUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -640,6 +653,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderICreateUsersWithListInputEndpoint = services
                 .AddRefitClient<ICreateUsersWithListInputEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -648,6 +662,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderILoginUserEndpoint = services
                 .AddRefitClient<ILoginUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -656,6 +671,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderILogoutUserEndpoint = services
                 .AddRefitClient<ILogoutUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -664,6 +680,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIGetUserByNameEndpoint = services
                 .AddRefitClient<IGetUserByNameEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -672,6 +689,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIUpdateUserEndpoint = services
                 .AddRefitClient<IUpdateUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();
@@ -680,6 +698,7 @@ namespace Refitter.Tests.AdditionalFiles.ByEndpoint
 
             var clientBuilderIDeleteUserEndpoint = services
                 .AddRefitClient<IDeleteUserEndpoint>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = baseUrl)
                 .AddHttpMessageHandler<EmptyMessageHandler>()
                 .AddHttpMessageHandler<AnotherEmptyMessageHandler>();

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
@@ -7,7 +7,6 @@ using Refit;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using System.Net.Http;
 
 #nullable enable annotations
 
@@ -743,6 +742,7 @@ public PetStatus Status { get; set; }
 namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
 {
     using System;
+    using System.Net.Http;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Http.Resilience;
     using Refit;
@@ -766,6 +766,7 @@ namespace Refitter.Tests.AdditionalFiles.SingeInterfaceWithHttpResilience
         {
             var clientBuilderISwaggerPetstoreInterfaceWithHttpResilience = services
                 .AddRefitClient<ISwaggerPetstoreInterfaceWithHttpResilience>(settings)
+                
                 .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://petstore3.swagger.io/api/v3"));
 
             clientBuilderISwaggerPetstoreInterfaceWithHttpResilience

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
@@ -7,7 +7,6 @@ using Refit;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using System.Net.Http;
 
 #nullable enable annotations
 
@@ -453,6 +452,7 @@ public PetStatus Status { get; set; }
 namespace Refitter.Tests.AdditionalFiles.SingeInterface
 {
     using System;
+    using System.Net.Http;
     using Microsoft.Extensions.DependencyInjection;
     using Polly;
     using Polly.Contrib.WaitAndRetry;

--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -11,7 +11,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -40,7 +40,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />

--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -10,7 +10,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -38,7 +38,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />

--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -2,7 +2,8 @@ namespace Refitter.SourceGenerators.Tests.Build;
 
 public static class ProjectFileContents
 {
-    public const string Net80App = @"
+    public const string Net80App =
+        @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -14,10 +15,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -30,7 +31,8 @@ public static class ProjectFileContents
   </ItemGroup>
 </Project>";
 
-    public const string Net90App = @"
+    public const string Net90App =
+        @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -42,10 +44,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />

--- a/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
+++ b/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
@@ -22,7 +22,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>

--- a/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
+++ b/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
@@ -23,7 +23,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>
 

--- a/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
+++ b/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
@@ -22,7 +22,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -2,7 +2,8 @@ namespace Refitter.Tests.Build;
 
 public static class ProjectFileContents
 {
-    public const string Net80App = @"
+    public const string Net80App =
+        @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -14,10 +15,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -30,7 +31,8 @@ public static class ProjectFileContents
   </ItemGroup>
 </Project>";
 
-    public const string Net80AppWithWarningsAsErrors = @"
+    public const string Net80AppWithWarningsAsErrors =
+        @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -59,7 +61,8 @@ public static class ProjectFileContents
   </ItemGroup>
 </Project>";
 
-    public const string Net90App = @"
+    public const string Net90App =
+        @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -71,10 +74,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -87,7 +90,8 @@ public static class ProjectFileContents
   </ItemGroup>
 </Project>";
 
-    public const string Net90AppWithWarningsAsErrors = @"
+    public const string Net90AppWithWarningsAsErrors =
+        @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -100,10 +104,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.1"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.11"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.10.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -116,7 +120,8 @@ public static class ProjectFileContents
   </ItemGroup>
 </Project>";
 
-    public const string Net100App = @"
+    public const string Net100App =
+        @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -128,10 +133,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -144,7 +149,8 @@ public static class ProjectFileContents
   </ItemGroup>
 </Project>";
 
-    public const string Net100AppWithWarningsAsErrors = @"
+    public const string Net100AppWithWarningsAsErrors =
+        @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -157,10 +163,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.8"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.8"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -10,7 +10,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -67,7 +67,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -124,7 +124,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -153,7 +153,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""11.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -11,7 +11,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -70,7 +70,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -129,7 +129,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -159,7 +159,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.0.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />

--- a/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
@@ -65,7 +65,7 @@ public class GenerateJsonSerializerContextPolymorphismTests
             <RestorePackagesPath>packages</RestorePackagesPath>
           </PropertyGroup>
           <ItemGroup>
-            <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
+            <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
           </ItemGroup>
         </Project>
         """;

--- a/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
@@ -65,7 +65,7 @@ public class GenerateJsonSerializerContextPolymorphismTests
             <RestorePackagesPath>packages</RestorePackagesPath>
           </PropertyGroup>
           <ItemGroup>
-            <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
+            <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
           </ItemGroup>
         </Project>
         """;

--- a/src/Refitter/Refitter.csproj
+++ b/src/Refitter/Refitter.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.23.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/test/Apizr/Sample.csproj
+++ b/test/Apizr/Sample.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Apizr.Integrations.Fusillade" Version="6.4.2" />
   <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/test/ConsoleApp/Directory.Build.props
+++ b/test/ConsoleApp/Directory.Build.props
@@ -31,8 +31,8 @@
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
-        <PackageReference Include="Refit" Version="11.0.1" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
+        <PackageReference Include="Refit" Version="13.0.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
         <PackageReference Include="Polly" Version="8.6.6" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/test/ConsoleApp/Directory.Build.props
+++ b/test/ConsoleApp/Directory.Build.props
@@ -28,9 +28,9 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
         <PackageReference Include="Refit" Version="13.0.0" />
         <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
         <PackageReference Include="Polly" Version="8.6.6" />

--- a/test/ConsoleApp/Directory.Build.props
+++ b/test/ConsoleApp/Directory.Build.props
@@ -31,8 +31,8 @@
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
-        <PackageReference Include="Refit" Version="13.0.0" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
+        <PackageReference Include="Refit" Version="13.1.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
         <PackageReference Include="Polly" Version="8.6.6" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/test/ConsoleApp/NetStandard20/NetStandard20.csproj
+++ b/test/ConsoleApp/NetStandard20/NetStandard20.csproj
@@ -1,5 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-</Project>

--- a/test/ConsoleApp/NetStandard21/NetStandard21.csproj
+++ b/test/ConsoleApp/NetStandard21/NetStandard21.csproj
@@ -1,5 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-  </PropertyGroup>
-</Project>

--- a/test/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/test/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Refit" Version="11.0.1" />
+    <PackageReference Include="Refit" Version="13.0.0" />
     <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 

--- a/test/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/test/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Refit" Version="13.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/test/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/test/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Refit" Version="13.0.0" />
+    <PackageReference Include="Refit" Version="13.1.0" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 

--- a/test/MSBuild/Refitter.MSBuild.Tests.csproj
+++ b/test/MSBuild/Refitter.MSBuild.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
     </ItemGroup>
 
 </Project>

--- a/test/MSBuild/Refitter.MSBuild.Tests.csproj
+++ b/test/MSBuild/Refitter.MSBuild.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
     </ItemGroup>
 
 </Project>

--- a/test/MinimalApi/MinimalApi.csproj
+++ b/test/MinimalApi/MinimalApi.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.0" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
     <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/test/MinimalApi/MinimalApi.csproj
+++ b/test/MinimalApi/MinimalApi.csproj
@@ -18,13 +18,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.0" />
     <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
     <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/test/MinimalApi/MinimalApi.csproj
+++ b/test/MinimalApi/MinimalApi.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.0" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
     <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/test/MultipleFiles/Client/Client.csproj
+++ b/test/MultipleFiles/Client/Client.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-    <PackageReference Include="Refit" Version="11.0.1" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
+    <PackageReference Include="Refit" Version="13.0.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/test/MultipleFiles/Client/Client.csproj
+++ b/test/MultipleFiles/Client/Client.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-    <PackageReference Include="Refit" Version="13.0.0" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="13.0.0" />
+    <PackageReference Include="Refit" Version="13.1.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/test/SourceGenerator/Directory.Build.props
+++ b/test/SourceGenerator/Directory.Build.props
@@ -16,6 +16,6 @@
         <PackageReference Include="Refit" Version="13.0.0" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-        <PackageReference Include="System.Text.Json" Version="10.0.8" />
+        <PackageReference Include="System.Text.Json" Version="10.0.9" />
     </ItemGroup>
 </Project>

--- a/test/SourceGenerator/Directory.Build.props
+++ b/test/SourceGenerator/Directory.Build.props
@@ -13,7 +13,7 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\Refitter.SourceGenerator\Refitter.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-        <PackageReference Include="Refit" Version="11.0.1" />
+        <PackageReference Include="Refit" Version="13.0.0" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
         <PackageReference Include="System.Text.Json" Version="10.0.8" />

--- a/test/SourceGenerator/Directory.Build.props
+++ b/test/SourceGenerator/Directory.Build.props
@@ -13,7 +13,7 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\Refitter.SourceGenerator\Refitter.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-        <PackageReference Include="Refit" Version="13.0.0" />
+        <PackageReference Include="Refit" Version="13.1.0" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
         <PackageReference Include="System.Text.Json" Version="10.0.9" />


### PR DESCRIPTION
This pull request updates all usages of the `Refit` and `Refit.HttpClientFactory` NuGet packages across the codebase from version `11.0.1` to `13.1.0`. This ensures that all projects and test scenarios are aligned with the latest features and bug fixes provided by Refit.

Dependency version upgrades:

* Updated `Refit.HttpClientFactory` package reference from `11.0.1` to `13.1.0` in the following files:
  - `src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs` [[1]](diffhunk://#diff-85e848e84abcebc77e4aa9ab717be826fc49499d3a86604ccae2fa223472ae08L13-R13) [[2]](diffhunk://#diff-85e848e84abcebc77e4aa9ab717be826fc49499d3a86604ccae2fa223472ae08L41-R41)
  - `src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj`
  - `src/Refitter.Tests/Build/ProjectFileContents.cs` [[1]](diffhunk://#diff-b50eea9ef8bc22e552467f370a0388c3036d02b4d024b5b854a6cd0dff53db01L13-R13) [[2]](diffhunk://#diff-b50eea9ef8bc22e552467f370a0388c3036d02b4d024b5b854a6cd0dff53db01L70-R70) [[3]](diffhunk://#diff-b50eea9ef8bc22e552467f370a0388c3036d02b4d024b5b854a6cd0dff53db01L127-R127) [[4]](diffhunk://#diff-b50eea9ef8bc22e552467f370a0388c3036d02b4d024b5b854a6cd0dff53db01L156-R156)
  - `src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs`
  - `test/MSBuild/Refitter.MSBuild.Tests.csproj`
  - `test/MinimalApi/MinimalApi.csproj`
  - `test/MultipleFiles/Client/Client.csproj`
  - `test/ConsoleApp/Directory.Build.props`

* Updated `Refit` package reference from `11.0.1` to `13.1.0` in the following files:
  - `test/ConsoleApp/Directory.Build.props`
  - `test/HelloWorld/HelloWorld/HelloWorld.csproj`
  - `test/MultipleFiles/Client/Client.csproj`
  - `test/SourceGenerator/Directory.Build.props`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated NuGet package versions across test projects, sample apps, and build/test fixtures: `Refit`/`Refit.HttpClientFactory` to `13.1.0` (from `11.0.1`), plus aligned `Microsoft.Extensions.*` packages to `10.0.9` (and `Microsoft.Extensions.Http.Resilience` to `10.1.0` where applicable).
  * Bumped `System.Text.Json` to `10.0.9` in applicable projects.
  * Kept behavior unchanged; updated project-template formatting where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->