### PR TITLE
Fix generate response type for 202 Accepted responses

### DIFF
--- a/src/Refitter.Core/Generation/ReturnTypeGenerator.cs
+++ b/src/Refitter.Core/Generation/ReturnTypeGenerator.cs
@@ -32,7 +32,7 @@ internal class ReturnTypeGenerator(
             return $"{GetAsyncOperationType(false)}<HttpResponseMessage>";
         }
 
-        var successCodes = new[] { "200", "201", "203", "206" };
+        var successCodes = new[] { "200", "201", "202", "203", "206" };
         var returnTypeParameter = successCodes
             .Where(operation.Responses.ContainsKey)
             .Select(code => GetTypeName(code, operation))
@@ -59,7 +59,7 @@ internal class ReturnTypeGenerator(
 
     public bool IsFileStreamResponse(OpenApiOperation operation)
     {
-        var successCodes = new[] { "200", "201", "203", "206", "2XX" };
+        var successCodes = new[] { "200", "201", "202", "203", "206", "2XX" };
 
         foreach (var code in successCodes)
         {

--- a/src/Refitter.Tests/Scenarios/AcceptedResponseObjectTests.cs
+++ b/src/Refitter.Tests/Scenarios/AcceptedResponseObjectTests.cs
@@ -69,6 +69,21 @@ paths:
       responses:
         '202':
           description: 'Batch accepted for processing'
+  /exports:
+    post:
+      tags:
+        - 'Jobs'
+      summary: 'Start an export'
+      description: 'Accepts the request and streams back the export payload'
+      operationId: 'createExport'
+      responses:
+        '202':
+          description: 'Export accepted for processing'
+          content:
+            application/octet-stream:
+              schema:
+                type: 'string'
+                format: 'binary'
 components:
   schemas:
     Job:
@@ -113,6 +128,13 @@ components:
     {
         string generatedCode = await GenerateCode();
         generatedCode.Should().Contain("Task CreateBatch();");
+    }
+
+    [Test]
+    public async Task Should_Generate_HttpResponseMessage_When_Accepted_Returns_Binary_Content()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("Task<HttpResponseMessage> CreateExport();");
     }
 
     [Test]

--- a/src/Refitter.Tests/Scenarios/AcceptedResponseObjectTests.cs
+++ b/src/Refitter.Tests/Scenarios/AcceptedResponseObjectTests.cs
@@ -1,0 +1,136 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Refitter.Tests.TestUtilities;
+using TUnit.Core;
+
+namespace Refitter.Tests.Scenarios;
+
+public class AcceptedResponseObjectTests
+{
+    private const string OpenApiSpec =
+        @"
+openapi: '3.0.0'
+info:
+  version: '1.0.0'
+  title: 'Accepted Response API'
+  description: 'An API that returns 202 Accepted for long running operations'
+servers:
+  - url: 'https://api.example.com/v1'
+paths:
+  /jobs:
+    post:
+      tags:
+        - 'Jobs'
+      summary: 'Start a job'
+      description: 'Accepts the request and returns a handle for polling'
+      operationId: 'createJob'
+      responses:
+        '202':
+          description: 'Job accepted for processing'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+  /jobs/{id}:
+    get:
+      tags:
+        - 'Jobs'
+      summary: 'Get job status'
+      description: 'Returns 200 when the job is finished and 202 while it is still running'
+      operationId: 'getJob'
+      parameters:
+        - name: 'id'
+          in: 'path'
+          description: 'Job ID'
+          required: true
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'Job completed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+        '202':
+          description: 'Job still running'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+  /batches:
+    post:
+      tags:
+        - 'Jobs'
+      summary: 'Start a batch'
+      description: 'Accepts the request with no response content'
+      operationId: 'createBatch'
+      responses:
+        '202':
+          description: 'Batch accepted for processing'
+components:
+  schemas:
+    Job:
+      type: 'object'
+      properties:
+        id:
+          type: 'string'
+        status:
+          type: 'string'
+";
+
+    [Test]
+    public async Task Can_Generate_Code()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generatedCode = await GenerateCode();
+        BuildHelper.BuildCSharp(generatedCode).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Should_Generate_Accepted_Response_Return_Type()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("Task<Job> CreateJob();");
+    }
+
+    [Test]
+    public async Task Should_Prefer_Ok_Over_Accepted_When_Both_Are_Present()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("Task<Job> GetJob(string id);");
+    }
+
+    [Test]
+    public async Task Should_Not_Generate_Return_Type_When_Accepted_Has_No_Content()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("Task CreateBatch();");
+    }
+
+    [Test]
+    public async Task Should_Generate_Job_Contract()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("public partial class Job");
+        generatedCode.Should().Contain("public string Id { get; set; }");
+        generatedCode.Should().Contain("public string Status { get; set; }");
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(OpenApiSpec);
+        var settings = new RefitGeneratorSettings { OpenApiPath = swaggerFile, UseCancellationTokens = false };
+
+        var sut = await RefitGenerator.CreateAsync(settings);
+        var generatedCode = sut.Generate();
+        return generatedCode;
+    }
+}


### PR DESCRIPTION
## Description:

Adds `202` to the list of success status codes that Refitter maps to a response type. Without it, an operation whose only success response is `202 Accepted` generates a bare `Task` and the response body is silently unreachable, even when the spec declares content for it.

Resolves #1201, which has the full background: RFC 9110 §6.4.1 excludes only 1xx, 204, and 304 from carrying content, so `202` sits in the same category as the codes already on the list, and §15.3.3 describes the status-monitor body that a `202` is normally expected to carry.

Two lines changed in `ReturnTypeGenerator`:

- `Generate` gains `"202"`, placed after `"200"` and `"201"` so ordering precedence is unchanged for operations that declare several success codes
- `IsFileStreamResponse` gains `"202"` for consistency, so a `202` returning binary content is detected the same way a `200` is

#### Example OpenAPI Specifications:
```yaml
openapi: '3.0.0'
info:
  version: '1.0.0'
  title: 'Accepted Response API'
paths:
  /jobs:
    post:
      tags:
        - 'Jobs'
      operationId: 'createJob'
      responses:
        '202':
          description: 'Job accepted for processing'
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Job'
  /jobs/{id}:
    get:
      tags:
        - 'Jobs'
      operationId: 'getJob'
      parameters:
        - name: 'id'
          in: 'path'
          required: true
          schema:
            type: 'string'
      responses:
        '200':
          description: 'Job completed'
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Job'
        '202':
          description: 'Job still running'
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Job'
  /batches:
    post:
      tags:
        - 'Jobs'
      operationId: 'createBatch'
      responses:
        '202':
          description: 'Batch accepted for processing'
components:
  schemas:
    Job:
      type: 'object'
      properties:
        id:
          type: 'string'
        status:
          type: 'string'
```

#### Example generated Refit interface
```cs
public partial interface IJobs
{
    [Post("/jobs")]
    Task<Job> CreateJob();

    [Get("/jobs/{id}")]
    Task<Job> GetJob(string id);

    [Post("/batches")]
    Task CreateBatch();
}
```

Before this change `CreateJob` was `Task CreateJob()`. `GetJob` already worked because it declares `200`, and it's included to pin that behavior. `CreateBatch` declares `202` with no content and still produces a bare `Task`.

## Tests

`src/Refitter.Tests/Scenarios/AcceptedResponseObjectTests.cs`, following the `Refitter.Tests.Scenarios` pattern (spec as a const string, assertions on generated output, and a build check). Six tests covering generation, buildability, the `202`-only case, `200` winning over `202` when both are declared, the `202`-without-content case, and contract generation.

Full suite: 2236 passed, 0 failed (2230 before this change).

## Notes

- Build and tests were run on Linux with the .NET 10 SDK. `dotnet format --verify-no-changes` reports `ENDOFLINE` violations across the repo on a Linux checkout, including on files I didn't touch, because `.editorconfig` sets `end_of_line = crlf` while git normalizes to LF via `* text=auto`. I checked that an unmodified `ReturnTypeGenerator.cs` reports the same 154 errors, so I left formatting alone rather than commit an unrelated line-ending rewrite. The committed diff is 2 lines plus the new test file. Please shout if CI disagrees and I'll fix it up.
- This changes generated output for anyone whose spec declares a `202` with content, so it falls in the same category as the parser change documented in the v2.0.0 breaking changes guide. If you'd rather not move the default, I'm happy to put it behind a setting instead.

Thanks!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `202 Accepted` responses when generating client return types.
  * Detects response models and file/binary content returned with `202`.
  * Prefers `200 OK` return type when both `200` and `202` are defined.
  * Generates task-only methods when a `202` response has no content, and `HttpResponseMessage` for binary `202` responses.
* **Tests**
  * Added `202 Accepted` end-to-end generation/contract coverage to ensure correct emitted signatures and models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->