### PR TITLE
Add silent mode to CLI and smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ OPTIONS:
                                                 DEFAULT
     -h, --help                                                   Prints help information
     -v, --version                                                Prints version information
-    -s, --settings-file                                          Path to .refitter settings file. Specifying this will ignore all other settings (except for --output)
+    -s, --settings-file                                          Path to .refitter settings file. Specifying this will ignore all other settings (except for --output and --silent)
     -n, --namespace                             GeneratedCode    Default namespace to use for generated types
         --contracts-namespace                                    Default namespace to use for generated contracts
         --property-naming-policy                PascalCase       Controls how generated contract properties are named. May be one of PascalCase, PreserveOriginal

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ OPTIONS:
         --no-operation-headers                                   Don't generate operation headers
         --ignored-operation-headers                              A collection of headers to omit from operation signatures. May be set multiple times
         --no-logging                                             Don't log errors or collect telemetry
+        --silent                                                 Suppress all console output. Errors are still reported through the exit code
         --additional-namespace                                   Add additional namespace to generated types
         --exclude-namespace                                      Exclude namespace on generated types
         --use-iso-date-format                                    Explicitly format date query string parameters in ISO 8601 standard date format using delimiters (2023-06-15)

--- a/docs/docfx_project/articles/cli-tool.md
+++ b/docs/docfx_project/articles/cli-tool.md
@@ -67,6 +67,7 @@ OPTIONS:
         --cancellation-tokens                                    Use cancellation tokens
         --no-operation-headers                                   Don't generate operation headers
         --no-logging                                             Don't log errors or collect telemetry
+        --silent                                                 Suppress all console output. Errors are still reported through the exit code
         --additional-namespace                                   Add additional namespace to generated types
         --exclude-namespace                                      Exclude namespace on generated types
         --use-iso-date-format                                    Explicitly format date query string parameters in ISO 8601 standard date format using delimiters (2023-06-15)

--- a/docs/docfx_project/articles/cli-tool.md
+++ b/docs/docfx_project/articles/cli-tool.md
@@ -52,7 +52,7 @@ OPTIONS:
                                                 DEFAULT
     -h, --help                                                   Prints help information
     -v, --version                                                Prints version information
-    -s, --settings-file                                          Path to .refitter settings file. Specifying this will ignore all other settings (except for --output)
+    -s, --settings-file                                          Path to .refitter settings file. Specifying this will ignore all other settings (except for --output and --silent)
     -n, --namespace                             GeneratedCode    Default namespace to use for generated types
         --contracts-namespace                                    Default namespace to use for generated contracts
     -o, --output                                Output.cs        Path to Output file or folder (if multiple files are generated)

--- a/docs/docfx_project/articles/docker.md
+++ b/docs/docfx_project/articles/docker.md
@@ -600,6 +600,7 @@ OPTIONS:
         --no-operation-headers                                   Don't generate operation headers
         --ignored-operation-headers                              A collection of headers to omit from operation signatures
         --no-logging                                             Don't log errors or collect telemetry
+        --silent                                                 Suppress all console output. Errors are still reported through the exit code
         --additional-namespace                                   Add additional namespace to generated types
         --exclude-namespace                                      Exclude namespace on generated types
         --use-iso-date-format                                    Explicitly format date query string parameters in ISO 8601 standard date format using delimiters (2023-06-15)
@@ -787,10 +788,10 @@ To see detailed logs if something goes wrong:
 docker run --rm -v $(pwd):/src christianhelle/refitter ./openapi.json --output ./Client.cs
 ```
 
-The `--no-logging` flag disables telemetry collection but not console output. To see minimal output, use:
+The `--no-logging` flag disables telemetry collection but not console output. To suppress all output, use `--silent`:
 
 ```shell
-docker run --rm -v $(pwd):/src christianhelle/refitter ./openapi.json --no-banner --output ./Client.cs
+docker run --rm -v $(pwd):/src christianhelle/refitter ./openapi.json --silent --output ./Client.cs
 ```
 
 ### Verifying the Image

--- a/docs/docfx_project/articles/docker.md
+++ b/docs/docfx_project/articles/docker.md
@@ -583,7 +583,7 @@ OPTIONS:
                                                 DEFAULT
     -h, --help                                                   Prints help information
     -v, --version                                                Prints version information
-    -s, --settings-file                                          Path to .refitter settings file. Specifying this will ignore all other settings (except for --output)
+    -s, --settings-file                                          Path to .refitter settings file. Specifying this will ignore all other settings (except for --output and --silent)
     -n, --namespace                             GeneratedCode    Default namespace to use for generated types
         --contracts-namespace                                    Default namespace to use for generated contracts
     -o, --output                                Output.cs        Path to Output file or folder (if multiple files are generated)

--- a/docs/docfx_project/articles/refitter-file-format.md
+++ b/docs/docfx_project/articles/refitter-file-format.md
@@ -63,6 +63,7 @@ The following is an example `.refitter` file
   ],
   "generateDefaultAdditionalProperties": true, // Optional. default=true
   "allowRemoteReferences": false, // Optional. Default=false. When true, remote http/https $ref references inside the document are resolved
+  "silent": false, // Optional. Default=false. Suppress all console output when running the CLI tool. Errors are still reported through the exit code
   "operationNameGenerator": "Default", // Optional. May be one of Default, MultipleClientsFromOperationId, MultipleClientsFromPathSegments, MultipleClientsFromFirstTagAndOperationId, MultipleClientsFromFirstTagAndOperationName, MultipleClientsFromFirstTagAndPathSegments, SingleClientFromOperationId, SingleClientFromPathSegments
   "immutableRecords": false,
   "useDynamicQuerystringParameters": false, // Optional. Default=false
@@ -187,6 +188,7 @@ When using `openApiPaths`, the documents are merged into a single generated clie
 - `includeInheritanceHierarchy`: Set to true to keep all possible type-instances of inheritance/union types. If this is false only directly referenced types will be kept. This works in conjunction with `trimUnusedSchema`
 - `generateDefaultAdditionalProperties`: Set to `false` to skip default additional properties. Default is `true`
 - `allowRemoteReferences`: When `true`, remote (`http`/`https`) `$ref` references inside the document are resolved. Disabled by default to prevent generation-time SSRF and remote file inclusion. Local `$ref` references are always confined to the input document's directory tree. Default is `false`
+- `silent`: Set to `true` to suppress all console output when running the CLI tool. Errors are still reported through the exit code. Default is `false`
 - `operationNameGenerator`: The NSwag `IOperationNameGenerator` implementation to use. See <https://refitter.github.io/api/Refitter.Core.OperationNameGeneratorTypes.html>
 - `immutableRecords`: Set to `true` to generate contracts as immutable records instead of classes. Default is `false`
 - `useDynamicQuerystringParameters`: Set to `true` to wrap multiple query parameters into a single complex one. Default is `false` (no wrapping). See <https://github.com/reactiveui/refit?tab=readme-ov-file#dynamic-querystring-parameters> for more information.
@@ -416,6 +418,10 @@ When using `openApiPaths`, the documents are merged into a single generated clie
         "allowRemoteReferences": {
             "type": "boolean",
             "description": "When true, remote (http/https) $ref references inside the document are resolved. Disabled by default to prevent generation-time SSRF and remote file inclusion. Local $ref references are always confined to the input document's directory tree."
+        },
+        "silent": {
+            "type": "boolean",
+            "description": "Suppress all console output when running the CLI tool. Errors are still reported through the exit code."
         },
         "operationNameGenerator": {
             "type": "string",

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -181,6 +181,7 @@ docker run --rm -v %cd%:/src christianhelle/refitter %*
     --operation-name-generator   Naming strategy
     --no-banner                  Hide banner
     --simple-output              Plain text output
+    --silent                     Suppress all console output
 ```
 
 ## Volume Mounting

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -156,7 +156,7 @@ docker run --rm -v %cd%:/src christianhelle/refitter %*
 ```
 -n, --namespace                  Default namespace (default: GeneratedCode)
 -o, --output                     Output file path (default: Output.cs)
--s, --settings-file              Path to .refitter settings file
+-s, --settings-file              Path to .refitter settings file. Specifying this will ignore all other settings (except for --output and --silent)
     --contracts-namespace        Namespace for contracts
     --contracts-output           Separate output for contracts
     --interface-only             Generate only interfaces
@@ -181,7 +181,7 @@ docker run --rm -v %cd%:/src christianhelle/refitter %*
     --operation-name-generator   Naming strategy
     --no-banner                  Hide banner
     --simple-output              Plain text output
-    --silent                     Suppress all console output
+    --silent                     Suppress all console output. Errors are still reported through the exit code
 ```
 
 ## Volume Mounting

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -600,6 +600,7 @@ OPTIONS:
         --no-operation-headers                                   Don't generate operation headers
         --ignored-operation-headers                              A collection of headers to omit from operation signatures
         --no-logging                                             Don't log errors or collect telemetry
+        --silent                                                 Suppress all console output. Errors are still reported through the exit code
         --additional-namespace                                   Add additional namespace to generated types
         --exclude-namespace                                      Exclude namespace on generated types
         --use-iso-date-format                                    Explicitly format date query string parameters in ISO 8601 standard date format using delimiters (2023-06-15)
@@ -787,10 +788,10 @@ To see detailed logs if something goes wrong:
 docker run --rm -v $(pwd):/src christianhelle/refitter ./openapi.json --output ./Client.cs
 ```
 
-The `--no-logging` flag disables telemetry collection but not console output. To see minimal output, use:
+The `--no-logging` flag disables telemetry collection but not console output. To suppress all output, use `--silent`:
 
 ```shell
-docker run --rm -v $(pwd):/src christianhelle/refitter ./openapi.json --no-banner --output ./Client.cs
+docker run --rm -v $(pwd):/src christianhelle/refitter ./openapi.json --silent --output ./Client.cs
 ```
 
 ### Verifying the Image

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -583,7 +583,7 @@ OPTIONS:
                                                 DEFAULT
     -h, --help                                                   Prints help information
     -v, --version                                                Prints version information
-    -s, --settings-file                                          Path to .refitter settings file. Specifying this will ignore all other settings (except for --output)
+    -s, --settings-file                                          Path to .refitter settings file. Specifying this will ignore all other settings (except for --output and --silent)
     -n, --namespace                             GeneratedCode    Default namespace to use for generated types
         --contracts-namespace                                    Default namespace to use for generated contracts
     -o, --output                                Output.cs        Path to Output file or folder (if multiple files are generated)

--- a/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/RefitGeneratorSettings.cs
@@ -443,4 +443,12 @@ public class RefitGeneratorSettings : IOutputConfiguration, INamingConfiguration
     /// </summary>
     [Description("Suffix to append to all generated contract type names. Default is null which doesn't append any suffix.")]
     public string? ContractTypeSuffix { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the CLI should suppress all console output.
+    /// </summary>
+    [Description("Suppress all console output when running the CLI tool. Default is false.")]
+    [JsonPropertyName("silent")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool Silent { get; set; }
 }

--- a/src/Refitter.Tests/GenerateCommandTests.cs
+++ b/src/Refitter.Tests/GenerateCommandTests.cs
@@ -571,12 +571,12 @@ public class GenerateCommandTests
     [Test]
     public void Program_Main_Should_Produce_No_Output_When_Silent()
     {
-        var workspace = CreateWorkspace();
+        string workspace = CreateWorkspace();
 
         try
         {
-            var openApiPath = Path.Combine(workspace, "petstore.json");
-            var outputPath = Path.Combine(workspace, "Generated", "PetstoreClient.cs");
+            string openApiPath = Path.Combine(workspace, "petstore.json");
+            string outputPath = Path.Combine(workspace, "Generated", "PetstoreClient.cs");
 
             File.WriteAllText(
                 openApiPath,
@@ -602,7 +602,7 @@ public class GenerateCommandTests
                 }
                 """);
 
-            var result = InvokeProgram(
+            (int ExitCode, string Output) result = InvokeProgram(
             [
                 openApiPath,
                 "--output", outputPath,
@@ -623,7 +623,7 @@ public class GenerateCommandTests
     [Test]
     public void Program_Main_Should_Produce_No_Output_When_Settings_File_Is_Silent()
     {
-        var workspace = CreateWorkspace();
+        string workspace = CreateWorkspace();
 
         try
         {
@@ -651,7 +651,7 @@ public class GenerateCommandTests
                 }
                 """);
 
-            var settingsFile = Path.Combine(workspace, "petstore.refitter");
+            string settingsFile = Path.Combine(workspace, "petstore.refitter");
             File.WriteAllText(
                 settingsFile,
                 """
@@ -664,7 +664,7 @@ public class GenerateCommandTests
                 }
                 """);
 
-            var result = InvokeProgram(
+            (int ExitCode, string Output) result = InvokeProgram(
             [
                 "--settings-file", settingsFile,
                 "--no-logging"

--- a/src/Refitter.Tests/GenerateCommandTests.cs
+++ b/src/Refitter.Tests/GenerateCommandTests.cs
@@ -568,6 +568,118 @@ public class GenerateCommandTests
         }
     }
 
+    [Test]
+    public void Program_Main_Should_Produce_No_Output_When_Silent()
+    {
+        var workspace = CreateWorkspace();
+
+        try
+        {
+            var openApiPath = Path.Combine(workspace, "petstore.json");
+            var outputPath = Path.Combine(workspace, "Generated", "PetstoreClient.cs");
+
+            File.WriteAllText(
+                openApiPath,
+                """
+                {
+                  "openapi": "3.0.0",
+                  "info": {
+                    "title": "Petstore API",
+                    "version": "1.0.0"
+                  },
+                  "paths": {
+                    "/pets": {
+                      "get": {
+                        "operationId": "GetPets",
+                        "responses": {
+                          "200": {
+                            "description": "ok"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+
+            var result = InvokeProgram(
+            [
+                openApiPath,
+                "--output", outputPath,
+                "--silent",
+                "--no-logging"
+            ]);
+
+            result.ExitCode.Should().Be(0, result.Output);
+            result.Output.Should().BeEmpty();
+            File.Exists(outputPath).Should().BeTrue();
+        }
+        finally
+        {
+            DeleteWorkspace(workspace);
+        }
+    }
+
+    [Test]
+    public void Program_Main_Should_Produce_No_Output_When_Settings_File_Is_Silent()
+    {
+        var workspace = CreateWorkspace();
+
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(workspace, "petstore.json"),
+                """
+                {
+                  "openapi": "3.0.0",
+                  "info": {
+                    "title": "Petstore API",
+                    "version": "1.0.0"
+                  },
+                  "paths": {
+                    "/pets": {
+                      "get": {
+                        "operationId": "GetPets",
+                        "responses": {
+                          "200": {
+                            "description": "ok"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+
+            var settingsFile = Path.Combine(workspace, "petstore.refitter");
+            File.WriteAllText(
+                settingsFile,
+                """
+                {
+                  "openApiPath": "petstore.json",
+                  "namespace": "Petstore",
+                  "outputFolder": "Generated",
+                  "outputFilename": "PetstoreClient.cs",
+                  "silent": true
+                }
+                """);
+
+            var result = InvokeProgram(
+            [
+                "--settings-file", settingsFile,
+                "--no-logging"
+            ]);
+
+            result.ExitCode.Should().Be(0, result.Output);
+            result.Output.Should().BeEmpty();
+            File.Exists(Path.Combine(workspace, "Generated", "PetstoreClient.cs")).Should().BeTrue();
+        }
+        finally
+        {
+            DeleteWorkspace(workspace);
+        }
+    }
+
     private static (int ExitCode, string Output) InvokeProgram(string[] args)
     {
         var cliPath = Path.Combine(AppContext.BaseDirectory, "refitter.dll");

--- a/src/Refitter.Tests/SettingsFile/SerializerTests.cs
+++ b/src/Refitter.Tests/SettingsFile/SerializerTests.cs
@@ -151,4 +151,43 @@ public class SerializerTests
         var settings = new CodeGeneratorSettings();
         settings.JsonLibraryVersion.Should().Be(8.0m);
     }
+
+    [Test]
+    public void Default_Silent_Should_Be_False()
+    {
+        var settings = new RefitGeneratorSettings();
+        settings.Silent.Should().BeFalse();
+    }
+
+    [Test]
+    public void Can_Serialize_RefitGeneratorSettings_With_Silent()
+    {
+        var settings = CreateTestSettings();
+        settings.Silent = true;
+
+        var json = Serializer.Serialize(settings);
+
+        json.Should().Contain("\"silent\": true");
+    }
+
+    [Test]
+    public void Can_Deserialize_RefitGeneratorSettings_With_Silent()
+    {
+        const string json = """{"silent": true}""";
+
+        var settings = Serializer.Deserialize<RefitGeneratorSettings>(json);
+
+        settings.Should().NotBeNull();
+        settings.Silent.Should().BeTrue();
+    }
+
+    [Test]
+    public void Can_Serialize_RefitGeneratorSettings_With_Default_Silent_Omits_Property()
+    {
+        var settings = CreateTestSettings();
+
+        var json = Serializer.Serialize(settings);
+
+        json.Should().NotContain("\"silent\"");
+    }
 }

--- a/src/Refitter.Tests/SettingsFile/SerializerTests.cs
+++ b/src/Refitter.Tests/SettingsFile/SerializerTests.cs
@@ -155,17 +155,17 @@ public class SerializerTests
     [Test]
     public void Default_Silent_Should_Be_False()
     {
-        var settings = new RefitGeneratorSettings();
+        RefitGeneratorSettings settings = new RefitGeneratorSettings();
         settings.Silent.Should().BeFalse();
     }
 
     [Test]
     public void Can_Serialize_RefitGeneratorSettings_With_Silent()
     {
-        var settings = CreateTestSettings();
+        RefitGeneratorSettings settings = CreateTestSettings();
         settings.Silent = true;
 
-        var json = Serializer.Serialize(settings);
+        string json = Serializer.Serialize(settings);
 
         json.Should().Contain("\"silent\": true");
     }
@@ -175,7 +175,7 @@ public class SerializerTests
     {
         const string json = """{"silent": true}""";
 
-        var settings = Serializer.Deserialize<RefitGeneratorSettings>(json);
+        RefitGeneratorSettings settings = Serializer.Deserialize<RefitGeneratorSettings>(json);
 
         settings.Should().NotBeNull();
         settings.Silent.Should().BeTrue();
@@ -184,9 +184,9 @@ public class SerializerTests
     [Test]
     public void Can_Serialize_RefitGeneratorSettings_With_Default_Silent_Omits_Property()
     {
-        var settings = CreateTestSettings();
+        RefitGeneratorSettings settings = CreateTestSettings();
 
-        var json = Serializer.Serialize(settings);
+        string json = Serializer.Serialize(settings);
 
         json.Should().NotContain("\"silent\"");
     }

--- a/src/Refitter.Tests/SettingsFile/SettingsTests.cs
+++ b/src/Refitter.Tests/SettingsFile/SettingsTests.cs
@@ -32,6 +32,7 @@ public class SettingsTests
         settings.NoOperationHeaders.Should().BeFalse();
         settings.IgnoredOperationHeaders.Should().NotBeNull().And.BeEmpty();
         settings.NoLogging.Should().BeFalse();
+        settings.Silent.Should().BeFalse();
         settings.AdditionalNamespaces.Should().NotBeNull().And.BeEmpty();
         settings.ExcludeNamespaces.Should().NotBeNull().And.BeEmpty();
         settings.UseIsoDateFormat.Should().BeFalse();
@@ -113,6 +114,7 @@ public class SettingsTests
             UseCancellationTokens = true,
             NoOperationHeaders = true,
             NoLogging = true,
+            Silent = true,
             UseIsoDateFormat = true,
             SkipValidation = true,
             NoDeprecatedOperations = true,
@@ -137,6 +139,7 @@ public class SettingsTests
         settings.UseCancellationTokens.Should().BeTrue();
         settings.NoOperationHeaders.Should().BeTrue();
         settings.NoLogging.Should().BeTrue();
+        settings.Silent.Should().BeTrue();
         settings.UseIsoDateFormat.Should().BeTrue();
         settings.SkipValidation.Should().BeTrue();
         settings.NoDeprecatedOperations.Should().BeTrue();

--- a/src/Refitter.Tests/SettingsMapperTests.cs
+++ b/src/Refitter.Tests/SettingsMapperTests.cs
@@ -481,6 +481,20 @@ public class SettingsMapperTests
     }
 
     [Test]
+    public void Map_Should_Copy_Silent()
+    {
+        Settings settings = new Settings
+        {
+            OpenApiPath = "https://example.com/openapi.json",
+            Silent = true,
+        };
+
+        RefitGeneratorSettings result = SettingsMapper.Map(settings);
+
+        result.Silent.Should().BeTrue();
+    }
+
+    [Test]
     public void ConventionMapper_Should_Copy_Same_Name_Same_Type()
     {
         var source = new ConventionSource { Name = "test", Value = 42 };

--- a/src/Refitter.Tests/SilentGenerationReporterTests.cs
+++ b/src/Refitter.Tests/SilentGenerationReporterTests.cs
@@ -16,7 +16,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportHeader_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter().ReportHeader("1.2.3");
+        Action act = () => new SilentGenerationReporter().ReportHeader("1.2.3");
 
         act.Should().NotThrow();
     }
@@ -24,7 +24,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportSupportKey_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter().ReportSupportKey("TEST-KEY-123");
+        Action act = () => new SilentGenerationReporter().ReportSupportKey("TEST-KEY-123");
 
         act.Should().NotThrow();
     }
@@ -38,7 +38,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportSingleFileOutput_Does_Not_Throw()
     {
-        var act = () =>
+        Action act = () =>
             new SilentGenerationReporter().ReportSingleFileOutput("Output.cs", "/tmp", "12 KB", 300);
 
         act.Should().NotThrow();
@@ -47,8 +47,8 @@ public class SilentGenerationReporterTests
     [Test]
     public async Task GenerateMultipleFilesWithProgressAsync_Invokes_Generator_And_Returns_Result()
     {
-        var called = false;
-        var result = await new SilentGenerationReporter()
+        bool called = false;
+        GeneratorOutput result = await new SilentGenerationReporter()
             .GenerateMultipleFilesWithProgressAsync(() =>
             {
                 called = true;
@@ -62,9 +62,9 @@ public class SilentGenerationReporterTests
     [Test]
     public void BeginMultiFileOutput_AddFile_And_Complete_Do_Not_Throw()
     {
-        var act = () =>
+        Action act = () =>
         {
-            var report = new SilentGenerationReporter().BeginMultiFileOutput();
+            IMultiFileOutputReport report = new SilentGenerationReporter().BeginMultiFileOutput();
             report.AddFile("Api.cs", "/tmp", "5 KB", 100);
             report.Complete(1, "5 KB", 100);
         };
@@ -75,7 +75,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportFileWritten_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter().ReportFileWritten("/output/Api.cs");
+        Action act = () => new SilentGenerationReporter().ReportFileWritten("/output/Api.cs");
 
         act.Should().NotThrow();
     }
@@ -83,7 +83,7 @@ public class SilentGenerationReporterTests
     [Test]
     public async Task ValidateWithProgressAsync_Invokes_Validator()
     {
-        var called = false;
+        bool called = false;
         await new SilentGenerationReporter().ValidateWithProgressAsync(async () =>
         {
             called = true;
@@ -96,7 +96,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportValidationFailed_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter().ReportValidationFailed();
+        Action act = () => new SilentGenerationReporter().ReportValidationFailed();
 
         act.Should().NotThrow();
     }
@@ -104,7 +104,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportValidationDiagnostic_Error_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter().ReportValidationDiagnostic(
+        Action act = () => new SilentGenerationReporter().ReportValidationDiagnostic(
             new OpenApiError("field", "Something went wrong"),
             isError: true);
 
@@ -114,7 +114,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportValidationDiagnostic_Warning_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter().ReportValidationDiagnostic(
+        Action act = () => new SilentGenerationReporter().ReportValidationDiagnostic(
             new OpenApiError("field", "A warning"),
             isError: false);
 
@@ -124,11 +124,11 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportValidationStatistics_Does_Not_Throw()
     {
-        var result = new OpenApiValidationResult(
+        OpenApiValidationResult result = new OpenApiValidationResult(
             new Microsoft.OpenApi.Reader.OpenApiDiagnostic(),
             new OpenApiStats());
 
-        var act = () => new SilentGenerationReporter().ReportValidationStatistics(result);
+        Action act = () => new SilentGenerationReporter().ReportValidationStatistics(result);
 
         act.Should().NotThrow();
     }
@@ -136,7 +136,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportSuccess_SingleFile_Does_Not_Throw()
     {
-        var act = () =>
+        Action act = () =>
             new SilentGenerationReporter().ReportSuccess(TimeSpan.FromMilliseconds(1234), multipleFiles: false);
 
         act.Should().NotThrow();
@@ -145,7 +145,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportSuccess_MultipleFiles_Does_Not_Throw()
     {
-        var act = () =>
+        Action act = () =>
             new SilentGenerationReporter().ReportSuccess(TimeSpan.FromMilliseconds(1234), multipleFiles: true);
 
         act.Should().NotThrow();
@@ -154,7 +154,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportDonationBanner_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter().ReportDonationBanner();
+        Action act = () => new SilentGenerationReporter().ReportDonationBanner();
 
         act.Should().NotThrow();
     }
@@ -162,13 +162,13 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportConfigurationWarnings_Does_Not_Throw()
     {
-        var warnings = new List<Warning>
+        List<Warning> warnings = new List<Warning>
         {
             new("Title1", "Desc1"),
             new("Title2", "Desc2"),
         };
 
-        var act = () => new SilentGenerationReporter().ReportConfigurationWarnings(warnings);
+        Action act = () => new SilentGenerationReporter().ReportConfigurationWarnings(warnings);
 
         act.Should().NotThrow();
     }
@@ -176,7 +176,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportAllPathsFilteredWarning_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter()
+        Action act = () => new SilentGenerationReporter()
             .ReportAllPathsFilteredWarning(["^/pets", "^/users"]);
 
         act.Should().NotThrow();
@@ -185,7 +185,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportSettingsFileGenerated_Does_Not_Throw()
     {
-        var act = () =>
+        Action act = () =>
             new SilentGenerationReporter().ReportSettingsFileGenerated("/tmp/petstore.refitter");
 
         act.Should().NotThrow();
@@ -194,7 +194,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportGenerationFailed_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter().ReportGenerationFailed();
+        Action act = () => new SilentGenerationReporter().ReportGenerationFailed();
 
         act.Should().NotThrow();
     }
@@ -202,7 +202,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportUnsupportedVersion_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter().ReportUnsupportedVersion("1.0");
+        Action act = () => new SilentGenerationReporter().ReportUnsupportedVersion("1.0");
 
         act.Should().NotThrow();
     }
@@ -210,7 +210,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportExceptionDetails_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter()
+        Action act = () => new SilentGenerationReporter()
             .ReportExceptionDetails(new InvalidOperationException("boom"));
 
         act.Should().NotThrow();
@@ -219,7 +219,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportSkipValidationSuggestion_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter().ReportSkipValidationSuggestion();
+        Action act = () => new SilentGenerationReporter().ReportSkipValidationSuggestion();
 
         act.Should().NotThrow();
     }
@@ -227,7 +227,7 @@ public class SilentGenerationReporterTests
     [Test]
     public void ReportSupportHelp_Does_Not_Throw()
     {
-        var act = () => new SilentGenerationReporter().ReportSupportHelp();
+        Action act = () => new SilentGenerationReporter().ReportSupportHelp();
 
         act.Should().NotThrow();
     }

--- a/src/Refitter.Tests/SilentGenerationReporterTests.cs
+++ b/src/Refitter.Tests/SilentGenerationReporterTests.cs
@@ -1,0 +1,234 @@
+using FluentAssertions;
+using Microsoft.OpenApi;
+using Refitter.Core;
+using Refitter.Core.Validation;
+
+namespace Refitter.Tests;
+
+/// <summary>
+/// Smoke tests for <see cref="SilentGenerationReporter"/>. These exercise every method
+/// for line/branch coverage; nothing is written to the console because the reporter
+/// is a no-op. The delegate-wrapping methods must still invoke their delegates.
+/// </summary>
+
+public class SilentGenerationReporterTests
+{
+    [Test]
+    public void ReportHeader_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter().ReportHeader("1.2.3");
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportSupportKey_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter().ReportSupportKey("TEST-KEY-123");
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public async Task ReportSingleFileGenerationProgressAsync_Does_Not_Throw()
+    {
+        await new SilentGenerationReporter().ReportSingleFileGenerationProgressAsync();
+    }
+
+    [Test]
+    public void ReportSingleFileOutput_Does_Not_Throw()
+    {
+        var act = () =>
+            new SilentGenerationReporter().ReportSingleFileOutput("Output.cs", "/tmp", "12 KB", 300);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public async Task GenerateMultipleFilesWithProgressAsync_Invokes_Generator_And_Returns_Result()
+    {
+        var called = false;
+        var result = await new SilentGenerationReporter()
+            .GenerateMultipleFilesWithProgressAsync(() =>
+            {
+                called = true;
+                return new GeneratorOutput([]);
+            });
+
+        called.Should().BeTrue();
+        result.Should().NotBeNull();
+    }
+
+    [Test]
+    public void BeginMultiFileOutput_AddFile_And_Complete_Do_Not_Throw()
+    {
+        var act = () =>
+        {
+            var report = new SilentGenerationReporter().BeginMultiFileOutput();
+            report.AddFile("Api.cs", "/tmp", "5 KB", 100);
+            report.Complete(1, "5 KB", 100);
+        };
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportFileWritten_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter().ReportFileWritten("/output/Api.cs");
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public async Task ValidateWithProgressAsync_Invokes_Validator()
+    {
+        var called = false;
+        await new SilentGenerationReporter().ValidateWithProgressAsync(async () =>
+        {
+            called = true;
+            return await Task.FromResult(new OpenApiValidationResult(new Microsoft.OpenApi.Reader.OpenApiDiagnostic(), new OpenApiStats()));
+        });
+
+        called.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReportValidationFailed_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter().ReportValidationFailed();
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportValidationDiagnostic_Error_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter().ReportValidationDiagnostic(
+            new OpenApiError("field", "Something went wrong"),
+            isError: true);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportValidationDiagnostic_Warning_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter().ReportValidationDiagnostic(
+            new OpenApiError("field", "A warning"),
+            isError: false);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportValidationStatistics_Does_Not_Throw()
+    {
+        var result = new OpenApiValidationResult(
+            new Microsoft.OpenApi.Reader.OpenApiDiagnostic(),
+            new OpenApiStats());
+
+        var act = () => new SilentGenerationReporter().ReportValidationStatistics(result);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportSuccess_SingleFile_Does_Not_Throw()
+    {
+        var act = () =>
+            new SilentGenerationReporter().ReportSuccess(TimeSpan.FromMilliseconds(1234), multipleFiles: false);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportSuccess_MultipleFiles_Does_Not_Throw()
+    {
+        var act = () =>
+            new SilentGenerationReporter().ReportSuccess(TimeSpan.FromMilliseconds(1234), multipleFiles: true);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportDonationBanner_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter().ReportDonationBanner();
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportConfigurationWarnings_Does_Not_Throw()
+    {
+        var warnings = new List<Warning>
+        {
+            new("Title1", "Desc1"),
+            new("Title2", "Desc2"),
+        };
+
+        var act = () => new SilentGenerationReporter().ReportConfigurationWarnings(warnings);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportAllPathsFilteredWarning_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter()
+            .ReportAllPathsFilteredWarning(["^/pets", "^/users"]);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportSettingsFileGenerated_Does_Not_Throw()
+    {
+        var act = () =>
+            new SilentGenerationReporter().ReportSettingsFileGenerated("/tmp/petstore.refitter");
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportGenerationFailed_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter().ReportGenerationFailed();
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportUnsupportedVersion_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter().ReportUnsupportedVersion("1.0");
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportExceptionDetails_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter()
+            .ReportExceptionDetails(new InvalidOperationException("boom"));
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportSkipValidationSuggestion_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter().ReportSkipValidationSuggestion();
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReportSupportHelp_Does_Not_Throw()
+    {
+        var act = () => new SilentGenerationReporter().ReportSupportHelp();
+
+        act.Should().NotThrow();
+    }
+}

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -80,7 +80,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             refitGeneratorSettings = SettingsMapper.Map(settings);
         }
 
-        var reporter = CreateReporter(settings, refitGeneratorSettings);
+        IGenerationReporter reporter = CreateReporter(settings, refitGeneratorSettings);
 
         var orchestrator = new GenerationOrchestrator();
         return await orchestrator.RunAsync(

--- a/src/Refitter/GenerateCommand.cs
+++ b/src/Refitter/GenerateCommand.cs
@@ -12,10 +12,17 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
 
     private RefitGeneratorSettings? cachedSettings;
 
-    private static IGenerationReporter CreateReporter(Settings settings) =>
-        settings.SimpleOutput
+    private static IGenerationReporter CreateReporter(
+        Settings settings,
+        RefitGeneratorSettings? generatorSettings = null)
+    {
+        if (settings.Silent || generatorSettings?.Silent == true)
+            return new SilentGenerationReporter();
+
+        return settings.SimpleOutput
             ? new SimpleGenerationReporter()
             : new RichGenerationReporter();
+    }
 
     protected override ValidationResult Validate(CommandContext context, Settings settings)
     {
@@ -45,8 +52,6 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         Settings settings,
         CancellationToken cancellationToken)
     {
-        var reporter = CreateReporter(settings);
-
         if (!settings.NoLogging)
             Analytics.Configure();
 
@@ -75,6 +80,8 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
             refitGeneratorSettings = SettingsMapper.Map(settings);
         }
 
+        var reporter = CreateReporter(settings, refitGeneratorSettings);
+
         var orchestrator = new GenerationOrchestrator();
         return await orchestrator.RunAsync(
             refitGeneratorSettings,
@@ -100,7 +107,7 @@ public sealed class GenerateCommand : AsyncCommand<Settings>
         var json = Serializer.Serialize(refitGeneratorSettings);
         await File.WriteAllTextAsync(settingsFilePath, json, cancellationToken);
 
-        CreateReporter(settings).ReportSettingsFileGenerated(settingsFilePath);
+        CreateReporter(settings, refitGeneratorSettings).ReportSettingsFileGenerated(settingsFilePath);
     }
 
     internal static string DetermineSettingsFilePath(Settings settings)

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -54,7 +54,7 @@ OPTIONS:
                                                 DEFAULT
     -h, --help                                                   Prints help information
     -v, --version                                                Prints version information
-    -s, --settings-file                                          Path to .refitter settings file. Specifying this will ignore all other settings (except for --output)
+    -s, --settings-file                                          Path to .refitter settings file. Specifying this will ignore all other settings (except for --output and --silent)
     -n, --namespace                             GeneratedCode    Default namespace to use for generated types
         --contracts-namespace                                    Default namespace to use for generated contracts
     -o, --output                                Output.cs        Path to the generated file in single-file mode, or the output directory in multiple-file mode

--- a/src/Refitter/README.md
+++ b/src/Refitter/README.md
@@ -69,6 +69,7 @@ OPTIONS:
         --cancellation-tokens                                    Use cancellation tokens
         --no-operation-headers                                   Don't generate operation headers
         --no-logging                                             Don't log errors or collect telemetry
+        --silent                                                 Suppress all console output. Errors are still reported through the exit code
         --additional-namespace                                   Add additional namespace to generated types
         --exclude-namespace                                      Exclude namespace on generated types
         --use-iso-date-format                                    Explicitly format date query string parameters in ISO 8601 standard date format using delimiters (2023-06-15)

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -105,6 +105,11 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool NoLogging { get; set; }
 
+    [Description("Suppress all console output. Errors are still reported through the exit code")]
+    [CommandOption("--silent")]
+    [DefaultValue(false)]
+    public bool Silent { get; set; }
+
     /// <summary>
     /// The telemetry source of this invocation, e.g. <c>msbuild</c>. Used internally by the MSBuild integration.
     /// </summary>

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -13,7 +13,7 @@ public sealed class Settings : CommandSettings
     [DefaultValue(null)]
     public string? OpenApiPath { get; set; }
 
-    [Description("Path to .refitter settings file. Specifying this will ignore all other settings (except for --output)")]
+    [Description("Path to .refitter settings file. Specifying this will ignore all other settings (except for --output and --silent)")]
     [CommandOption("-s|--settings-file")]
     public string? SettingsFilePath { get; set; }
 
@@ -105,6 +105,11 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool NoLogging { get; set; }
 
+    /// <summary>
+    /// Suppress all console output when running the CLI tool. Errors are still reported
+    /// through the process exit code. Can also be enabled by setting <c>"silent": true</c>
+    /// in a settings file.
+    /// </summary>
     [Description("Suppress all console output. Errors are still reported through the exit code")]
     [CommandOption("--silent")]
     [DefaultValue(false)]

--- a/src/Refitter/SettingsMapper.cs
+++ b/src/Refitter/SettingsMapper.cs
@@ -23,6 +23,7 @@ internal static class SettingsMapper
         result.GenerateDeprecatedOperations = !settings.NoDeprecatedOperations;
         result.GenerateDefaultAdditionalProperties = !settings.SkipDefaultAdditionalProperties;
         result.AllowRemoteReferences = settings.AllowRemoteReferences;
+        result.Silent = settings.Silent;
         result.TypeAccessibility = settings.InternalTypeAccessibility
             ? Core.TypeAccessibility.Internal
             : Core.TypeAccessibility.Public;

--- a/src/Refitter/SilentGenerationReporter.cs
+++ b/src/Refitter/SilentGenerationReporter.cs
@@ -20,8 +20,11 @@ internal sealed class SilentGenerationReporter : IGenerationReporter
     {
     }
 
-    public Task ReportSingleFileGenerationProgressAsync(CancellationToken cancellationToken = default) =>
-        Task.CompletedTask;
+    public Task ReportSingleFileGenerationProgressAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
 
     public void ReportSingleFileOutput(string fileName, string directory, string sizeFormatted, int lines)
     {

--- a/src/Refitter/SilentGenerationReporter.cs
+++ b/src/Refitter/SilentGenerationReporter.cs
@@ -1,0 +1,114 @@
+using Microsoft.OpenApi;
+using Refitter.Core;
+using Refitter.Core.Validation;
+
+namespace Refitter;
+
+/// <summary>
+/// Reporter used with <c>--silent</c> (or <c>"silent": true</c> in a settings file).
+/// Suppresses every piece of console output while still running the generation and
+/// validation delegates wrapped by the progress methods. Errors are still surfaced
+/// through the process exit code.
+/// </summary>
+internal sealed class SilentGenerationReporter : IGenerationReporter
+{
+    public void ReportHeader(string version)
+    {
+    }
+
+    public void ReportSupportKey(string supportKey)
+    {
+    }
+
+    public Task ReportSingleFileGenerationProgressAsync(CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    public void ReportSingleFileOutput(string fileName, string directory, string sizeFormatted, int lines)
+    {
+    }
+
+    public Task<GeneratorOutput> GenerateMultipleFilesWithProgressAsync(
+        Func<GeneratorOutput> generate,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(generate());
+    }
+
+    public IMultiFileOutputReport BeginMultiFileOutput() => new SilentMultiFileOutputReport();
+
+    public void ReportFileWritten(string outputPath)
+    {
+    }
+
+    public async Task<OpenApiValidationResult> ValidateWithProgressAsync(
+        Func<Task<OpenApiValidationResult>> validate,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await validate();
+    }
+
+    public void ReportValidationFailed()
+    {
+    }
+
+    public void ReportValidationDiagnostic(OpenApiError error, bool isError)
+    {
+    }
+
+    public void ReportValidationStatistics(OpenApiValidationResult validationResult)
+    {
+    }
+
+    public void ReportSuccess(TimeSpan duration, bool multipleFiles)
+    {
+    }
+
+    public void ReportDonationBanner()
+    {
+    }
+
+    public void ReportConfigurationWarnings(IReadOnlyList<Warning> warnings)
+    {
+    }
+
+    public void ReportAllPathsFilteredWarning(IReadOnlyList<string> matchPatterns)
+    {
+    }
+
+    public void ReportSettingsFileGenerated(string settingsFilePath)
+    {
+    }
+
+    public void ReportGenerationFailed()
+    {
+    }
+
+    public void ReportUnsupportedVersion(string specificationVersion)
+    {
+    }
+
+    public void ReportExceptionDetails(Exception exception)
+    {
+    }
+
+    public void ReportSkipValidationSuggestion()
+    {
+    }
+
+    public void ReportSupportHelp()
+    {
+    }
+
+    private sealed class SilentMultiFileOutputReport : IMultiFileOutputReport
+    {
+        public void AddFile(string fileName, string directory, string sizeFormatted, int lines)
+        {
+        }
+
+        public void Complete(int fileCount, string totalSizeFormatted, int totalLines)
+        {
+        }
+    }
+}

--- a/test/Apizr/petstore.apizr.refitter
+++ b/test/Apizr/petstore.apizr.refitter
@@ -1,6 +1,7 @@
 {
   "openApiPath": "https://petstore3.swagger.io/api/v3/openapi.json",
   "namespace": "Petstore.ApizrSample",
+  "silent": true,
   "outputFolder": "GeneratedCode",
   "outputFilename": "SwaggerPetstoreApizr.generated.cs",
   "generateMultipleFiles": true,

--- a/test/MultipleFiles/petstore.refitter
+++ b/test/MultipleFiles/petstore.refitter
@@ -2,6 +2,7 @@
   "openApiPath": "https://petstore3.swagger.io/api/v3/openapi.json",
   "namespace": "Petstore",
   "contractsNamespace": "Petstore.Contracts",
+  "silent": true,
   "outputFolder": "Client",
   "contractsOutputFolder": "Contracts/",
   "generateMultipleFiles": true,

--- a/test/SourceGenerator/Directory.Build.props
+++ b/test/SourceGenerator/Directory.Build.props
@@ -16,6 +16,6 @@
         <PackageReference Include="Refit" Version="15.1.0" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-        <PackageReference Include="System.Text.Json" Version="10.0.10" />
+        <PackageReference Include="System.Text.Json" Version="10.0.11" />
     </ItemGroup>
 </Project>

--- a/test/SourceGenerator/Net6/Net6.csproj
+++ b/test/SourceGenerator/Net6/Net6.csproj
@@ -1,5 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-</Project>

--- a/test/SourceGenerator/Net7/Net7.csproj
+++ b/test/SourceGenerator/Net7/Net7.csproj
@@ -1,5 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
-</Project>

--- a/test/SourceGenerator/NetStandard20/NetStandard20.csproj
+++ b/test/SourceGenerator/NetStandard20/NetStandard20.csproj
@@ -1,5 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-</Project>

--- a/test/SourceGenerator/NetStandard21/NetStandard21.csproj
+++ b/test/SourceGenerator/NetStandard21/NetStandard21.csproj
@@ -1,5 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-  </PropertyGroup>
-</Project>

--- a/test/SourceGenerator/SourceGenerator.slnx
+++ b/test/SourceGenerator/SourceGenerator.slnx
@@ -3,9 +3,5 @@
   <Project Path="Net472/Net472.csproj" />
   <Project Path="Net48/Net48.csproj" />
   <Project Path="Net481/Net481.csproj" />
-  <Project Path="Net6/Net6.csproj" />
-  <Project Path="Net7/Net7.csproj" />
   <Project Path="Net8/Net8.csproj" />
-  <Project Path="NetStandard20/NetStandard20.csproj" />
-  <Project Path="NetStandard21/NetStandard21.csproj" />
 </Solution>

--- a/test/Streaming/.refitter
+++ b/test/Streaming/.refitter
@@ -1,6 +1,7 @@
 {
   "openApiPath": "../OpenAPI/v3.1/lmstudio.json",
   "namespace": "Test",
+  "silent": true,
   "naming": {
     "useOpenApiTitle": true,
     "interfaceName": "ApiClient"

--- a/test/multiple-sources.refitter
+++ b/test/multiple-sources.refitter
@@ -7,6 +7,7 @@
     "OpenAPI/v3.0/economic-webhooks.json"
   ],
   "namespace": "MultipleSources",
+  "silent": true,
   "outputFolder": "GeneratedCode",
   "multipleInterfaces": "bytag"
 }

--- a/test/petstore.refitter
+++ b/test/petstore.refitter
@@ -2,6 +2,7 @@
   "openApiPath": "./OpenAPI/v3.0/petstore.json",
   "namespace": "Petstore",
   "contractsNamespace": "Petstore.Contracts",
+  "silent": true,
   "outputFolder": "GeneratedCode",
   "contractsOutputFolder": "GeneratedCode/Contracts/",
   "outputFilename": "SwaggerPetstoreDirect.cs",

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -7,18 +7,60 @@ param (
     [switch]
     $UseDocker = $false,
 
+    # Show progress output from this script and all child processes.
+    # By default, output is suppressed and only a final summary is printed.
+    [Parameter(Mandatory=$false)]
+    [switch]
+    $Verbose = $false,
+
     # Kept for backward compatibility
     [Parameter(Mandatory=$false)]
     [bool]
     $Parallel = $true
 )
 
-function ThrowOnNativeFailure
+$script:ChildLogDirectory = Join-Path $env:TEMP "refitter-smoke-tests-$([guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $script:ChildLogDirectory -Force | Out-Null
+
+function Invoke-ChildProcess
 {
-    if (-not $?)
+    param (
+        [string]$FilePath,
+        [string]$Arguments,
+        [string]$Description
+    )
+
+    Write-Verbose "$FilePath $Arguments"
+
+    if ($Verbose)
     {
-        throw "Native Failure"
+        $p = Start-Process $FilePath -Args $Arguments -NoNewWindow -PassThru
+        $p | Wait-Process
+        return $p.ExitCode
     }
+
+    $stdoutLog = Join-Path $script:ChildLogDirectory "$([guid]::NewGuid().ToString('N')).log"
+    $stderrLog = "$stdoutLog.err"
+    $p = Start-Process $FilePath -Args $Arguments -NoNewWindow -RedirectStandardOutput $stdoutLog -RedirectStandardError $stderrLog -PassThru
+    $p | Wait-Process
+
+    if ($p.ExitCode -ne 0)
+    {
+        Write-Host "FAILED: $Description (exit code $($p.ExitCode))"
+        Write-Host "Command: $FilePath $Arguments"
+        if (Test-Path $stdoutLog)
+        {
+            Write-Host "-- stdout --"
+            Get-Content $stdoutLog -Tail 60 | ForEach-Object { Write-Host $_ }
+        }
+        if (Test-Path $stderrLog)
+        {
+            Write-Host "-- stderr --"
+            Get-Content $stderrLog -Tail 60 | ForEach-Object { Write-Host $_ }
+        }
+    }
+
+    return $p.ExitCode
 }
 
 function GetProcessPath([bool]$buildFromSource, [bool]$useDocker)
@@ -51,18 +93,19 @@ function StartRefitter
         [bool]$useDocker = $false
     )
 
+    if (-not $Verbose)
+    {
+        $arguments += " --silent"
+    }
+
     if ($useDocker)
     {
         $dockerPrefix = BuildDockerPrefix
         $fullArgs = "$dockerPrefix $arguments"
-        Write-Host "docker $fullArgs"
-        Start-Process "docker" -Args $fullArgs -NoNewWindow -PassThru
+        return Invoke-ChildProcess -FilePath "docker" -Arguments $fullArgs -Description "refitter"
     }
-    else
-    {
-        Write-Host "$processPath $arguments"
-        Start-Process $processPath -Args $arguments -NoNewWindow -PassThru
-    }
+
+    return Invoke-ChildProcess -FilePath $processPath -Arguments $arguments -Description "refitter"
 }
 
 function GenerateFromSettingsFile
@@ -73,12 +116,11 @@ function GenerateFromSettingsFile
         [bool]$useDocker = $false
     )
 
-    $p = StartRefitter `
+    $exitCode = StartRefitter `
         -arguments "--no-logging --settings-file $settingsFile" `
         -processPath $processPath `
         -useDocker $useDocker
-    $p | Wait-Process
-    if ($p.ExitCode -ne 0) { throw "Refitter failed for settings file: $settingsFile" }
+    if ($exitCode -ne 0) { throw "Refitter failed for settings file: $settingsFile" }
 }
 
 function BuildSolution
@@ -93,10 +135,9 @@ function BuildSolution
     if ($noRestore) { $buildArgs += " --no-restore" }
     if ($smokeTest) { $buildArgs += " --property:SmokeTest=true" }
 
-    Write-Host "`r`nBuilding $solution`r`n"
-    $p = Start-Process "dotnet" -Args $buildArgs -NoNewWindow -PassThru
-    $p | Wait-Process
-    if ($p.ExitCode -ne 0) { throw "Build Failed: $solution" }
+    Write-Verbose "Building $solution"
+    $exitCode = Invoke-ChildProcess -FilePath "dotnet" -Arguments $buildArgs -Description "Build $solution"
+    if ($exitCode -ne 0) { throw "Build Failed: $solution" }
 }
 
 function CleanGeneratedCode
@@ -132,9 +173,8 @@ function RunGenerationTasks
         $task = $tasks[$i]
         $arguments = "$($task.SpecPath) --namespace $($task.Namespace) --output $($task.OutputPath) --no-logging"
         if ($task.Args) { $arguments += " $($task.Args)" }
-        $p = StartRefitter -arguments $arguments -processPath $processPath -useDocker $useDocker
-        $p | Wait-Process
-        if ($p.ExitCode -ne 0) { throw "Refitter generation failed for: $($task.SpecPath) ($($task.Namespace))" }
+        $exitCode = StartRefitter -arguments $arguments -processPath $processPath -useDocker $useDocker
+        if ($exitCode -ne 0) { throw "Refitter generation failed for: $($task.SpecPath) ($($task.Namespace))" }
     }
 }
 
@@ -222,27 +262,32 @@ function RunTests
     # ==========================================
     if ($BuildFromSource -and -not $UseDocker)
     {
-        Write-Host "dotnet publish ../src/Refitter/Refitter.csproj -c Release -o bin -f net10.0"
-        Start-Process "dotnet" -Args "publish ../src/Refitter/Refitter.csproj -c Release -o bin -f net10.0" -NoNewWindow -PassThru | Wait-Process
+        Write-Verbose "dotnet publish ../src/Refitter/Refitter.csproj -c Release -o bin -f net10.0"
+        $exitCode = Invoke-ChildProcess `
+            -FilePath "dotnet" `
+            -Arguments "publish ../src/Refitter/Refitter.csproj -c Release -o bin -f net10.0 --nologo -v q" `
+            -Description "dotnet publish"
+        if ($exitCode -ne 0) { throw "Publish failed!" }
 
-        Write-Host "refitter --version"
-        $p = Start-Process "./bin/refitter" -Args "--version" -NoNewWindow -PassThru
-        $p | Wait-Process
-        if ($p.ExitCode -ne 0) { throw "Show version failed!" }
+        $exitCode = Invoke-ChildProcess `
+            -FilePath "./bin/refitter" `
+            -Arguments "--version" `
+            -Description "refitter --version"
+        if ($exitCode -ne 0) { throw "Show version failed!" }
     }
 
     # ==========================================
     # Phase 1: Pre-restore packages
     # ==========================================
-    Write-Host "`r`n=== Pre-restoring packages ===`r`n"
-    Start-Process "dotnet" -Args "restore ./ConsoleApp/ConsoleApp.slnx --nologo -v q" -NoNewWindow -PassThru | Wait-Process
-    Start-Process "dotnet" -Args "restore ./ConsoleApp/ConsoleApp.Core.slnx --nologo -v q" -NoNewWindow -PassThru | Wait-Process
-    Start-Process "dotnet" -Args "restore ./Apizr/Sample.csproj --nologo -v q" -NoNewWindow -PassThru | Wait-Process
+    Write-Verbose "Pre-restoring packages"
+    Invoke-ChildProcess -FilePath "dotnet" -Arguments "restore ./ConsoleApp/ConsoleApp.slnx --nologo -v q" -Description "restore ConsoleApp.slnx" | Out-Null
+    Invoke-ChildProcess -FilePath "dotnet" -Arguments "restore ./ConsoleApp/ConsoleApp.Core.slnx --nologo -v q" -Description "restore ConsoleApp.Core.slnx" | Out-Null
+    Invoke-ChildProcess -FilePath "dotnet" -Arguments "restore ./Apizr/Sample.csproj --nologo -v q" -Description "restore Apizr/Sample.csproj" | Out-Null
 
     # ==========================================
     # Phase 2: Settings-file tests (individual generate + build)
     # ==========================================
-    Write-Host "`r`n=== Settings-file tests ===`r`n"
+    Write-Verbose "Settings-file tests"
 
     CleanGeneratedCode
     GenerateFromSettingsFile -settingsFile "./petstore.refitter" -processPath $processPath -useDocker $UseDocker
@@ -266,7 +311,7 @@ function RunTests
     # ==========================================
     # Phase 3: Generate all STANDARD variants (no build until all are generated)
     # ==========================================
-    Write-Host "`r`n=== Generating standard variants ===`r`n"
+    Write-Verbose "Generating standard variants"
     CleanGeneratedCode
 
     $standardTasks = @()
@@ -465,8 +510,8 @@ function RunTests
         }
     }
 
-    Write-Host "Standard generation tasks: $($standardTasks.Count)"
-    Write-Host "NetCore generation tasks: $($netCoreTasks.Count)"
+    Write-Verbose "Standard generation tasks: $($standardTasks.Count)"
+    Write-Verbose "NetCore generation tasks: $($netCoreTasks.Count)"
 
     # Execute standard generation in parallel batches
     RunGenerationTasks -tasks $standardTasks -processPath $processPath -useDocker $UseDocker
@@ -474,7 +519,7 @@ function RunTests
     # ==========================================
     # Phase 4: Build standard variants (one build validates all)
     # ==========================================
-    Write-Host "`r`n=== Building standard variants ===`r`n"
+    Write-Verbose "Building standard variants"
     BuildSolution -solution "./ConsoleApp/ConsoleApp.slnx" -noRestore -smokeTest
 
     # ==========================================
@@ -482,45 +527,41 @@ function RunTests
     # This variant uses --multiple-interfaces ByEndpoint --operation-name-template which
     # generates duplicate types per-endpoint (known limitation). We verify generation succeeds.
     # ==========================================
-    Write-Host "`r`n=== Generate-only: MultipleInterfacesWithCustomName (petstore) ===`r`n"
+    Write-Verbose "Generate-only: MultipleInterfacesWithCustomName (petstore)"
     $customNameSpec = "./OpenAPI/v3.0/petstore.json"
     $customNameArgs = "--multiple-interfaces ByEndpoint --operation-name-template ExecuteAsync"
     $customNameOutput = "./GeneratedCode/MultipleInterfacesWithCustomName_generateonly.cs"
     $customNameInvocation = "$customNameSpec --namespace GenerateOnly.MultipleInterfacesWithCustomName --output $customNameOutput --no-logging $customNameArgs"
-    $p = StartRefitter `
+    $exitCode = StartRefitter `
         -arguments $customNameInvocation `
         -processPath $processPath `
         -useDocker $UseDocker
-    $p | Wait-Process
-    if ($p.ExitCode -ne 0) { throw "Generate-only test failed: MultipleInterfacesWithCustomName; exit code $($p.ExitCode)" }
+    if ($exitCode -ne 0) { throw "Generate-only test failed: MultipleInterfacesWithCustomName; exit code $exitCode" }
     if (-not (Test-Path $customNameOutput)) { throw "Generate-only test failed: MultipleInterfacesWithCustomName" }
     Remove-Item $customNameOutput -Force
-    Write-Host "Generate-only test passed: MultipleInterfacesWithCustomName"
+    Write-Verbose "Generate-only test passed: MultipleInterfacesWithCustomName"
 
     # ==========================================
     # Phase 5: Generate netCore variants (accumulate on top of standard code)
     # Net8/Net9/Net10 can compile both standard and netCore code
     # ==========================================
-    Write-Host "`r`n=== Generating netCore variants ===`r`n"
+    Write-Verbose "Generating netCore variants"
     RunGenerationTasks -tasks $netCoreTasks -processPath $processPath -useDocker $UseDocker
 
     # ==========================================
     # Phase 6: Build netCore variants
     # ==========================================
-    Write-Host "`r`n=== Building netCore variants ===`r`n"
+    Write-Verbose "Building netCore variants"
     BuildSolution -solution "./ConsoleApp/ConsoleApp.Core.slnx" -noRestore -smokeTest
 
     # ==========================================
     # Phase 7: URL-based tests (network-dependent)
     # ==========================================
-    Write-Host "`r`n=== URL-based tests ===`r`n"
+    Write-Verbose "URL-based tests"
     CleanGeneratedCode
 
     @("https://petstore3.swagger.io/api/v3/openapi.json", "https://petstore3.swagger.io/api/v3/openapi.yaml") | ForEach-Object {
         $url = $_
-        $urlFormat = if ($url.EndsWith(".json")) { "json" } else { "yaml" }
-        $namespace = "PetstoreFromUri"
-        $outputPath = "PetstoreFromUri.generated.cs"
 
         try {
             Get-ChildItem './GeneratedCode/*.cs' -Recurse -ErrorAction Stop |
@@ -530,12 +571,11 @@ function RunTests
             # Ignore not-found errors (path/file doesn't exist yet)
         }
 
-        $p = StartRefitter `
-            -arguments """$url"" --namespace $namespace --output ./GeneratedCode/$outputPath --no-logging" `
+        $exitCode = StartRefitter `
+            -arguments """$url"" --namespace PetstoreFromUri --output ./GeneratedCode/PetstoreFromUri.generated.cs --no-logging" `
             -processPath $processPath `
             -useDocker $UseDocker
-        $p | Wait-Process
-        if ($p.ExitCode -ne 0) { throw "Refitter failed for URL: $url" }
+        if ($exitCode -ne 0) { throw "Refitter failed for URL: $url" }
 
         BuildSolution -solution "./ConsoleApp/ConsoleApp.slnx" -noRestore
     }
@@ -543,7 +583,7 @@ function RunTests
     # ==========================================
     # Phase 8: Operation Name Generator Tests
     # ==========================================
-    Write-Host "`r`n=== Operation Name Generator Tests ===`r`n"
+    Write-Verbose "Operation Name Generator Tests"
 
     $opNameGenerators = @(
         "Default",
@@ -560,9 +600,8 @@ function RunTests
     foreach ($gen in $opNameGenerators)
     {
         $genArgs = "./OpenAPI/v3.0/petstore.json --namespace OpNameGen_$gen --output ./GeneratedCode/OpNameGen_$gen.generated.cs --no-logging --operation-name-generator $gen"
-        $p = StartRefitter -arguments $genArgs -processPath $processPath -useDocker $UseDocker
-        $p | Wait-Process
-        if ($p.ExitCode -ne 0) { Write-Warning "Operation name generator '$gen' failed (may be expected for some generators)" }
+        $exitCode = StartRefitter -arguments $genArgs -processPath $processPath -useDocker $UseDocker
+        if ($exitCode -ne 0) { Write-Verbose "Operation name generator '$gen' failed (may be expected for some generators)" }
     }
     # Build only what was successfully generated
     if (Test-Path './GeneratedCode/OpNameGen_*.generated.cs') {
@@ -572,7 +611,7 @@ function RunTests
     # ==========================================
     # Phase 9: Collection Format Variant Tests
     # ==========================================
-    Write-Host "`r`n=== Collection Format Variant Tests ===`r`n"
+    Write-Verbose "Collection Format Variant Tests"
 
     $collectionFormats = @("Multi", "Ssv", "Tsv", "Pipes")
 
@@ -580,16 +619,15 @@ function RunTests
     foreach ($fmt in $collectionFormats)
     {
         $fmtArgs = "./OpenAPI/v3.0/petstore.json --namespace CollFmt_$fmt --output ./GeneratedCode/CollFmt_$fmt.generated.cs --no-logging --collection-format $fmt"
-        $p = StartRefitter -arguments $fmtArgs -processPath $processPath -useDocker $UseDocker
-        $p | Wait-Process
-        if ($p.ExitCode -ne 0) { throw "Collection format '$fmt' generation failed" }
+        $exitCode = StartRefitter -arguments $fmtArgs -processPath $processPath -useDocker $UseDocker
+        if ($exitCode -ne 0) { throw "Collection format '$fmt' generation failed" }
     }
     BuildSolution -solution "./ConsoleApp/ConsoleApp.Core.slnx" -noRestore -smokeTest
 
     # ==========================================
     # Phase 10: Combination Tests
     # ==========================================
-    Write-Host "`r`n=== Combination Tests ===`r`n"
+    Write-Verbose "Combination Tests"
 
     CleanGeneratedCode
     $combinationTasks = @(
@@ -630,9 +668,8 @@ function RunTests
             $output = $combo.Output
         }
         $fullArgs = "$($combo.Spec) --namespace $ns --output $output --no-logging $($combo.Args)"
-        $p = StartRefitter -arguments $fullArgs -processPath $processPath -useDocker $UseDocker
-        $p | Wait-Process
-        if ($p.ExitCode -ne 0) { throw "Combination test '$($combo.Name)' generation failed" }
+        $exitCode = StartRefitter -arguments $fullArgs -processPath $processPath -useDocker $UseDocker
+        if ($exitCode -ne 0) { throw "Combination test '$($combo.Name)' generation failed" }
     }
     BuildSolution -solution "./ConsoleApp/ConsoleApp.Core.slnx" -noRestore -smokeTest
 
@@ -644,38 +681,40 @@ function RunTests
     # OpenAPI/v3.0/asana.yaml to avoid transient HTTP errors. Generate
     # with default settings and build once to guard against regressions.
     # ==========================================
-    Write-Host "`r`n=== Asana API regression test (issue #359) ===`r`n"
+    Write-Verbose "Asana API regression test (issue #359)"
 
     CleanGeneratedCode
     $asanaArgs = "./OpenAPI/v3.0/asana.yaml --namespace Asana --output ./GeneratedCode/Asana.generated.cs --no-logging"
-    $p = StartRefitter -arguments $asanaArgs -processPath $processPath -useDocker $UseDocker
-    $p | Wait-Process
-    if ($p.ExitCode -ne 0) { throw "Asana API generation failed (issue #359 regression)" }
+    $exitCode = StartRefitter -arguments $asanaArgs -processPath $processPath -useDocker $UseDocker
+    if ($exitCode -ne 0) { throw "Asana API generation failed (issue #359 regression)" }
     BuildSolution -solution "./ConsoleApp/ConsoleApp.Core.slnx" -noRestore -smokeTest
 }
 
 if ($UseProduction)
 {
-    Write-Host "Running smoke tests in production mode"
-    Write-Host "dotnet tool update -g refitter --prerelease"
-    Start-Process "dotnet" -Args "tool update -g refitter --prerelease" -NoNewWindow -PassThru | Wait-Process
-    ThrowOnNativeFailure
-    Write-Host "`r`n"
+    Write-Verbose "Running smoke tests in production mode"
+    Invoke-ChildProcess -FilePath "dotnet" -Arguments "tool update -g refitter --prerelease -v q" -Description "dotnet tool update -g refitter --prerelease" | Out-Null
 }
 
 if ($UseDocker)
 {
-    Write-Host "Running smoke tests in Docker mode"
-    Write-Host "docker pull christianhelle/refitter:latest"
-    Start-Process "docker" -Args "pull christianhelle/refitter:latest" -NoNewWindow -PassThru | Wait-Process
-    ThrowOnNativeFailure
-    Write-Host "`r`n"
+    Write-Verbose "Running smoke tests in Docker mode"
+    Invoke-ChildProcess -FilePath "docker" -Arguments "pull christianhelle/refitter:latest" -Description "docker pull christianhelle/refitter:latest" | Out-Null
 }
 
-Measure-Command {
-    RunTests `
-        -BuildFromSource (-not $UseProduction -and -not $UseDocker) `
-        -UseDocker $UseDocker
+try
+{
+    $totalTime = Measure-Command {
+        RunTests `
+            -BuildFromSource (-not $UseProduction -and -not $UseDocker) `
+            -UseDocker $UseDocker
+    }
+    Write-Host "Smoke tests passed in $([math]::Round($totalTime.TotalSeconds, 1)) seconds"
 }
-Write-Host "`r`n"
-Write-Host "`r`n"
+finally
+{
+    if (Test-Path $script:ChildLogDirectory)
+    {
+        Remove-Item -Path $script:ChildLogDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -1,3 +1,4 @@
+[CmdletBinding()]
 param (
     [Parameter(Mandatory=$false)]
     [switch]
@@ -7,17 +8,15 @@ param (
     [switch]
     $UseDocker = $false,
 
-    # Show progress output from this script and all child processes.
-    # By default, output is suppressed and only a final summary is printed.
-    [Parameter(Mandatory=$false)]
-    [switch]
-    $Verbose = $false,
-
     # Kept for backward compatibility
     [Parameter(Mandatory=$false)]
     [bool]
     $Parallel = $true
 )
+
+# Output is suppressed by default. Pass -Verbose to show progress output
+# from this script and all child processes.
+$script:VerboseOutput = $VerbosePreference -eq "Continue"
 
 $script:ChildLogDirectory = Join-Path $env:TEMP "refitter-smoke-tests-$([guid]::NewGuid().ToString('N'))"
 New-Item -ItemType Directory -Path $script:ChildLogDirectory -Force | Out-Null
@@ -32,7 +31,7 @@ function Invoke-ChildProcess
 
     Write-Verbose "$FilePath $Arguments"
 
-    if ($Verbose)
+    if ($script:VerboseOutput)
     {
         $p = Start-Process $FilePath -Args $Arguments -NoNewWindow -PassThru
         $p | Wait-Process
@@ -93,7 +92,7 @@ function StartRefitter
         [bool]$useDocker = $false
     )
 
-    if (-not $Verbose)
+    if (-not $script:VerboseOutput)
     {
         $arguments += " --silent"
     }

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -18,7 +18,7 @@ param (
 # from this script and all child processes.
 $script:VerboseOutput = $VerbosePreference -eq "Continue"
 
-$script:ChildLogDirectory = Join-Path $env:TEMP "refitter-smoke-tests-$([guid]::NewGuid().ToString('N'))"
+$script:ChildLogDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "refitter-smoke-tests-$([guid]::NewGuid().ToString('N'))"
 New-Item -ItemType Directory -Path $script:ChildLogDirectory -Force | Out-Null
 
 function Invoke-ChildProcess
@@ -279,9 +279,12 @@ function RunTests
     # Phase 1: Pre-restore packages
     # ==========================================
     Write-Verbose "Pre-restoring packages"
-    Invoke-ChildProcess -FilePath "dotnet" -Arguments "restore ./ConsoleApp/ConsoleApp.slnx --nologo -v q" -Description "restore ConsoleApp.slnx" | Out-Null
-    Invoke-ChildProcess -FilePath "dotnet" -Arguments "restore ./ConsoleApp/ConsoleApp.Core.slnx --nologo -v q" -Description "restore ConsoleApp.Core.slnx" | Out-Null
-    Invoke-ChildProcess -FilePath "dotnet" -Arguments "restore ./Apizr/Sample.csproj --nologo -v q" -Description "restore Apizr/Sample.csproj" | Out-Null
+    $exitCode = Invoke-ChildProcess -FilePath "dotnet" -Arguments "restore ./ConsoleApp/ConsoleApp.slnx --nologo -v q" -Description "restore ConsoleApp.slnx"
+    if ($exitCode -ne 0) { throw "Restore failed: ConsoleApp.slnx" }
+    $exitCode = Invoke-ChildProcess -FilePath "dotnet" -Arguments "restore ./ConsoleApp/ConsoleApp.Core.slnx --nologo -v q" -Description "restore ConsoleApp.Core.slnx"
+    if ($exitCode -ne 0) { throw "Restore failed: ConsoleApp.Core.slnx" }
+    $exitCode = Invoke-ChildProcess -FilePath "dotnet" -Arguments "restore ./Apizr/Sample.csproj --nologo -v q" -Description "restore Apizr/Sample.csproj"
+    if ($exitCode -ne 0) { throw "Restore failed: Apizr/Sample.csproj" }
 
     # ==========================================
     # Phase 2: Settings-file tests (individual generate + build)
@@ -692,13 +695,15 @@ function RunTests
 if ($UseProduction)
 {
     Write-Verbose "Running smoke tests in production mode"
-    Invoke-ChildProcess -FilePath "dotnet" -Arguments "tool update -g refitter --prerelease -v q" -Description "dotnet tool update -g refitter --prerelease" | Out-Null
+    $exitCode = Invoke-ChildProcess -FilePath "dotnet" -Arguments "tool update -g refitter --prerelease -v q" -Description "dotnet tool update -g refitter --prerelease"
+    if ($exitCode -ne 0) { throw "Production tool update failed" }
 }
 
 if ($UseDocker)
 {
     Write-Verbose "Running smoke tests in Docker mode"
-    Invoke-ChildProcess -FilePath "docker" -Arguments "pull christianhelle/refitter:latest" -Description "docker pull christianhelle/refitter:latest" | Out-Null
+    $exitCode = Invoke-ChildProcess -FilePath "docker" -Arguments "pull christianhelle/refitter:latest" -Description "docker pull christianhelle/refitter:latest"
+    if ($exitCode -ne 0) { throw "Docker image pull failed" }
 }
 
 try

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -692,22 +692,22 @@ function RunTests
     BuildSolution -solution "./ConsoleApp/ConsoleApp.Core.slnx" -noRestore -smokeTest
 }
 
-if ($UseProduction)
-{
-    Write-Verbose "Running smoke tests in production mode"
-    $exitCode = Invoke-ChildProcess -FilePath "dotnet" -Arguments "tool update -g refitter --prerelease -v q" -Description "dotnet tool update -g refitter --prerelease"
-    if ($exitCode -ne 0) { throw "Production tool update failed" }
-}
-
-if ($UseDocker)
-{
-    Write-Verbose "Running smoke tests in Docker mode"
-    $exitCode = Invoke-ChildProcess -FilePath "docker" -Arguments "pull christianhelle/refitter:latest" -Description "docker pull christianhelle/refitter:latest"
-    if ($exitCode -ne 0) { throw "Docker image pull failed" }
-}
-
 try
 {
+    if ($UseProduction)
+    {
+        Write-Verbose "Running smoke tests in production mode"
+        $exitCode = Invoke-ChildProcess -FilePath "dotnet" -Arguments "tool update -g refitter --prerelease -v q" -Description "dotnet tool update -g refitter --prerelease"
+        if ($exitCode -ne 0) { throw "Production tool update failed" }
+    }
+
+    if ($UseDocker)
+    {
+        Write-Verbose "Running smoke tests in Docker mode"
+        $exitCode = Invoke-ChildProcess -FilePath "docker" -Arguments "pull christianhelle/refitter:latest" -Description "docker pull christianhelle/refitter:latest"
+        if ($exitCode -ne 0) { throw "Docker image pull failed" }
+    }
+
     $totalTime = Measure-Command {
         RunTests `
             -BuildFromSource (-not $UseProduction -and -not $UseDocker) `


### PR DESCRIPTION
## Summary

Adds a `--silent` CLI option (and a `"silent": true` settings-file property) that suppresses all console output from Refitter. This keeps `test/smoke-tests.ps1` from flooding the output window when run by AI agents or CI — it now produces only a one-line summary by default and streams full output when invoked with `-Verbose`.

## Changes

- **Refitter.Core**: new `Silent` property on `RefitGeneratorSettings`, serialized as `"silent"` in `.refitter` files
- **Refitter CLI**: new `--silent` option on `Settings`; new `SilentGenerationReporter` (no-op `IGenerationReporter`); `GenerateCommand` selects the reporter after loading generator settings so either the CLI flag or the settings file can enable silent mode
- **test/smoke-tests.ps1**: `[CmdletBinding()]` + `-Verbose`; output suppressed by default, child-process stdout/stderr redirected to temp logs (printed only on failure); refitter invocations append `--silent` when not verbose
- **Smoke test fixtures**: `petstore.refitter`, `Apizr`, `MultipleFiles`, `multiple-sources`, `Streaming` now set `"silent": true`
- **Docs**: CLI arg tables (README, cli-tool, docker, docker-hub) and `.refitter` file-format docs updated

## Verification

- 2344 unit tests pass
- Full smoke test ran silently in 590s producing exactly one line: `Smoke tests passed in 590 seconds`
- CLI `--silent`: 0 bytes output vs 3591 bytes without; settings-file `silent: true` verified silent too

TDD: tests written first for each change (serializer round-trip, `Settings` defaults, reporter delegate-wrapping, end-to-end `Program_Main` no-output tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `--silent` option to suppress console output during generation.
  - Errors continue to be reported through the process exit code.
  - Added configuration-file support for silent mode, defaulting to `false`.
  - Silent mode remains effective when using `--settings-file`.

- **Documentation**
  - Updated CLI, Docker, and configuration documentation with usage details and examples.

- **Tests**
  - Added coverage for silent operation, configuration handling, defaults, and successful generation without console output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->