### PR TITLE
Upgrade oasreader to v3.7.0.20

### DIFF
--- a/docs/docfx_project/articles/breaking-changes-v2-0-0.md
+++ b/docs/docfx_project/articles/breaking-changes-v2-0-0.md
@@ -131,7 +131,7 @@ If your CI/CD pipeline references generated files:
 ## Silent Behavioral Change: OpenAPI Parser Upgrade
 
 ### Summary
-Refitter v2.0.0 upgrades the OpenAPI parser from **Microsoft.OpenApi.Readers 1.x to 3.x** (`OasReader 3.5.0.19`). This is a **major version upgrade** with materially different schema interpretation.
+Refitter v2.0.0 upgrades the OpenAPI parser from **Microsoft.OpenApi.Readers 1.x to 3.x** (`OasReader 3.7.0.20`). This is a **major version upgrade** with materially different schema interpretation.
 
 ### Impact
 Users upgrading from v1.7.3 may see **different generated C# code** even without changing their OpenAPI specifications. This is not a breaking change in the Refitter API, but a **behavioral change in code generation** caused by the parser upgrade. The branch proves the parser changed and documents how to migrate; it does **not** prove full 1.7.3-vs-v2.0 behavioral equivalence across a broad real-world corpus.

--- a/src/Refitter.Core/Refitter.Core.csproj
+++ b/src/Refitter.Core/Refitter.Core.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
     <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="14.7.1" />
     <PackageReference Include="NSwag.Core.Yaml" Version="14.7.1" />
-    <PackageReference Include="OasReader" Version="3.5.0.19" />
+    <PackageReference Include="OasReader" Version="3.7.0.20" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
+++ b/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="H.Generators.Extensions" Version="1.24.2" PrivateAssets="all" />
     <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="14.7.1" PrivateAssets="all" />
     <PackageReference Include="NSwag.Core.Yaml" Version="14.7.1" PrivateAssets="all" />
-    <PackageReference Include="OasReader" Version="3.5.0.19" PrivateAssets="all" />
+    <PackageReference Include="OasReader" Version="3.7.0.20" PrivateAssets="all" />
     <PackageReference Include="Refit" Version="10.2.0" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
This resolves the following Dependabot vulnerability alerts:

1) https://github.com/christianhelle/refitter/security/dependabot/6
2) https://github.com/christianhelle/refitter/security/dependabot/7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the breaking-changes note to reflect the newer OpenAPI parser version and its impact on schema interpretation.

* **Chores**
  * Upgraded the OpenAPI parser used by the product to a newer release across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->