### PR TITLE
Fix code scanning workflow permissions alerts

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - 'main' 
 
+permissions:
+  contents: read
+
 jobs:
   changelog:
     if: github.ref == 'refs/heads/main' && github.repository == 'christianhelle/refitter'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,6 +23,9 @@ env:
   VERSION: 2.1.3.${{ github.run_number }}
   CODECOV_TOKEN: cbd141f8-4d0d-4bc1-84a7-970f9f9b87ac
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: 👌 Verify build

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -12,6 +12,9 @@ on:
       branches:
         - 'main' 
 
+permissions:
+  contents: read
+
 jobs:
     publish-docs:
       if: github.ref == 'refs/heads/main' && github.repository == 'christianhelle/refitter'

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -12,6 +12,9 @@ on:
       - 'docs/docfx_project/articles/msbuild.md'
       - 'test/MSBuild/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: 👌 Verify build (${{ matrix.os }})

--- a/.github/workflows/production-tests.yml
+++ b/.github/workflows/production-tests.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
 
   nuget:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   
   script:

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -3,6 +3,11 @@ name: Release (Preview)
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: write
+  packages: write
+
 jobs:
   publish:
     uses: ./.github/workflows/release-template.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - "release"
 
+permissions:
+  id-token: write
+  contents: write
+  packages: write
+
 jobs:
   publish:
     uses: ./.github/workflows/release-template.yml

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -19,6 +19,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
 
   script:


### PR DESCRIPTION
## Description:

Fixes all 12 open code scanning alerts on the repository. Each alert is CodeQL rule `actions/missing-workflow-permissions` ("Workflow does not contain permissions") on `refs/heads/main`.

All 9 affected workflow files now declare an explicit top-level `permissions:` block:

- **Release caller workflows** (`release.yml`, `release-preview.yml`) declare `id-token: write`, `contents: write`, `packages: write`. These callers pass `secrets: inherit` to `release-template.yml`, and a called workflow's `GITHUB_TOKEN` permissions can only be downgraded, never elevated, by its own block. Granting the same set preserves OIDC NuGet publishing, tag creation, and package uploads.
- **All other workflows** (`msbuild.yml`, `smoke-tests.yml`, `codecov.yml`, `production-tests.yml`, `regression-tests.yml`, `docfx.yml`, `changelog.yml`) declare `contents: read` as least privilege, which is sufficient for checkout/build/test. `docfx.yml` and `changelog.yml` push via PAT rather than `GITHUB_TOKEN`, so read-only token scope does not affect their deploy steps.

No behavior changes; all workflow YAML files parse cleanly.

#### Example OpenAPI Specifications:
N/A

#### Example generated Refit interface
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Strengthened automated workflow security by explicitly limiting repository access to read-only where appropriate.
  - Updated release workflows to support secure package publishing and identity-token authentication.
  - Improved permission consistency across testing, documentation, validation, changelog, and release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->