### PR TITLE
Tag MSBuild-driven generations in telemetry

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -113,7 +113,7 @@ images/                 # Project images and assets
 
 All new code must include unit tests following the pattern used in `Refitter.Tests.Scenarios` namespace.
 
-The project uses **TUnit v1.47.0** as its testing framework (not xUnit). TUnit provides significantly faster test execution (3x faster than xUnit), which improves both local development and CI/CD pipeline performance.
+The project uses **TUnit v1.61.38** as its testing framework (not xUnit). TUnit provides significantly faster test execution (3x faster than xUnit), which improves both local development and CI/CD pipeline performance.
 
 Use TUnit's `[Test]` attribute for test methods:
 

--- a/src/Refitter.Core/CodeGeneration/JsonSerializerContextGenerator.cs
+++ b/src/Refitter.Core/CodeGeneration/JsonSerializerContextGenerator.cs
@@ -281,9 +281,9 @@ internal static class JsonSerializerContextGenerator
             _ => typeSyntax.ToString(),
         };
 
-    #pragma warning disable S1186 // Positional record constructor is compiler-generated
+#pragma warning disable S1186 // Positional record constructor is compiler-generated
     private sealed record DeclaredTypeInfo(
-    #pragma warning restore S1186
+#pragma warning restore S1186
         string Namespace,
         IReadOnlyList<string> Containers,
         string Name,

--- a/src/Refitter.MSBuild/README.md
+++ b/src/Refitter.MSBuild/README.md
@@ -38,6 +38,8 @@ The MSBuild package includes a custom `.target` file which executes the `Refitte
 
 The `RefitterGenerateTask` task scans the project folder for `.refitter` files and executes them all. `RefitterAutoScan` defaults to `true`, so normal builds keep generating code automatically. Set `<RefitterAutoScan>false</RefitterAutoScan>` to skip that automatic build hook while keeping `dotnet build -t:RefitterGenerate` available for explicit generation.
 
+Refitter CLI invocations spawned by the task are tagged in telemetry as coming from MSBuild. Set `<RefitterNoLogging>true</RefitterNoLogging>` to disable telemetry for MSBuild-driven generations.
+
 ## Configuration
 
 By default, telemetry collection is enabled. To opt-out, add the following to your `.csproj` file:

--- a/src/Refitter.MSBuild/RefitterGenerateTask.cs
+++ b/src/Refitter.MSBuild/RefitterGenerateTask.cs
@@ -111,7 +111,7 @@ public class RefitterGenerateTask : MSBuildTask
         foreach (var file in files)
         {
             TryLogCommandLine($"Processing {file}");
-            var generated = TryExecuteRefitter(file, out var failed);
+            var generated = TryExecuteRefitter(file, files.Length, out var failed);
             if (failed)
             {
                 hasErrors = true;
@@ -129,12 +129,12 @@ public class RefitterGenerateTask : MSBuildTask
         return !hasErrors;
     }
 
-    private List<string>? TryExecuteRefitter(string file, out bool failed)
+    private List<string>? TryExecuteRefitter(string file, int totalFileCount, out bool failed)
     {
         failed = false;
         try
         {
-            return StartProcess(file, out failed);
+            return StartProcess(file, totalFileCount, out failed);
         }
         catch (Exception e)
         {
@@ -144,7 +144,7 @@ public class RefitterGenerateTask : MSBuildTask
         }
     }
 
-    private List<string> StartProcess(string file, out bool failed)
+    private List<string> StartProcess(string file, int totalFileCount, out bool failed)
     {
         failed = false;
         var assembly = Assembly.GetExecutingAssembly();
@@ -171,6 +171,12 @@ public class RefitterGenerateTask : MSBuildTask
         }
 
         var args = $"\"{refitterDll}\" --settings-file \"{file}\" --simple-output";
+        args += $" --telemetry-source msbuild --telemetry-file-count {totalFileCount}";
+        var runtimeTfm = GetRuntimeTfm(refitterDll!);
+        if (runtimeTfm is not null)
+        {
+            args += $" --telemetry-runtime {runtimeTfm}";
+        }
         if (DisableLogging)
         {
             args += " --no-logging";
@@ -218,6 +224,21 @@ public class RefitterGenerateTask : MSBuildTask
         }
 
         return ResolveGeneratedFiles(outputLines, file, out failed, TryLogError);
+    }
+
+    private static string? GetRuntimeTfm(string refitterDll)
+    {
+        var folderName = Path.GetFileName(Path.GetDirectoryName(refitterDll));
+        if (string.IsNullOrEmpty(folderName) ||
+            !folderName.StartsWith("net", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var version = folderName.Substring(3);
+        return version.Length > 0 && version.All(c => char.IsDigit(c) || c == '.')
+            ? folderName
+            : null;
     }
 
     private static ProcessExecutionResult RunProcess(

--- a/src/Refitter.MSBuild/RefitterGenerateTask.cs
+++ b/src/Refitter.MSBuild/RefitterGenerateTask.cs
@@ -172,7 +172,7 @@ public class RefitterGenerateTask : MSBuildTask
 
         var args = $"\"{refitterDll}\" --settings-file \"{file}\" --simple-output";
         args += $" --telemetry-source msbuild --telemetry-file-count {totalFileCount}";
-        var runtimeTfm = GetRuntimeTfm(refitterDll!);
+        string? runtimeTfm = GetRuntimeTfm(refitterDll!);
         if (runtimeTfm is not null)
         {
             args += $" --telemetry-runtime {runtimeTfm}";
@@ -236,7 +236,8 @@ public class RefitterGenerateTask : MSBuildTask
         }
 
         var version = folderName.Substring(3);
-        return version.Length > 0 && version.All(c => char.IsDigit(c) || c == '.')
+        var components = version.Split('.');
+        return components.All(component => component.Length > 0 && component.All(char.IsDigit))
             ? folderName
             : null;
     }

--- a/src/Refitter.Tests/MSBuild/RefitterGenerateTaskTests.cs
+++ b/src/Refitter.Tests/MSBuild/RefitterGenerateTaskTests.cs
@@ -620,6 +620,44 @@ public class RefitterGenerateTaskTests
     }
 
     [Test]
+    public void Execute_Should_Pass_Telemetry_Source_Args_To_Refitter()
+    {
+        var workspace = CreateWorkspace();
+
+        try
+        {
+            CreateRefitterSettingsFile(workspace);
+            var generatedFile = CreateGeneratedFile(workspace);
+
+            RefitterGenerateTask.InstalledDotnetRuntimesProvider = () => ["Microsoft.NETCore.App 9.0.0"];
+            RefitterGenerateTask.FileExists = path =>
+                path.Contains("net9.0", StringComparison.OrdinalIgnoreCase) ||
+                File.Exists(path);
+            RefitterGenerateTask.ProcessRunner = (startInfo, logOutput, _) =>
+            {
+                startInfo.Arguments.Should().Contain("--telemetry-source msbuild");
+                startInfo.Arguments.Should().Contain("--telemetry-file-count 1");
+                startInfo.Arguments.Should().Contain("--telemetry-runtime net9.0");
+                logOutput($"{RefitterGenerateTask.GeneratedFileMarker}{generatedFile}");
+                return new RefitterGenerateTask.ProcessExecutionResult(false, 0);
+            };
+
+            var buildEngine = new RecordingBuildEngine();
+            var task = CreateTask(workspace, buildEngine);
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.GeneratedFiles.Should().ContainSingle();
+        }
+        finally
+        {
+            RefitterGenerateTask.ResetTestHooks();
+            DeleteWorkspace(workspace);
+        }
+    }
+
+    [Test]
     public void Execute_Should_Fall_Back_To_DotNet8_Runtime_When_Newer_Runtimes_Are_Unavailable()
     {
         var workspace = CreateWorkspace();

--- a/src/Refitter.Tests/MSBuild/RefitterGenerateTaskTests.cs
+++ b/src/Refitter.Tests/MSBuild/RefitterGenerateTaskTests.cs
@@ -622,33 +622,41 @@ public class RefitterGenerateTaskTests
     [Test]
     public void Execute_Should_Pass_Telemetry_Source_Args_To_Refitter()
     {
-        var workspace = CreateWorkspace();
+        string workspace = CreateWorkspace();
 
         try
         {
             CreateRefitterSettingsFile(workspace);
-            var generatedFile = CreateGeneratedFile(workspace);
+            string generatedFile = CreateGeneratedFile(workspace);
+            CreateRefitterSettingsFile(workspace, "petstore2.refitter");
+            string secondGeneratedFile = CreateGeneratedFile(workspace, "Petstore2.cs");
 
             RefitterGenerateTask.InstalledDotnetRuntimesProvider = () => ["Microsoft.NETCore.App 9.0.0"];
             RefitterGenerateTask.FileExists = path =>
                 path.Contains("net9.0", StringComparison.OrdinalIgnoreCase) ||
                 File.Exists(path);
+
+            int invocation = 0;
             RefitterGenerateTask.ProcessRunner = (startInfo, logOutput, _) =>
             {
+                invocation++;
                 startInfo.Arguments.Should().Contain("--telemetry-source msbuild");
-                startInfo.Arguments.Should().Contain("--telemetry-file-count 1");
+                startInfo.Arguments.Should().Contain("--telemetry-file-count 2");
                 startInfo.Arguments.Should().Contain("--telemetry-runtime net9.0");
-                logOutput($"{RefitterGenerateTask.GeneratedFileMarker}{generatedFile}");
+                string marker = invocation == 1 ? generatedFile : secondGeneratedFile;
+                logOutput($"{RefitterGenerateTask.GeneratedFileMarker}{marker}");
                 return new RefitterGenerateTask.ProcessExecutionResult(false, 0);
             };
 
-            var buildEngine = new RecordingBuildEngine();
-            var task = CreateTask(workspace, buildEngine);
+            RecordingBuildEngine buildEngine = new();
+            RefitterGenerateTask task = CreateTask(workspace, buildEngine);
+            task.IncludePatterns = "petstore.refitter;petstore2.refitter";
 
-            var result = task.Execute();
+            bool result = task.Execute();
 
             result.Should().BeTrue();
-            task.GeneratedFiles.Should().ContainSingle();
+            invocation.Should().Be(2);
+            task.GeneratedFiles.Should().HaveCount(2);
         }
         finally
         {
@@ -970,16 +978,16 @@ public class RefitterGenerateTaskTests
         return workspace;
     }
 
-    private static string CreateRefitterSettingsFile(string workspace)
+    private static string CreateRefitterSettingsFile(string workspace, string fileName = "petstore.refitter")
     {
-        var settingsPath = Path.Combine(workspace, "petstore.refitter");
+        string settingsPath = Path.Combine(workspace, fileName);
         File.WriteAllText(settingsPath, "{}");
         return settingsPath;
     }
 
-    private static string CreateGeneratedFile(string workspace)
+    private static string CreateGeneratedFile(string workspace, string fileName = "Petstore.cs")
     {
-        var generatedFile = Path.Combine(workspace, "Generated", "Petstore.cs");
+        string generatedFile = Path.Combine(workspace, "Generated", fileName);
         Directory.CreateDirectory(Path.GetDirectoryName(generatedFile)!);
         File.WriteAllText(generatedFile, "// generated");
         return generatedFile;

--- a/src/Refitter.Tests/Telemetry/AnalyticsTests.cs
+++ b/src/Refitter.Tests/Telemetry/AnalyticsTests.cs
@@ -82,49 +82,91 @@ public class AnalyticsTests
     [NotInParallel("Telemetry")]
     public void LogFeatureUsage_Should_Track_Msbuild_Invocation_With_Telemetry_Settings()
     {
+        var previousClient = Analytics.GetTelemetryClient();
+        var previousTelemetrySource = GetTelemetrySource();
         var captured = new List<ITelemetry>();
         var client = CreateTelemetryClient(captured);
         Analytics.SetTelemetryClient(client);
 
-        var settings = new Settings
+        try
         {
-            TelemetrySource = "msbuild",
-            TelemetryFileCount = 3,
-            TelemetryRuntime = "net9.0"
-        };
-        var refitSettings = new RefitGeneratorSettings();
+            var settings = new Settings
+            {
+                TelemetrySource = "msbuild",
+                TelemetryFileCount = 3,
+                TelemetryRuntime = "net9.0"
+            };
+            var refitSettings = new RefitGeneratorSettings();
 
-        Analytics.LogFeatureUsage(settings, refitSettings);
+            Analytics.LogFeatureUsage(settings, refitSettings);
 
-        var msbuildEvent = captured
-            .OfType<EventTelemetry>()
-            .Single(e => e.Name == "msbuild-invocation");
-        msbuildEvent.Properties["file-count"].Should().Be("3");
-        msbuildEvent.Properties["runtime"].Should().Be("net9.0");
-        client.Context.GlobalProperties["telemetry-source"].Should().Be("msbuild");
+            var msbuildEvent = captured
+                .OfType<EventTelemetry>()
+                .Single(e => e.Name == "msbuild-invocation");
+            msbuildEvent.Properties["file-count"].Should().Be("3");
+            msbuildEvent.Properties["runtime"].Should().Be("net9.0");
+            client.Context.GlobalProperties["telemetry-source"].Should().Be("msbuild");
+        }
+        finally
+        {
+            Analytics.SetTelemetryClient(previousClient);
+            RestoreTelemetrySource(previousTelemetrySource);
+        }
     }
 
     [Test]
     [NotInParallel("Telemetry")]
     public async Task LogError_Should_Apply_Msbuild_Telemetry_Source()
     {
-        ExceptionlessClient.Default.Configuration.Enabled = false;
+        var previousClient = Analytics.GetTelemetryClient();
+        var previousTelemetrySource = GetTelemetrySource();
+        bool previousExceptionlessEnabled = ExceptionlessClient.Default.Configuration.Enabled;
         var captured = new List<ITelemetry>();
         var client = CreateTelemetryClient(captured);
         Analytics.SetTelemetryClient(client);
 
-        var settings = new Settings
+        try
         {
-            TelemetrySource = "msbuild",
-            TelemetryFileCount = 3,
-            TelemetryRuntime = "net9.0"
-        };
-        var exception = new Exception("Test exception");
+            ExceptionlessClient.Default.Configuration.Enabled = false;
+            var settings = new Settings
+            {
+                TelemetrySource = "msbuild",
+                TelemetryFileCount = 3,
+                TelemetryRuntime = "net9.0"
+            };
+            var exception = new Exception("Test exception");
 
-        await Analytics.LogError(exception, settings);
+            await Analytics.LogError(exception, settings);
 
-        captured.OfType<ExceptionTelemetry>().Should().NotBeEmpty();
-        client.Context.GlobalProperties["telemetry-source"].Should().Be("msbuild");
+            captured.OfType<ExceptionTelemetry>().Should().NotBeEmpty();
+            client.Context.GlobalProperties["telemetry-source"].Should().Be("msbuild");
+        }
+        finally
+        {
+            ExceptionlessClient.Default.Configuration.Enabled = previousExceptionlessEnabled;
+            Analytics.SetTelemetryClient(previousClient);
+            RestoreTelemetrySource(previousTelemetrySource);
+        }
+    }
+
+    private static string? GetTelemetrySource()
+    {
+        ExceptionlessClient.Default.Configuration.DefaultData.TryGetValue(
+            "telemetry-source",
+            out object? source);
+        return source as string;
+    }
+
+    private static void RestoreTelemetrySource(string? previousSource)
+    {
+        if (previousSource is null)
+        {
+            ExceptionlessClient.Default.Configuration.DefaultData.Remove("telemetry-source");
+        }
+        else
+        {
+            ExceptionlessClient.Default.Configuration.DefaultData["telemetry-source"] = previousSource;
+        }
     }
 
     private static TelemetryClient CreateTelemetryClient(List<ITelemetry> captured)

--- a/src/Refitter.Tests/Telemetry/AnalyticsTests.cs
+++ b/src/Refitter.Tests/Telemetry/AnalyticsTests.cs
@@ -61,4 +61,49 @@ public class AnalyticsTests
 
         action.Should().NotThrow();
     }
+
+    [Test]
+    public void IsMsbuildInvocation_Should_Be_True_Only_For_Msbuild_Source()
+    {
+        Analytics.IsMsbuildInvocation("msbuild").Should().BeTrue();
+        Analytics.IsMsbuildInvocation("MSBUILD").Should().BeTrue();
+        Analytics.IsMsbuildInvocation("cli").Should().BeFalse();
+        Analytics.IsMsbuildInvocation("").Should().BeFalse();
+        Analytics.IsMsbuildInvocation(null).Should().BeFalse();
+    }
+
+    [Test]
+    public void LogFeatureUsage_Should_Not_Throw_With_Msbuild_Telemetry_Settings()
+    {
+        var settings = new Settings
+        {
+            NoLogging = true,
+            TelemetrySource = "msbuild",
+            TelemetryFileCount = 3,
+            TelemetryRuntime = "net9.0",
+            SettingsFilePath = "petstore.refitter"
+        };
+        var refitSettings = new RefitGeneratorSettings();
+
+        var action = () => Analytics.LogFeatureUsage(settings, refitSettings);
+
+        action.Should().NotThrow();
+    }
+
+    [Test]
+    public async Task LogError_Should_Not_Throw_With_Msbuild_Telemetry_Settings()
+    {
+        var settings = new Settings
+        {
+            NoLogging = true,
+            TelemetrySource = "msbuild",
+            TelemetryFileCount = 3,
+            TelemetryRuntime = "net9.0"
+        };
+        var exception = new Exception("Test exception");
+
+        var action = async () => await Analytics.LogError(exception, settings);
+
+        await action.Should().NotThrowAsync();
+    }
 }

--- a/src/Refitter.Tests/Telemetry/AnalyticsTests.cs
+++ b/src/Refitter.Tests/Telemetry/AnalyticsTests.cs
@@ -1,4 +1,9 @@
+using Exceptionless;
 using FluentAssertions;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
 using Refitter.Core;
 
 namespace Refitter.Tests.Telemetry;
@@ -7,6 +12,7 @@ namespace Refitter.Tests.Telemetry;
 public class AnalyticsTests
 {
     [Test]
+    [NotInParallel("Telemetry")]
     public void Configure_Should_Not_Throw()
     {
         var action = () => Analytics.Configure();
@@ -73,37 +79,83 @@ public class AnalyticsTests
     }
 
     [Test]
-    public void LogFeatureUsage_Should_Not_Throw_With_Msbuild_Telemetry_Settings()
+    [NotInParallel("Telemetry")]
+    public void LogFeatureUsage_Should_Track_Msbuild_Invocation_With_Telemetry_Settings()
     {
+        var captured = new List<ITelemetry>();
+        var client = CreateTelemetryClient(captured);
+        Analytics.SetTelemetryClient(client);
+
         var settings = new Settings
         {
-            NoLogging = true,
             TelemetrySource = "msbuild",
             TelemetryFileCount = 3,
-            TelemetryRuntime = "net9.0",
-            SettingsFilePath = "petstore.refitter"
+            TelemetryRuntime = "net9.0"
         };
         var refitSettings = new RefitGeneratorSettings();
 
-        var action = () => Analytics.LogFeatureUsage(settings, refitSettings);
+        Analytics.LogFeatureUsage(settings, refitSettings);
 
-        action.Should().NotThrow();
+        var msbuildEvent = captured
+            .OfType<EventTelemetry>()
+            .Single(e => e.Name == "msbuild-invocation");
+        msbuildEvent.Properties["file-count"].Should().Be("3");
+        msbuildEvent.Properties["runtime"].Should().Be("net9.0");
+        client.Context.GlobalProperties["telemetry-source"].Should().Be("msbuild");
     }
 
     [Test]
-    public async Task LogError_Should_Not_Throw_With_Msbuild_Telemetry_Settings()
+    [NotInParallel("Telemetry")]
+    public async Task LogError_Should_Apply_Msbuild_Telemetry_Source()
     {
+        ExceptionlessClient.Default.Configuration.Enabled = false;
+        var captured = new List<ITelemetry>();
+        var client = CreateTelemetryClient(captured);
+        Analytics.SetTelemetryClient(client);
+
         var settings = new Settings
         {
-            NoLogging = true,
             TelemetrySource = "msbuild",
             TelemetryFileCount = 3,
             TelemetryRuntime = "net9.0"
         };
         var exception = new Exception("Test exception");
 
-        var action = async () => await Analytics.LogError(exception, settings);
+        await Analytics.LogError(exception, settings);
 
-        await action.Should().NotThrowAsync();
+        captured.OfType<ExceptionTelemetry>().Should().NotBeEmpty();
+        client.Context.GlobalProperties["telemetry-source"].Should().Be("msbuild");
+    }
+
+    private static TelemetryClient CreateTelemetryClient(List<ITelemetry> captured)
+    {
+        var configuration = new TelemetryConfiguration
+        {
+            ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+            TelemetryChannel = new CapturingTelemetryChannel(captured)
+        };
+        return new TelemetryClient(configuration);
+    }
+
+    private sealed class CapturingTelemetryChannel : ITelemetryChannel
+    {
+        private readonly List<ITelemetry> captured;
+
+        public CapturingTelemetryChannel(List<ITelemetry> captured) =>
+            this.captured = captured;
+
+        public bool? DeveloperMode { get; set; }
+
+        public string EndpointAddress { get; set; } = string.Empty;
+
+        public void Send(ITelemetry item) => captured.Add(item);
+
+        public void Flush()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/src/Refitter/Analytics.cs
+++ b/src/Refitter/Analytics.cs
@@ -46,6 +46,8 @@ public static class Analytics
         if (settings.NoLogging)
             return;
 
+        ApplyTelemetrySource(settings);
+
         foreach (var property in typeof(Settings).GetProperties())
         {
             if (!CanLogFeature(settings, property))
@@ -59,7 +61,10 @@ public static class Analytics
                     attribute =>
                         !attribute.LongNames.Contains("namespace") &&
                         !attribute.LongNames.Contains("output") &&
-                        !attribute.LongNames.Contains("no-logging"))
+                        !attribute.LongNames.Contains("no-logging") &&
+                        !attribute.LongNames.Contains("telemetry-source") &&
+                        !attribute.LongNames.Contains("telemetry-file-count") &&
+                        !attribute.LongNames.Contains("telemetry-runtime"))
                 .ToList()
                 .ForEach(attribute => LogFeatureUsage(attribute, property));
         }
@@ -74,6 +79,8 @@ public static class Analytics
                 });
             telemetryClient.Flush();
         }
+
+        LogMsbuildInvocation(settings);
     }
 
     private static void LogFeatureUsage(CommandOptionAttribute attribute, PropertyInfo property)
@@ -81,6 +88,42 @@ public static class Analytics
         var featureName = attribute.LongNames.FirstOrDefault() ?? property.Name;
 
         telemetryClient.TrackEvent(featureName);
+        telemetryClient.Flush();
+    }
+
+    internal static bool IsMsbuildInvocation(string? telemetrySource) =>
+        string.Equals(telemetrySource, "msbuild", StringComparison.OrdinalIgnoreCase);
+
+    private static void ApplyTelemetrySource(Settings settings)
+    {
+        if (string.IsNullOrWhiteSpace(settings.TelemetrySource))
+        {
+            return;
+        }
+
+        telemetryClient.Context.GlobalProperties["telemetry-source"] = settings.TelemetrySource;
+        ExceptionlessClient.Default.Configuration.DefaultData["telemetry-source"] = settings.TelemetrySource;
+    }
+
+    private static void LogMsbuildInvocation(Settings settings)
+    {
+        if (!IsMsbuildInvocation(settings.TelemetrySource))
+        {
+            return;
+        }
+
+        var properties = new Dictionary<string, string>();
+        if (settings.TelemetryFileCount is not null)
+        {
+            properties["file-count"] = settings.TelemetryFileCount.Value.ToString();
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.TelemetryRuntime))
+        {
+            properties["runtime"] = settings.TelemetryRuntime;
+        }
+
+        telemetryClient.TrackEvent("msbuild-invocation", properties);
         telemetryClient.Flush();
     }
 
@@ -108,6 +151,8 @@ public static class Analytics
     {
         if (settings.NoLogging)
             return;
+
+        ApplyTelemetrySource(settings);
 
         string json = Serializer.Serialize(settings);
         var properties = Serializer.Deserialize<Dictionary<string, object>>(json)!;

--- a/src/Refitter/Analytics.cs
+++ b/src/Refitter/Analytics.cs
@@ -112,7 +112,7 @@ public static class Analytics
             return;
         }
 
-        var properties = new Dictionary<string, string>();
+        Dictionary<string, string> properties = new();
         if (settings.TelemetryFileCount is not null)
         {
             properties["file-count"] = settings.TelemetryFileCount.Value.ToString();

--- a/src/Refitter/Analytics.cs
+++ b/src/Refitter/Analytics.cs
@@ -18,8 +18,11 @@ public static class Analytics
     private const string ApplicationInsightsConnectionString = "InstrumentationKey=470c204f-b460-493a-9e31-d9b2f5e25abb;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/;ApplicationId=0836c3ac-e8ac-4e0c-ade8-3e0fadb9b40c";
     private static TelemetryClient telemetryClient = null!;
 
-    internal static void SetTelemetryClient(TelemetryClient client) =>
-        telemetryClient = client;
+    internal static void SetTelemetryClient(TelemetryClient? client) =>
+        telemetryClient = client!;
+
+    internal static TelemetryClient? GetTelemetryClient() =>
+        telemetryClient;
 
     public static void Configure()
     {

--- a/src/Refitter/Analytics.cs
+++ b/src/Refitter/Analytics.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Reflection;
 using Exceptionless;
 using Exceptionless.Plugins;
@@ -115,7 +116,7 @@ public static class Analytics
         Dictionary<string, string> properties = new();
         if (settings.TelemetryFileCount is not null)
         {
-            properties["file-count"] = settings.TelemetryFileCount.Value.ToString();
+            properties["file-count"] = settings.TelemetryFileCount.Value.ToString(CultureInfo.InvariantCulture);
         }
 
         if (!string.IsNullOrWhiteSpace(settings.TelemetryRuntime))

--- a/src/Refitter/Analytics.cs
+++ b/src/Refitter/Analytics.cs
@@ -18,6 +18,9 @@ public static class Analytics
     private const string ApplicationInsightsConnectionString = "InstrumentationKey=470c204f-b460-493a-9e31-d9b2f5e25abb;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/;ApplicationId=0836c3ac-e8ac-4e0c-ade8-3e0fadb9b40c";
     private static TelemetryClient telemetryClient = null!;
 
+    internal static void SetTelemetryClient(TelemetryClient client) =>
+        telemetryClient = client;
+
     public static void Configure()
     {
         ExceptionlessClient.Default.Configuration.SetUserIdentity(

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -119,6 +119,9 @@ OPTIONS:
         --no-inline-json-converters                              Don't inline JsonConverter attributes for enum properties. When disabled, enum properties will not have [JsonConverter(typeof(JsonStringEnumConverter))] attributes
         --integer-type                           int             The .NET type to use for OpenAPI integer types without a format specifier. Common values: 'int' (default), 'long'
         --custom-template-directory                              Custom directory with NSwag fluid templates for code generation. Default is null which uses the default NSwag templates. See <https://github.com/RicoSuter/NSwag/wiki/Templates>
+        --telemetry-source                                       Report the telemetry source of this invocation. Used internally by the MSBuild integration.
+        --telemetry-file-count                                   Report the total number of settings files in the current workload. Used internally by the MSBuild integration.
+        --telemetry-runtime                                      Report the bundled runtime selected for this invocation. Used internally by the MSBuild integration.
 ```
 
 ## CLI Tool Output Example
@@ -136,6 +139,8 @@ The following options are advanced/internal and are used by the MSBuild integrat
 - `--telemetry-source <value>` — reports the source of the invocation, e.g. `msbuild`. When set to `msbuild` (case-insensitive) a dedicated `msbuild-invocation` event is emitted.
 - `--telemetry-file-count <n>` — reports the total number of settings files in the current workload.
 - `--telemetry-runtime <tfm>` — reports the bundled runtime selected for this invocation, e.g. `net9.0`.
+
+These values are self-reported and advisory because they are user-controlled CLI options: `--telemetry-source=msbuild` indicates the caller claims an MSBuild origin, not that one is proven. A caller that requires reliable attribution should hand off provenance through a protected, non-user-controlled channel instead of relying on these flags.
 
 ### .Refitter File format
 

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -127,6 +127,16 @@ Here's what the console output looks like when running the Refitter CLI tool:
 
 ![Console Output](https://raw.githubusercontent.com/christianhelle/refitter/refs/heads/main/images/console-output.png)
 
+## Telemetry
+
+Refitter collects anonymous usage telemetry and error reports to improve the tool. Telemetry can be disabled with `--no-logging`.
+
+The following options are advanced/internal and are used by the MSBuild integration to tag telemetry with provenance:
+
+- `--telemetry-source <value>` — reports the source of the invocation, e.g. `msbuild`. When set to `msbuild` (case-insensitive) a dedicated `msbuild-invocation` event is emitted.
+- `--telemetry-file-count <n>` — reports the total number of settings files in the current workload.
+- `--telemetry-runtime <tfm>` — reports the bundled runtime selected for this invocation, e.g. `net9.0`.
+
 ### .Refitter File format
 
 The following is an example `.refitter` file

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -105,6 +105,18 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool NoLogging { get; set; }
 
+    [Description("Report the telemetry source of this invocation. Used internally by the MSBuild integration.")]
+    [CommandOption("--telemetry-source")]
+    public string? TelemetrySource { get; set; }
+
+    [Description("Report the total number of settings files in the current workload. Used internally by the MSBuild integration.")]
+    [CommandOption("--telemetry-file-count")]
+    public int? TelemetryFileCount { get; set; }
+
+    [Description("Report the bundled runtime selected for this invocation. Used internally by the MSBuild integration.")]
+    [CommandOption("--telemetry-runtime")]
+    public string? TelemetryRuntime { get; set; }
+
     [Description("Add additional namespace to generated types")]
     [CommandOption("--additional-namespace")]
     [DefaultValue(new string[0])]

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -105,14 +105,23 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool NoLogging { get; set; }
 
+    /// <summary>
+    /// The telemetry source of this invocation, e.g. <c>msbuild</c>. Used internally by the MSBuild integration.
+    /// </summary>
     [Description("Report the telemetry source of this invocation. Used internally by the MSBuild integration.")]
     [CommandOption("--telemetry-source")]
     public string? TelemetrySource { get; set; }
 
+    /// <summary>
+    /// The total number of settings files in the current workload. Used internally by the MSBuild integration.
+    /// </summary>
     [Description("Report the total number of settings files in the current workload. Used internally by the MSBuild integration.")]
     [CommandOption("--telemetry-file-count")]
     public int? TelemetryFileCount { get; set; }
 
+    /// <summary>
+    /// The bundled runtime selected for this invocation, e.g. <c>net9.0</c>. Used internally by the MSBuild integration.
+    /// </summary>
     [Description("Report the bundled runtime selected for this invocation. Used internally by the MSBuild integration.")]
     [CommandOption("--telemetry-runtime")]
     public string? TelemetryRuntime { get; set; }


### PR DESCRIPTION
## Description:

Currently the MSBuild integration (`Refitter.MSBuild`) just spawns the Refitter CLI as a subprocess, so telemetry from MSBuild-driven code generations is indistinguishable from direct CLI usage. This PR makes MSBuild invocations identifiable in the existing telemetry (Application Insights + Exceptionless) without adding any telemetry infrastructure to the `netstandard2.0` MSBuild task.

The MSBuild task now passes provenance arguments to the spawned CLI:

- `--telemetry-source msbuild` - always passed by the task
- `--telemetry-file-count <n>` - the total number of `.refitter` files in the current workload (passed on every invocation, since the task spawns the CLI once per file)
- `--telemetry-runtime <tfm>` - the bundled runtime selected by the task (e.g. `net9.0`), derived from the resolved `refitter.dll` path; omitted when falling back to a co-located CLI

On the CLI side, `Analytics` stamps all events for the process with the source via an Application Insights global property and Exceptionless default data, and when the source is `msbuild` (case-insensitive) it additionally emits a dedicated `msbuild-invocation` event carrying the file count and runtime. The three new options are excluded from reflection-based feature-usage logging.

Notable decisions:

- `--no-logging` still gates all telemetry, so the extra arguments are harmless when logging is disabled.
- Pre-spawn failures (zero files found, no resolvable runtime, spawn timeout) remain silent on the telemetry side, since no task-side telemetry was added. This gap is accepted and documented.
- The new options are documented in both the CLI and MSBuild READMEs.

#### Example OpenAPI Specifications:
N/A - telemetry change, no generated output affected.

#### Example generated Refit interface
N/A - generated Refit interface output is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved anonymous telemetry for command-line and MSBuild-based generation, including invocation source, input-file count, and runtime details.
  * Added telemetry configuration options and support for disabling telemetry during MSBuild generations.
* **Documentation**
  * Documented telemetry behavior, available opt-out settings, and MSBuild telemetry details.
* **Tests**
  * Added coverage for MSBuild telemetry detection, metadata recording, multiple-input generation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->