### PR TITLE
Update Refit to v15.1.0

### DIFF
--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -15,10 +15,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.11"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.11"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -44,10 +44,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.11"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.11"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />

--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -11,7 +11,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -40,7 +40,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />

--- a/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
+++ b/src/Refitter.SourceGenerator.Tests/Refitter.SourceGenerator.Tests.csproj
@@ -22,7 +22,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Refit.HttpClientFactory" Version="15.0.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="15.1.0" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>

--- a/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
+++ b/src/Refitter.SourceGenerator/Refitter.SourceGenerator.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="14.7.1" PrivateAssets="all" />
     <PackageReference Include="NSwag.Core.Yaml" Version="14.7.1" PrivateAssets="all" />
     <PackageReference Include="OasReader" Version="3.7.0.20" PrivateAssets="all" />
-    <PackageReference Include="Refit" Version="15.0.0" PrivateAssets="all" />
+    <PackageReference Include="Refit" Version="15.1.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -15,10 +15,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.11"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.11"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -45,10 +45,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.11"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.11"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -74,10 +74,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.11"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.11"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -104,10 +104,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.11"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.11"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -133,10 +133,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.11"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.11"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />
@@ -163,10 +163,10 @@ public static class ProjectFileContents
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.DependencyInjection"" Version=""10.0.11"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Polly"" Version=""10.0.10"" />
     <PackageReference Include=""Microsoft.Extensions.Http.Resilience"" Version=""10.1.0"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.10"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""10.0.11"" />
     <PackageReference Include=""Polly.Contrib.WaitAndRetry"" Version=""1.1.1"" />
     <PackageReference Include=""System.Reactive"" Version=""6.0.1"" />
     <PackageReference Include=""Apizr.Integrations.FileTransfer.MediatR"" Version=""6.4.0"" />

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -11,7 +11,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -41,7 +41,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -70,7 +70,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -100,7 +100,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -129,7 +129,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -159,7 +159,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""14.0.1"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />

--- a/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
@@ -65,7 +65,7 @@ public class GenerateJsonSerializerContextPolymorphismTests
             <RestorePackagesPath>packages</RestorePackagesPath>
           </PropertyGroup>
           <ItemGroup>
-            <PackageReference Include="Refit.HttpClientFactory" Version="14.0.1" />
+            <PackageReference Include="Refit.HttpClientFactory" Version="15.1.0" />
           </ItemGroup>
         </Project>
         """;

--- a/test/ConsoleApp/Directory.Build.props
+++ b/test/ConsoleApp/Directory.Build.props
@@ -28,8 +28,8 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
         <PackageReference Include="Refit" Version="15.1.0" />
         <PackageReference Include="Refit.HttpClientFactory" Version="15.1.0" />

--- a/test/ConsoleApp/Directory.Build.props
+++ b/test/ConsoleApp/Directory.Build.props
@@ -31,8 +31,8 @@
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
-        <PackageReference Include="Refit" Version="15.0.0" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="15.0.0" />
+        <PackageReference Include="Refit" Version="15.1.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="15.1.0" />
         <PackageReference Include="Polly" Version="8.7.0" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/test/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/test/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Refit" Version="15.0.0" />
+    <PackageReference Include="Refit" Version="15.1.0" />
     <PackageReference Include="System.Text.Json" Version="10.0.10" />
   </ItemGroup>
 

--- a/test/MSBuild/Refitter.MSBuild.Tests.csproj
+++ b/test/MSBuild/Refitter.MSBuild.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Refit.HttpClientFactory" Version="15.0.0" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="15.1.0" />
     </ItemGroup>
 
 </Project>

--- a/test/MinimalApi/MinimalApi.csproj
+++ b/test/MinimalApi/MinimalApi.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="15.0.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="15.1.0" />
     <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/test/MultipleFiles/Client/Client.csproj
+++ b/test/MultipleFiles/Client/Client.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
-    <PackageReference Include="Refit" Version="15.0.0" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="15.0.0" />
+    <PackageReference Include="Refit" Version="15.1.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="15.1.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/test/SourceGenerator/Directory.Build.props
+++ b/test/SourceGenerator/Directory.Build.props
@@ -13,7 +13,7 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\Refitter.SourceGenerator\Refitter.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-        <PackageReference Include="Refit" Version="15.0.0" />
+        <PackageReference Include="Refit" Version="15.1.0" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
         <PackageReference Include="System.Text.Json" Version="10.0.10" />

--- a/test/Streaming/Streaming.csproj
+++ b/test/Streaming/Streaming.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Refit" Version="15.0.0" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="15.0.0" />
+    <PackageReference Include="Refit" Version="15.1.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="15.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Updates the Refit and Refit.HttpClientFactory NuGet package references from v15.0.0 to v15.1.0 across all test projects, source generator, and test build helper templates.

Refit.HttpClientFactory 15.1.0 pulls in Microsoft.Extensions.Http 10.0.11, which requires `Microsoft.Extensions.Options.ConfigurationExtensions` and `Microsoft.Extensions.DependencyInjection` at 10.0.11+. The test project templates and ConsoleApp smoke-test props were accordingly bumped from 10.0.10 to 10.0.11 to avoid NU1605 package downgrade errors.

## Commits

- `48988bb8` update Refit package references to v15.1.0
- `84536bf2` bump Refit version in test build helper projects
- `6aba9bba` bump Microsoft.Extensions packages to 10.0.11 for Refit 15.1.0

## Verification

- `dotnet build -c Release src/Refitter.slnx` — succeeds, 0 warnings, 0 errors
- `dotnet test --solution src/Refitter.slnx -c Release` — 2421/2421 tests pass
- `test/smoke-tests.ps1` — all generation and compile phases pass
