### PR TITLE
Publish NuGet packages to GitHub Packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,13 @@ jobs:
         dotnet msbuild src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
     - name: 🛠️ Build
       run: dotnet build -c Release src/Refitter.slnx -p:UseSourceLink=true -p:PackageVersion="${{ env.VERSION }}" -p:Version="${{ env.VERSION }}"
+    - name: 📦 Pack MSBuild task
+      run: |
+        dotnet pack --no-build -c Release src/Refitter.MSBuild/Refitter.MSBuild.csproj `
+          -p:UseSourceLink=true `
+          -p:PackageVersion="${{ env.VERSION }}" `
+          -p:Version="${{ env.VERSION }}"
+      shell: pwsh
     - name: 🧪 Unit tests (fast gate)
       run: dotnet test --solution src/Refitter.slnx -c Release --no-build --treenode-filter "/*/*/*/*[Category!=Integration]"
     - name: 🧪 Full test suite

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,8 +73,10 @@ jobs:
     - name: 🚀 Publish to GitHub Packages
       if: github.event_name == 'push'
       shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         dotnet nuget push **/*.nupkg `
           --source https://nuget.pkg.github.com/christianhelle/index.json `
-          --api-key ${{ secrets.GITHUB_TOKEN }} `
+          --api-key $env:GITHUB_TOKEN `
           --skip-duplicate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,3 +70,11 @@ jobs:
       run: |
         dotnet tool update -g docfx
         docfx docs/docfx_project/docfx.json
+    - name: 🚀 Publish to GitHub Packages
+      if: github.event_name == 'push'
+      shell: pwsh
+      run: |
+        dotnet nuget push **/*.nupkg `
+          --source https://nuget.pkg.github.com/christianhelle/index.json `
+          --api-key ${{ secrets.GITHUB_TOKEN }} `
+          --skip-duplicate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,10 @@ on:
 env:
   VERSION: 2.1.2.${{ github.run_number }}
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     name: 👌 Verify build


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/build.yml` to support publishing NuGet packages to GitHub Packages and to improve permissions management. The main changes include adding package publishing steps, updating permissions, and introducing a dedicated pack step for the MSBuild task.

**Workflow permissions and publishing:**

* Added explicit `permissions` for `contents: read` and `packages: write` to the workflow to enable secure publishing of packages.
* Added a new step to pack the `Refitter.MSBuild` MSBuild task using `dotnet pack`, ensuring the package is built and ready for publishing.
* Introduced a conditional step to publish all `.nupkg` files to GitHub Packages when the workflow is triggered by a push event, using the GitHub token and skipping duplicates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated packaging of the MSBuild component during builds.
  * Added publishing of generated NuGet packages to GitHub Packages on push events.
  * Improved build workflow permissions to support secure package publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->