### PR TITLE
Update Refit packages to v14.0.1

### DIFF
--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -16,9 +16,9 @@ public static class ProjectFileContents
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
     <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -45,9 +45,9 @@ public static class ProjectFileContents
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
     <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />

--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -15,7 +15,7 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
@@ -44,7 +44,7 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />

--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -11,7 +11,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -40,7 +40,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />

--- a/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
+++ b/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
@@ -22,7 +22,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="14.0.1" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>

--- a/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
+++ b/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
@@ -23,7 +23,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Refit.HttpClientFactory" Version="14.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>
 

--- a/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
+++ b/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="14.7.1" PrivateAssets="all" />
     <PackageReference Include="NSwag.Core.Yaml" Version="14.7.1" PrivateAssets="all" />
     <PackageReference Include="OasReader" Version="3.7.0.20" PrivateAssets="all" />
-    <PackageReference Include="Refit" Version="13.1.0" PrivateAssets="all" />
+    <PackageReference Include="Refit" Version="14.0.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -11,7 +11,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -41,7 +41,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -70,7 +70,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -100,7 +100,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""8.0.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -129,7 +129,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -159,7 +159,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""13.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -15,10 +15,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -74,10 +74,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -104,10 +104,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -133,10 +133,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -163,10 +163,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.9"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.9"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -42,13 +42,13 @@ public static class ProjectFileContents
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
-    <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
-    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
+    <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
+    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""8.0.1"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""8.0.11"" />
-    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""8.10.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""8.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />

--- a/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
@@ -65,7 +65,7 @@ public class GenerateJsonSerializerContextPolymorphismTests
             <RestorePackagesPath>packages</RestorePackagesPath>
           </PropertyGroup>
           <ItemGroup>
-            <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
+            <PackageReference Include="Refit.HttpClientFactory" Version="14.0.1" />
           </ItemGroup>
         </Project>
         """;

--- a/test/ConsoleApp/Directory.Build.props
+++ b/test/ConsoleApp/Directory.Build.props
@@ -31,8 +31,8 @@
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
-        <PackageReference Include="Refit" Version="13.1.0" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
+        <PackageReference Include="Refit" Version="14.0.1" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="14.0.1" />
         <PackageReference Include="Polly" Version="8.7.0" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/test/ConsoleApp/Directory.Build.props
+++ b/test/ConsoleApp/Directory.Build.props
@@ -28,9 +28,9 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
         <PackageReference Include="Refit" Version="14.0.1" />
         <PackageReference Include="Refit.HttpClientFactory" Version="14.0.1" />
         <PackageReference Include="Polly" Version="8.7.0" />

--- a/test/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/test/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Refit" Version="13.1.0" />
+    <PackageReference Include="Refit" Version="14.0.1" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 

--- a/test/MSBuild/Refitter.MSBuild.Tests.csproj
+++ b/test/MSBuild/Refitter.MSBuild.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="14.0.1" />
     </ItemGroup>
 
 </Project>

--- a/test/MinimalApi/MinimalApi.csproj
+++ b/test/MinimalApi/MinimalApi.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="14.0.1" />
     <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/test/MinimalApi/MinimalApi.csproj
+++ b/test/MinimalApi/MinimalApi.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/test/MultipleFiles/Client/Client.csproj
+++ b/test/MultipleFiles/Client/Client.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
-    <PackageReference Include="Refit" Version="13.1.0" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="13.1.0" />
+    <PackageReference Include="Refit" Version="14.0.1" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="14.0.1" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/test/SourceGenerator/Directory.Build.props
+++ b/test/SourceGenerator/Directory.Build.props
@@ -16,6 +16,6 @@
         <PackageReference Include="Refit" Version="14.0.1" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-        <PackageReference Include="System.Text.Json" Version="10.0.9" />
+        <PackageReference Include="System.Text.Json" Version="10.0.10" />
     </ItemGroup>
 </Project>

--- a/test/SourceGenerator/Directory.Build.props
+++ b/test/SourceGenerator/Directory.Build.props
@@ -13,7 +13,7 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\Refitter.SourceGenerator\Refitter.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-        <PackageReference Include="Refit" Version="13.1.0" />
+        <PackageReference Include="Refit" Version="14.0.1" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
         <PackageReference Include="System.Text.Json" Version="10.0.9" />


### PR DESCRIPTION
Bump all Refit/Refit.HttpClientFactory package references from 13.1.0 to 14.0.1 across all test projects and the source generator.

## Changes

- Update Refit/Refit.HttpClientFactory from 13.1.0 to 14.0.1 in 11 files
- Bump transitive dependencies (Microsoft.Extensions.DependencyInjection, Options.ConfigurationExtensions, Http.Polly) from 10.0.9 to 10.0.10 to match Refit 14.0.1's dependency requirements

## Verification

- All 2257 unit tests pass (0 failures)
- Source generator tests pass on both net8.0 and net10.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Refit and Refit.HttpClientFactory to 14.0.1 across application, sample, and test projects.
  * Bumped related Microsoft.Extensions packages to 10.0.10 where applicable, including resiliency-related updates for newer targets.

* **Tests**
  * Updated embedded test project/package references to match the new dependency versions, keeping existing test scenarios consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->