### PR TITLE
Disambiguate dynamic QueryParams type names in ByTag mode

### DIFF
--- a/src/Refitter.Core/Partitioning/ByTagInterfacePartitioning.cs
+++ b/src/Refitter.Core/Partitioning/ByTagInterfacePartitioning.cs
@@ -41,8 +41,22 @@ internal class ByTagInterfacePartitioning : IInterfacePartitioning
         return methodName;
     }
 
-    public string GetDynamicQuerystringParameterType(string interfaceName, string methodName) =>
-        methodName + "QueryParams";
+    public string GetDynamicQuerystringParameterType(string interfaceName, string methodName)
+    {
+        var prefix = interfaceName;
+        if (prefix.StartsWith("I"))
+        {
+            prefix = prefix.Substring(1);
+        }
+
+        var suffix = GetInterfaceNameSuffix();
+        if (prefix.EndsWith(suffix) && prefix.Length > suffix.Length)
+        {
+            prefix = prefix.Substring(0, prefix.Length - suffix.Length);
+        }
+
+        return prefix + methodName + "QueryParams";
+    }
 
     public bool IsSingleInterface => false;
 

--- a/src/Refitter.Tests/Apizr/ApizrTests.cs
+++ b/src/Refitter.Tests/Apizr/ApizrTests.cs
@@ -172,8 +172,8 @@ paths:
     public async Task Generates_Dynamic_Querystring_Parameters_ByTag()
     {
         string generatedCode = await GenerateCode(true, MultipleInterfaces.ByTag);
-        generatedCode.Should().Contain("string id, [Query] GetFooDetailsQueryParams? queryParams, [RequestOptions] IApizrRequestOptions options);");
-        generatedCode.Should().Contain("public record GetFooDetailsQueryParams");
+        generatedCode.Should().Contain("string id, [Query] FooGetFooDetailsQueryParams? queryParams, [RequestOptions] IApizrRequestOptions options);");
+        generatedCode.Should().Contain("public record FooGetFooDetailsQueryParams");
     }
 
     [Test]

--- a/src/Refitter.Tests/Regression/Issue1190DynamicQueryParamsByTagTests.cs
+++ b/src/Refitter.Tests/Regression/Issue1190DynamicQueryParamsByTagTests.cs
@@ -54,6 +54,70 @@ public class Issue1190DynamicQueryParamsByTagTests
                   description: 'ok'
         """;
 
+    private const string OpenApiSpecSwagger2 = @"
+{
+  ""swagger"": ""2.0"",
+  ""info"": {
+    ""title"": ""Issue 1190 API"",
+    ""version"": ""1.0""
+  },
+  ""host"": ""localhost"",
+  ""basePath"": ""/"",
+  ""paths"": {
+    ""/MachineTool/Page"": {
+      ""get"": {
+        ""tags"": [
+          ""MachineTool""
+        ],
+        ""operationId"": ""Page"",
+        ""parameters"": [
+          {
+            ""name"": ""machineToolParam"",
+            ""in"": ""query"",
+            ""type"": ""string""
+          },
+          {
+            ""name"": ""machineToolFilter"",
+            ""in"": ""query"",
+            ""type"": ""string""
+          }
+        ],
+        ""responses"": {
+          ""200"": {
+            ""description"": ""ok""
+          }
+        }
+      }
+    },
+    ""/Material/Page"": {
+      ""get"": {
+        ""tags"": [
+          ""Material""
+        ],
+        ""operationId"": ""Page"",
+        ""parameters"": [
+          {
+            ""name"": ""materialParam"",
+            ""in"": ""query"",
+            ""type"": ""string""
+          },
+          {
+            ""name"": ""materialFilter"",
+            ""in"": ""query"",
+            ""type"": ""string""
+          }
+        ],
+        ""responses"": {
+          ""200"": {
+            ""description"": ""ok""
+          }
+        }
+      }
+    }
+  }
+}
+";
+
     [Test]
     public async Task ByTag_Generates_Distinct_QueryParams_Types_Per_Tag()
     {
@@ -82,9 +146,54 @@ public class Issue1190DynamicQueryParamsByTagTests
         BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
     }
 
+    // ── Swagger 2.0 companion tests ─────────────────────────────────────────
+
+    [Test]
+    public async Task ByTag_Generates_Distinct_QueryParams_Types_Per_Tag_Swagger2()
+    {
+        string generatedCode = await GenerateCodeSwagger2();
+
+        generatedCode.Should().Contain("partial interface IMachineToolApi");
+        generatedCode.Should().Contain("partial interface IMaterialApi");
+
+        generatedCode.Should().Contain("[Query] MachineToolPageAsyncQueryParams queryParams");
+        generatedCode.Should().Contain("[Query] MaterialPageAsyncQueryParams queryParams");
+
+        generatedCode.Should().Contain("public class MachineToolPageAsyncQueryParams");
+        generatedCode.Should().Contain("public class MaterialPageAsyncQueryParams");
+
+        generatedCode.Should().Contain("MachineToolParam");
+        generatedCode.Should().Contain("MachineToolFilter");
+        generatedCode.Should().Contain("MaterialParam");
+        generatedCode.Should().Contain("MaterialFilter");
+    }
+
+    [Category("Integration")]
+    [Test]
+    public async Task ByTag_Generated_Code_With_Distinct_QueryParams_Builds_Swagger2()
+    {
+        string generatedCode = await GenerateCodeSwagger2();
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
     private static async Task<string> GenerateCode()
     {
         var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = swaggerFile,
+            MultipleInterfaces = MultipleInterfaces.ByTag,
+            UseDynamicQuerystringParameters = true,
+            OperationNameTemplate = "{operationName}Async"
+        };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        return sut.Generate();
+    }
+
+    private static async Task<string> GenerateCodeSwagger2()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(OpenApiSpecSwagger2);
         var settings = new RefitGeneratorSettings
         {
             OpenApiPath = swaggerFile,

--- a/src/Refitter.Tests/Regression/Issue1190DynamicQueryParamsByTagTests.cs
+++ b/src/Refitter.Tests/Regression/Issue1190DynamicQueryParamsByTagTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Refitter.Tests.TestUtilities;
+using TUnit.Core;
+
+namespace Refitter.Tests.Regression;
+
+/// <summary>
+/// Regression tests for Issue #1190: dynamic QueryParams types are incorrectly shared
+/// by GET endpoints with the same method name across different controllers/tags.
+/// </summary>
+public class Issue1190DynamicQueryParamsByTagTests
+{
+    private const string OpenApiSpec = """
+        openapi: '3.0.0'
+        info:
+          title: 'Issue 1190 API'
+          version: '1.0'
+        paths:
+          /MachineTool/Page:
+            get:
+              tags:
+                - 'MachineTool'
+              operationId: 'Page'
+              parameters:
+                - in: query
+                  name: machineToolParam
+                  schema:
+                    type: string
+                - in: query
+                  name: machineToolFilter
+                  schema:
+                    type: string
+              responses:
+                '200':
+                  description: 'ok'
+          /Material/Page:
+            get:
+              tags:
+                - 'Material'
+              operationId: 'Page'
+              parameters:
+                - in: query
+                  name: materialParam
+                  schema:
+                    type: string
+                - in: query
+                  name: materialFilter
+                  schema:
+                    type: string
+              responses:
+                '200':
+                  description: 'ok'
+        """;
+
+    [Test]
+    public async Task ByTag_Generates_Distinct_QueryParams_Types_Per_Tag()
+    {
+        string generatedCode = await GenerateCode();
+
+        generatedCode.Should().Contain("partial interface IMachineToolApi");
+        generatedCode.Should().Contain("partial interface IMaterialApi");
+
+        generatedCode.Should().Contain("[Query] MachineToolPageAsyncQueryParams queryParams");
+        generatedCode.Should().Contain("[Query] MaterialPageAsyncQueryParams queryParams");
+
+        generatedCode.Should().Contain("public class MachineToolPageAsyncQueryParams");
+        generatedCode.Should().Contain("public class MaterialPageAsyncQueryParams");
+
+        generatedCode.Should().Contain("MachineToolParam");
+        generatedCode.Should().Contain("MachineToolFilter");
+        generatedCode.Should().Contain("MaterialParam");
+        generatedCode.Should().Contain("MaterialFilter");
+    }
+
+    [Category("Integration")]
+    [Test]
+    public async Task ByTag_Generated_Code_With_Distinct_QueryParams_Builds()
+    {
+        string generatedCode = await GenerateCode();
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = swaggerFile,
+            MultipleInterfaces = MultipleInterfaces.ByTag,
+            UseDynamicQuerystringParameters = true,
+            OperationNameTemplate = "{operationName}Async"
+        };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        return sut.Generate();
+    }
+}

--- a/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagsTests.cs
+++ b/src/Refitter.Tests/Scenarios/MultipleInterfacesByTagsTests.cs
@@ -141,9 +141,9 @@ paths:
     public async Task Generates_Dynamic_Querystring_Parameters()
     {
         string generatedCode = await GenerateCode(true);
-        generatedCode.Should().Contain("GetFooDetailsQueryParams");
-        generatedCode.Should().Contain("GetAllFoosQueryParams");
-        generatedCode.Should().Contain("GetBarDetailsQueryParams");
+        generatedCode.Should().Contain("FooGetFooDetailsQueryParams");
+        generatedCode.Should().Contain("FooGetAllFoosQueryParams");
+        generatedCode.Should().Contain("BarGetBarDetailsQueryParams");
     }
 
     [Test]


### PR DESCRIPTION
## Fixes #1190

### Root cause
`ByTagInterfacePartitioning.GetDynamicQuerystringParameterType()` used only `methodName + "QueryParams"`, so methods with the same name across different tags produced colliding type names.

### Fix
Extract the tag name from the interface name (strip `I` prefix and `Api` suffix) and prepend it to the type name, e.g. `PageAsyncQueryParams` → `MachineToolPageAsyncQueryParams`.

### Changes
- `cd862f40` — fix: include tag prefix in ByTag dynamic QueryParams type names
- `7a85b95a` — test: update ByTag dynamic QueryParams assertions for tag-prefixed names
- `08680bd0` — test: add regression test for issue #1190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated dynamic query parameter names when creating separate API interfaces by tag.
  * Prevented naming collisions when different tagged endpoints share the same operation name.
  * Ensured generated query parameter types remain distinct and compile successfully.

* **Tests**
  * Added regression coverage for tag-specific query parameter generation.
  * Updated expectations for tag-prefixed generated query parameter types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->