### PR TITLE
Add signature-aware counted overload and related tests

### DIFF
--- a/src/Refitter.Core/Generation/InterfaceGenerator.cs
+++ b/src/Refitter.Core/Generation/InterfaceGenerator.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using NJsonSchema;
 using NSwag;
+using NSwag.CodeGeneration.CSharp.Models;
 
 namespace Refitter.Core;
 
@@ -208,13 +208,15 @@ internal class InterfaceGenerator
         var verb = op.Verb.CapitalizeFirstCharacter();
         var baseOperationName = GetBaseOperationName(op);
         var rawMethodName = partitioning.GetMethodName(op, interfaceName, baseOperationName);
-        var signature = GetParameterSignature(operation);
+
+        var operationModel = generator.CreateOperationModel(operation);
+        operationModel.Path = op.Path;
+
+        var signature = GetParameterSignature(operation, operationModel);
         var methodName = IdentifierUtils.Counted(knownMethodIdentifiers, rawMethodName, signature);
 
         var dynamicQuerystringParameterType =
             partitioning.GetDynamicQuerystringParameterType(interfaceName, methodName);
-        var operationModel = generator.CreateOperationModel(operation);
-        operationModel.Path = op.Path;
 
         var (parametersString, parameters, operationDynamicQuerystringParameters) =
             methodSignatureGenerator.Generate(operationModel, operation, dynamicQuerystringParameterType);
@@ -274,29 +276,31 @@ internal class InterfaceGenerator
         return (operationDynamicQuerystringParameters ?? string.Empty, dynamicQuerystringParameterType);
     }
 
-    private static string GetParameterSignature(OpenApiOperation operation)
+    private static string GetParameterSignature(
+        OpenApiOperation operation,
+        CSharpOperationModel operationModel)
     {
         var parts = new List<string>();
 
-        if (operation.Parameters is { Count: > 0 })
-        {
-            foreach (var p in operation.Parameters)
+        foreach (var p in operationModel.Parameters
+            .Where(p => !p.IsBinaryBodyParameter)
+            .OrderBy(p => p.Kind switch
             {
-                var typeStr = p.Schema?.Type is JsonObjectType t
-                    ? t.ToString()
-                    : "any";
-                parts.Add($"{p.Name}:{typeStr}");
-            }
+                OpenApiParameterKind.Path => 0,
+                OpenApiParameterKind.Query => 1,
+                OpenApiParameterKind.Body => 2,
+                OpenApiParameterKind.Header => 3,
+                OpenApiParameterKind.FormData => 4,
+                _ => 99,
+            }))
+        {
+            parts.Add(p.Type);
         }
 
         if (operation.RequestBody is { Content.Count: > 0 })
         {
             var contentType = operation.RequestBody.Content.Keys.First();
-            var bodySchemaType = operation.RequestBody.Content.Values.First().Schema?.Type;
-            var bodyTypeStr = bodySchemaType is JsonObjectType bt
-                ? bt.ToString()
-                : "object";
-            parts.Add($"body:{contentType}:{bodyTypeStr}");
+            parts.Add($"body:{contentType}");
         }
 
         return string.Join("|", parts);

--- a/src/Refitter.Core/Generation/InterfaceGenerator.cs
+++ b/src/Refitter.Core/Generation/InterfaceGenerator.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using NJsonSchema;
 using NSwag;
 
 namespace Refitter.Core;
@@ -125,7 +128,7 @@ internal class InterfaceGenerator
         code.AppendLine(interfaceDeclaration);
         code.AppendLine($"{Separator}{{");
 
-        var knownMethodIdentifiers = new HashSet<string>();
+        var knownMethodIdentifiers = new Dictionary<string, HashSet<string>>();
 
         foreach (var op in operations)
         {
@@ -166,7 +169,7 @@ internal class InterfaceGenerator
         code.AppendLine(interfaceDeclaration);
         code.AppendLine($"{Separator}{{");
 
-        var knownMethodIdentifiers = new HashSet<string>();
+        var knownMethodIdentifiers = new Dictionary<string, HashSet<string>>();
 
         foreach (var op in operations)
         {
@@ -191,7 +194,7 @@ internal class InterfaceGenerator
         OpenApiOperationInfo op,
         string interfaceName,
         IInterfacePartitioning partitioning,
-        HashSet<string> knownMethodIdentifiers,
+        Dictionary<string, HashSet<string>> knownMethodIdentifiers,
         StringBuilder code)
     {
         var operation = op.Operation;
@@ -205,8 +208,8 @@ internal class InterfaceGenerator
         var verb = op.Verb.CapitalizeFirstCharacter();
         var baseOperationName = GetBaseOperationName(op);
         var rawMethodName = partitioning.GetMethodName(op, interfaceName, baseOperationName);
-        var methodName = IdentifierUtils.Counted(knownMethodIdentifiers, rawMethodName);
-        knownMethodIdentifiers.Add(methodName);
+        var signature = GetParameterSignature(operation);
+        var methodName = IdentifierUtils.Counted(knownMethodIdentifiers, rawMethodName, signature);
 
         var dynamicQuerystringParameterType =
             partitioning.GetDynamicQuerystringParameterType(interfaceName, methodName);
@@ -269,6 +272,34 @@ internal class InterfaceGenerator
         }
 
         return (operationDynamicQuerystringParameters ?? string.Empty, dynamicQuerystringParameterType);
+    }
+
+    private static string GetParameterSignature(OpenApiOperation operation)
+    {
+        var parts = new List<string>();
+
+        if (operation.Parameters is { Count: > 0 })
+        {
+            foreach (var p in operation.Parameters)
+            {
+                var typeStr = p.Schema?.Type is JsonObjectType t
+                    ? t.ToString()
+                    : "any";
+                parts.Add($"{p.Name}:{typeStr}");
+            }
+        }
+
+        if (operation.RequestBody is { Content.Count: > 0 })
+        {
+            var contentType = operation.RequestBody.Content.Keys.First();
+            var bodySchemaType = operation.RequestBody.Content.Values.First().Schema?.Type;
+            var bodyTypeStr = bodySchemaType is JsonObjectType bt
+                ? bt.ToString()
+                : "object";
+            parts.Add($"body:{contentType}:{bodyTypeStr}");
+        }
+
+        return string.Join("|", parts);
     }
 
     private string GetBaseOperationName(OpenApiOperationInfo op)

--- a/src/Refitter.Core/Utilities/IdentifierUtils.cs
+++ b/src/Refitter.Core/Utilities/IdentifierUtils.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 
@@ -89,6 +90,46 @@ internal static class IdentifierUtils
         "__reftype",
         "__refvalue"
     };
+
+    /// <summary>
+    /// Returns <paramref name="name"/> if the (<paramref name="name"/>, <paramref name="signature"/>) pair
+    /// is not yet tracked; otherwise appends a counter until a unique pair is found.
+    /// </summary>
+    public static string Counted(
+        IDictionary<string, HashSet<string>> knownIdentifiers,
+        string name,
+        string signature)
+    {
+        if (knownIdentifiers.TryGetValue(name, out var signatures))
+        {
+            if (!signatures.Contains(signature))
+            {
+                signatures.Add(signature);
+                return name;
+            }
+
+            var counter = 2;
+            while (knownIdentifiers.TryGetValue(
+                       $"{name}{counter}",
+                       out var nextSignatures)
+                   && nextSignatures.Contains(signature))
+            {
+                counter++;
+            }
+
+            var uniqueName = $"{name}{counter}";
+            if (!knownIdentifiers.ContainsKey(uniqueName))
+            {
+                knownIdentifiers[uniqueName] = new HashSet<string>();
+            }
+
+            knownIdentifiers[uniqueName].Add(signature);
+            return uniqueName;
+        }
+
+        knownIdentifiers[name] = new HashSet<string> { signature };
+        return name;
+    }
 
     /// <summary>
     /// Returns <c>{value}{counter}{suffix}</c> if <c>{value}{name}</c> exists in <paramref name="knownIdentifiers"/>

--- a/src/Refitter.Tests/IdentifierUtilsTests.cs
+++ b/src/Refitter.Tests/IdentifierUtilsTests.cs
@@ -72,6 +72,61 @@ public class IdentifierUtilsTests
     }
 
     [Test]
+    public void Counted_With_Signature_Returns_Name_When_Not_In_Set()
+    {
+        var knownIdentifiers = new Dictionary<string, HashSet<string>>();
+        var result = IdentifierUtils.Counted(knownIdentifiers, "GetItems", "");
+        result.Should().Be("GetItems");
+    }
+
+    [Test]
+    public void Counted_With_Signature_Allows_Overload_When_Signature_Differs()
+    {
+        var knownIdentifiers = new Dictionary<string, HashSet<string>>
+        {
+            { "GetItems", new HashSet<string> { "" } }
+        };
+        var result = IdentifierUtils.Counted(knownIdentifiers, "GetItems", "id:integer");
+        result.Should().Be("GetItems");
+    }
+
+    [Test]
+    public void Counted_With_Signature_Appends_Counter_When_Signature_Collides()
+    {
+        var knownIdentifiers = new Dictionary<string, HashSet<string>>
+        {
+            { "GetItems", new HashSet<string> { "" } }
+        };
+        var result = IdentifierUtils.Counted(knownIdentifiers, "GetItems", "");
+        result.Should().Be("GetItems2");
+    }
+
+    [Test]
+    public void Counted_With_Signature_Increments_Counter_On_Multiple_Collisions()
+    {
+        var knownIdentifiers = new Dictionary<string, HashSet<string>>
+        {
+            { "GetItems", new HashSet<string> { "" } },
+            { "GetItems2", new HashSet<string> { "" } }
+        };
+        var result = IdentifierUtils.Counted(knownIdentifiers, "GetItems", "");
+        result.Should().Be("GetItems3");
+    }
+
+    [Test]
+    public void Counted_With_Signature_Counts_Per_Signature()
+    {
+        var knownIdentifiers = new Dictionary<string, HashSet<string>>
+        {
+            { "GetItems", new HashSet<string> { "" } }
+        };
+        var overload = IdentifierUtils.Counted(knownIdentifiers, "GetItems", "id:integer");
+        var duplicate = IdentifierUtils.Counted(knownIdentifiers, "GetItems", "");
+        overload.Should().Be("GetItems");
+        duplicate.Should().Be("GetItems2");
+    }
+
+    [Test]
     public void ToCompilableIdentifier_Prefixes_Digit_Prefixed_PascalCase_Names()
     {
         var result = IdentifierUtils.ToCompilableIdentifier("42QuestionField");

--- a/src/Refitter.Tests/Scenarios/MethodOverloadTests.cs
+++ b/src/Refitter.Tests/Scenarios/MethodOverloadTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Refitter.Tests.TestUtilities;
+using TUnit.Core;
+
+namespace Refitter.Tests.Scenarios;
+
+/// <summary>
+/// Test for Issue #1199: method overloading with same name but different parameters
+/// should generate overloads, not counter-suffixed names like CustomformatGet2.
+/// </summary>
+public class MethodOverloadTests
+{
+    private const string OpenApiSpec = @"
+{
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""title"": ""Overload Test API"",
+    ""version"": ""1.0.0""
+  },
+  ""paths"": {
+    ""/customformat"": {
+      ""get"": {
+        ""tags"": [""CustomFormat""],
+        ""responses"": { ""200"": { ""description"": ""Success"" } }
+      }
+    },
+    ""/customformat/{id}"": {
+      ""get"": {
+        ""tags"": [""CustomFormat""],
+        ""parameters"": [
+          { ""in"": ""path"", ""name"": ""id"", ""required"": true, ""schema"": { ""type"": ""integer"" } }
+        ],
+        ""responses"": { ""200"": { ""description"": ""Success"" } }
+      }
+    }
+  }
+}
+";
+
+    [Test]
+    public async Task Can_Generate_Code()
+    {
+        var generatedCode = await GenerateCode();
+        generatedCode.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Same_Name_Different_Params_Should_Use_Overloads_Not_Counter()
+    {
+        var generatedCode = await GenerateCode();
+
+        // The second method should use the same name (overload), not have a counter suffix
+        generatedCode.Should().NotContain("CustomformatGet2(");
+    }
+
+    [Test]
+    public async Task Overloads_Should_Have_Different_Parameter_Lists()
+    {
+        var generatedCode = await GenerateCode();
+
+        // First overload: no parameters (path /customformat)
+        generatedCode.Should().Contain("CustomformatGet()");
+
+        // Second overload: has id parameter (path /customformat/{id})
+        generatedCode.Should().Contain("CustomformatGet(int id");
+    }
+
+    [Test]
+    public async Task Can_Build_Generated_Code()
+    {
+        var generatedCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerJsonFile(OpenApiSpec);
+        try
+        {
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = swaggerFile,
+                MultipleInterfaces = MultipleInterfaces.ByTag,
+                OperationNameGenerator = OperationNameGeneratorTypes.MultipleClientsFromPathSegments
+            };
+            var generator = await RefitGenerator.CreateAsync(settings);
+            return generator.Generate();
+        }
+        finally
+        {
+            if (File.Exists(swaggerFile))
+                File.Delete(swaggerFile);
+            var directory = Path.GetDirectoryName(swaggerFile);
+            if (directory != null && Directory.Exists(directory))
+                Directory.Delete(directory, true);
+        }
+    }
+}

--- a/src/Refitter.Tests/Scenarios/MethodOverloadTests.cs
+++ b/src/Refitter.Tests/Scenarios/MethodOverloadTests.cs
@@ -101,6 +101,7 @@ public class MethodOverloadTests
     }
 
     [Test]
+    [Category("Integration")]
     [Arguments(OpenApiSpec)]
     [Arguments(Swagger2Spec)]
     public async Task Can_Build_Generated_Code(string spec)

--- a/src/Refitter.Tests/Scenarios/MethodOverloadTests.cs
+++ b/src/Refitter.Tests/Scenarios/MethodOverloadTests.cs
@@ -39,26 +39,59 @@ public class MethodOverloadTests
 }
 ";
 
+    private const string Swagger2Spec = @"
+{
+  ""swagger"": ""2.0"",
+  ""info"": {
+    ""title"": ""Overload Test API"",
+    ""version"": ""1.0.0""
+  },
+  ""paths"": {
+    ""/customformat"": {
+      ""get"": {
+        ""tags"": [""CustomFormat""],
+        ""responses"": { ""200"": { ""description"": ""Success"" } }
+      }
+    },
+    ""/customformat/{id}"": {
+      ""get"": {
+        ""tags"": [""CustomFormat""],
+        ""parameters"": [
+          { ""in"": ""path"", ""name"": ""id"", ""required"": true, ""type"": ""integer"" }
+        ],
+        ""responses"": { ""200"": { ""description"": ""Success"" } }
+      }
+    }
+  }
+}
+";
+
     [Test]
-    public async Task Can_Generate_Code()
+    [Arguments(OpenApiSpec)]
+    [Arguments(Swagger2Spec)]
+    public async Task Can_Generate_Code(string spec)
     {
-        var generatedCode = await GenerateCode();
+        var generatedCode = await GenerateCode(spec);
         generatedCode.Should().NotBeNullOrWhiteSpace();
     }
 
     [Test]
-    public async Task Same_Name_Different_Params_Should_Use_Overloads_Not_Counter()
+    [Arguments(OpenApiSpec)]
+    [Arguments(Swagger2Spec)]
+    public async Task Same_Name_Different_Params_Should_Use_Overloads_Not_Counter(string spec)
     {
-        var generatedCode = await GenerateCode();
+        var generatedCode = await GenerateCode(spec);
 
         // The second method should use the same name (overload), not have a counter suffix
         generatedCode.Should().NotContain("CustomformatGet2(");
     }
 
     [Test]
-    public async Task Overloads_Should_Have_Different_Parameter_Lists()
+    [Arguments(OpenApiSpec)]
+    [Arguments(Swagger2Spec)]
+    public async Task Overloads_Should_Have_Different_Parameter_Lists(string spec)
     {
-        var generatedCode = await GenerateCode();
+        var generatedCode = await GenerateCode(spec);
 
         // First overload: no parameters (path /customformat)
         generatedCode.Should().Contain("CustomformatGet()");
@@ -68,18 +101,20 @@ public class MethodOverloadTests
     }
 
     [Test]
-    public async Task Can_Build_Generated_Code()
+    [Arguments(OpenApiSpec)]
+    [Arguments(Swagger2Spec)]
+    public async Task Can_Build_Generated_Code(string spec)
     {
-        var generatedCode = await GenerateCode();
+        var generatedCode = await GenerateCode(spec);
         BuildHelper
             .BuildCSharp(generatedCode)
             .Should()
             .BeTrue();
     }
 
-    private static async Task<string> GenerateCode()
+    private static async Task<string> GenerateCode(string spec)
     {
-        var swaggerFile = await SwaggerFileHelper.CreateSwaggerJsonFile(OpenApiSpec);
+        var swaggerFile = await SwaggerFileHelper.CreateSwaggerJsonFile(spec);
         try
         {
             var settings = new RefitGeneratorSettings


### PR DESCRIPTION
This pull request enhances the method overload handling in the code generation process, ensuring that methods with the same name but different parameter lists are correctly generated as overloads instead of being suffixed with counters. The changes also improve the uniqueness logic for method names and add comprehensive tests to verify the new behavior.

Implements the suggestion from https://github.com/christianhelle/refitter/issues/1199#issuecomment-5078858914 

### Method Overload Handling Improvements

* Updated the logic in `InterfaceGenerator.cs` to track known method identifiers using both the method name and its parameter signature, allowing true method overloads when parameter lists differ. (`src/Refitter.Core/Generation/InterfaceGenerator.cs` [[1]](diffhunk://#diff-cef65dfa33e671e1d82c8b0deced5054e37394451aab319b6832fa00d231d96cR1-R4) [[2]](diffhunk://#diff-cef65dfa33e671e1d82c8b0deced5054e37394451aab319b6832fa00d231d96cL128-R131) [[3]](diffhunk://#diff-cef65dfa33e671e1d82c8b0deced5054e37394451aab319b6832fa00d231d96cL169-R172) [[4]](diffhunk://#diff-cef65dfa33e671e1d82c8b0deced5054e37394451aab319b6832fa00d231d96cL194-R197) [[5]](diffhunk://#diff-cef65dfa33e671e1d82c8b0deced5054e37394451aab319b6832fa00d231d96cL208-R212) [[6]](diffhunk://#diff-cef65dfa33e671e1d82c8b0deced5054e37394451aab319b6832fa00d231d96cR277-R304)
* Added the `GetParameterSignature` helper to create a unique signature string for each method based on its parameters and request body. (`src/Refitter.Core/Generation/InterfaceGenerator.cs` [src/Refitter.Core/Generation/InterfaceGenerator.csR277-R304](diffhunk://#diff-cef65dfa33e671e1d82c8b0deced5054e37394451aab319b6832fa00d231d96cR277-R304))

### Utility Enhancements

* Refactored the `IdentifierUtils.Counted` method to support tracking overloads by accepting a dictionary of method names to sets of signatures, ensuring uniqueness based on both name and signature. (`src/Refitter.Core/Utilities/IdentifierUtils.cs` [[1]](diffhunk://#diff-01fa54f1ceae3b204c0cf7ccc5bb04725aeea671d8e58e41a23d8197dbba1e5fR1) [[2]](diffhunk://#diff-01fa54f1ceae3b204c0cf7ccc5bb04725aeea671d8e58e41a23d8197dbba1e5fR94-R133)

### Testing Improvements

* Added and expanded unit tests for the new overload-tracking logic in `IdentifierUtilsTests`, covering various overload and collision scenarios. (`src/Refitter.Tests/IdentifierUtilsTests.cs` [src/Refitter.Tests/IdentifierUtilsTests.csR74-R128](diffhunk://#diff-10f1487d188eccaed0af635e6cc05e07b22a6cedfa0b7f9733f7d32cdf7f83c3R74-R128))
* Introduced a new scenario test, `MethodOverloadTests`, to verify that the generated code creates proper overloads (same method name, different parameters) and does not append counter suffixes when overloads are possible. (`src/Refitter.Tests/Scenarios/MethodOverloadTests.cs` [src/Refitter.Tests/Scenarios/MethodOverloadTests.csR1-R103](diffhunk://#diff-fdccce0cca9cda59b5d7250413d5b8dda0650a030976422c1aa9669a68c168bfR1-R103))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated API methods with the same name now correctly use C# overloads when their parameter lists differ.
  * Method renaming now applies numeric suffixes only when both the signature and request body content match, avoiding unnecessary renames.
* **Tests**
  * Added scenario coverage to verify overload generation for OpenAPI 3.0 and Swagger 2.0 specs, including compilation of generated code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->