### PR TITLE
Fix exit code, streaming, and accept header bugs

### DIFF
--- a/src/Refitter.Core/Generation/MethodAttributeGenerator.cs
+++ b/src/Refitter.Core/Generation/MethodAttributeGenerator.cs
@@ -33,11 +33,7 @@ internal class MethodAttributeGenerator(
                 // Responses declared as a $ref to a shared component carry no inline
                 // content, so resolve through ActualResponse the way the return type
                 // generator does - otherwise the Accept header is silently omitted.
-                var content = response.ActualResponse?.Content;
-                if (content == null)
-                    continue;
-
-                foreach (var contentType in content.Keys)
+                foreach (var contentType in response.ActualResponse.Content.Keys)
                 {
                     uniqueContentTypes.Add(contentType);
                 }

--- a/src/Refitter.Core/Generation/MethodAttributeGenerator.cs
+++ b/src/Refitter.Core/Generation/MethodAttributeGenerator.cs
@@ -30,10 +30,14 @@ internal class MethodAttributeGenerator(
             var uniqueContentTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var response in operation.Responses.Values)
             {
-                if (response.Content == null)
+                // Responses declared as a $ref to a shared component carry no inline
+                // content, so resolve through ActualResponse the way the return type
+                // generator does - otherwise the Accept header is silently omitted.
+                var content = response.ActualResponse?.Content;
+                if (content == null)
                     continue;
 
-                foreach (var contentType in response.Content.Keys)
+                foreach (var contentType in content.Keys)
                 {
                     uniqueContentTypes.Add(contentType);
                 }

--- a/src/Refitter.Core/Generation/ReturnTypeGenerator.cs
+++ b/src/Refitter.Core/Generation/ReturnTypeGenerator.cs
@@ -137,7 +137,11 @@ internal class ReturnTypeGenerator(
                 }
             }
 
-            if (operation.ActualProduces.Any(IsStreamingContentType))
+            // Swagger 2.0 has no per-media-type schema, so the produces list is the only
+            // signal. A document-level produces list applies to every operation, so require
+            // all of them to be streaming - otherwise a single streaming entry alongside
+            // application/json would turn every operation in the document into a stream.
+            if (IsStreamingOnly(operation.ActualProduces))
             {
                 schema = response.Schema;
                 return true;
@@ -146,6 +150,23 @@ internal class ReturnTypeGenerator(
 
         schema = null;
         return false;
+    }
+
+    private static bool IsStreamingOnly(IEnumerable<string>? produces)
+    {
+        if (produces is null)
+            return false;
+
+        bool any = false;
+        foreach (string contentType in produces)
+        {
+            if (!IsStreamingContentType(contentType))
+                return false;
+
+            any = true;
+        }
+
+        return any;
     }
 
     private static bool IsStreamingContentType(string contentType)

--- a/src/Refitter.Core/Generation/ReturnTypeGenerator.cs
+++ b/src/Refitter.Core/Generation/ReturnTypeGenerator.cs
@@ -152,11 +152,8 @@ internal class ReturnTypeGenerator(
         return false;
     }
 
-    private static bool IsStreamingOnly(IEnumerable<string>? produces)
+    private static bool IsStreamingOnly(IEnumerable<string> produces)
     {
-        if (produces is null)
-            return false;
-
         bool any = false;
         foreach (string contentType in produces)
         {

--- a/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.SourceGenerator.Tests/Build/ProjectFileContents.cs
@@ -11,7 +11,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.2.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -40,7 +40,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.2.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />

--- a/src/Refitter.Tests/Build/ProjectFileContents.cs
+++ b/src/Refitter.Tests/Build/ProjectFileContents.cs
@@ -11,7 +11,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.2.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -41,7 +41,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.2.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -70,7 +70,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.2.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -100,7 +100,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.2.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""8.0.5"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -129,7 +129,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.2.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
@@ -159,7 +159,7 @@ public static class ProjectFileContents
     <NoWarn>NU1510;NU1903;CS1573;CS1591;SYSLIB1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.1.0"" />
+    <PackageReference Include=""Refit.HttpClientFactory"" Version=""15.2.0"" />
     <PackageReference Include=""System.Text.Json"" Version=""10.0.0"" />
     <PackageReference Include=""System.ComponentModel.Annotations"" Version=""5.0.0"" />
     <PackageReference Include=""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />

--- a/src/Refitter.Tests/GenerationOrchestratorTests.cs
+++ b/src/Refitter.Tests/GenerationOrchestratorTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
 using Refitter.Core;
 using Refitter.Core.Validation;
 
@@ -903,6 +904,55 @@ public class GenerationOrchestratorTests
             if (Directory.Exists(workspace))
                 Directory.Delete(workspace, recursive: true);
         }
+    }
+
+    [Test]
+    public void ReportValidationDiagnostics_Reports_Both_Errors_And_Warnings()
+    {
+        OpenApiDiagnostic diagnostic = new OpenApiDiagnostic();
+        diagnostic.Errors.Add(new OpenApiError("error-pointer", "an error"));
+        diagnostic.Warnings.Add(new OpenApiError("warning-pointer", "a warning"));
+
+        OpenApiValidationException exception = new OpenApiValidationException(
+            new OpenApiValidationResult(diagnostic, new OpenApiStats()));
+
+        CapturingGenerationReporter reporter = new CapturingGenerationReporter();
+        GenerationOrchestrator.ReportValidationDiagnostics(reporter, exception);
+
+        reporter.ValidationFailedCalled.Should().BeTrue();
+        reporter.ValidationDiagnostics.Should().HaveCount(2);
+        reporter.ValidationDiagnostics
+            .Should().ContainSingle(d => d.IsError && d.Error.Message == "an error");
+        reporter.ValidationDiagnostics
+            .Should().ContainSingle(d => !d.IsError && d.Error.Message == "a warning");
+    }
+
+    [Test]
+    public void ReportValidationDiagnostics_Reports_Failure_When_There_Are_No_Diagnostics()
+    {
+        OpenApiValidationException exception = new OpenApiValidationException(
+            new OpenApiValidationResult(new OpenApiDiagnostic(), new OpenApiStats()));
+
+        CapturingGenerationReporter reporter = new CapturingGenerationReporter();
+        GenerationOrchestrator.ReportValidationDiagnostics(reporter, exception);
+
+        reporter.ValidationFailedCalled.Should().BeTrue();
+        reporter.ValidationDiagnostics.Should().BeEmpty();
+    }
+
+    [Test]
+    [Arguments(unchecked((int)0x80131500), 1)]
+    [Arguments(0, 1)]
+    [Arguments(unchecked((int)0x80131509), unchecked((int)0x80131509))]
+    [Arguments(unchecked((int)0x80070002), unchecked((int)0x80070002))]
+    public void ToProcessExitCode_Never_Truncates_To_Success(int hresult, int expected)
+    {
+        Exception exception = new Exception("boom") { HResult = hresult };
+
+        int result = GenerationOrchestrator.ToProcessExitCode(exception);
+
+        result.Should().Be(expected);
+        (result & 0xFF).Should().NotBe(0);
     }
 
     /// <summary>

--- a/src/Refitter.Tests/GenerationOrchestratorTests.cs
+++ b/src/Refitter.Tests/GenerationOrchestratorTests.cs
@@ -839,6 +839,72 @@ public class GenerationOrchestratorTests
         }
     }
 
+    [Test]
+    public async Task RunAsync_Should_Report_Validation_Diagnostics_When_Validation_Fails()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "GenerationOrchestratorTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var openApiPath = Path.Combine(workspace, "spec.json");
+            var outputPath = Path.Combine(workspace, "Output.cs");
+            Directory.CreateDirectory(workspace);
+
+            File.WriteAllText(
+                openApiPath,
+                """
+                {
+                  "openapi": "3.0.0",
+                  "info": { "title": "Test API", "version": "1.0.0" },
+                  "paths": {
+                    "/pets": {
+                      "get": {
+                        "operationId": "GetPets",
+                        "parameters": [
+                          { "name": "X-Bad\", \"Injected: yes", "in": "header", "schema": { "type": "string" } }
+                        ],
+                        "responses": { "200": { "description": "ok" } }
+                      }
+                    }
+                  }
+                }
+                """);
+
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+            };
+
+            var cliSettings = new Settings
+            {
+                OpenApiPath = openApiPath,
+                OutputPath = outputPath,
+                NoLogging = true,
+                NoBanner = true,
+                SkipValidation = false,
+            };
+
+            var reporter = new CapturingGenerationReporter();
+            var orchestrator = new GenerationOrchestrator();
+            var result = await orchestrator.RunAsync(settings, cliSettings, reporter, default);
+
+            result.Should().NotBe(0);
+            reporter.GenerationFailedCalled.Should().BeTrue();
+            reporter.ValidationFailedCalled.Should().BeTrue();
+            reporter.ValidationDiagnostics.Should().NotBeEmpty();
+            reporter.ValidationDiagnostics.Should().Contain(d => d.IsError);
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
     /// <summary>
     /// Test implementation of IGenerationReporter that captures warnings for verification.
     /// </summary>
@@ -919,7 +985,10 @@ public class GenerationOrchestratorTests
 
         public void ReportValidationFailed() => ValidationFailedCalled = true;
 
-        public void ReportValidationDiagnostic(OpenApiError error, bool isError) { }
+        public List<(OpenApiError Error, bool IsError)> ValidationDiagnostics { get; } = [];
+
+        public void ReportValidationDiagnostic(OpenApiError error, bool isError) =>
+            ValidationDiagnostics.Add((error, isError));
 
         public void ReportValidationStatistics(OpenApiValidationResult validationResult) { }
 

--- a/src/Refitter.Tests/GenerationOrchestratorTests.cs
+++ b/src/Refitter.Tests/GenerationOrchestratorTests.cs
@@ -771,6 +771,74 @@ public class GenerationOrchestratorTests
         }
     }
 
+    [Test]
+    public async Task RunAsync_Should_Return_Exit_Code_That_Survives_Process_Truncation_On_Validation_Failure()
+    {
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "GenerationOrchestratorTests",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var openApiPath = Path.Combine(workspace, "spec.json");
+            var outputPath = Path.Combine(workspace, "Output.cs");
+            Directory.CreateDirectory(workspace);
+
+            // A header parameter name containing a quote fails AttributeStringValidator,
+            // which surfaces as an OpenApiValidationException whose HResult is 0x80131500.
+            File.WriteAllText(
+                openApiPath,
+                """
+                {
+                  "openapi": "3.0.0",
+                  "info": { "title": "Test API", "version": "1.0.0" },
+                  "paths": {
+                    "/pets": {
+                      "get": {
+                        "operationId": "GetPets",
+                        "parameters": [
+                          { "name": "X-Bad\", \"Injected: yes", "in": "header", "schema": { "type": "string" } }
+                        ],
+                        "responses": { "200": { "description": "ok" } }
+                      }
+                    }
+                  }
+                }
+                """);
+
+            var settings = new RefitGeneratorSettings
+            {
+                OpenApiPath = openApiPath,
+                Namespace = "TestNamespace",
+            };
+
+            var cliSettings = new Settings
+            {
+                OpenApiPath = openApiPath,
+                OutputPath = outputPath,
+                NoLogging = true,
+                NoBanner = true,
+                SkipValidation = false,
+            };
+
+            var reporter = new SimpleGenerationReporter();
+            var orchestrator = new GenerationOrchestrator();
+            var result = await orchestrator.RunAsync(settings, cliSettings, reporter, default);
+
+            result.Should().NotBe(0);
+
+            // Unix truncates process exit codes to the low 8 bits, so an exit code
+            // whose low byte is zero is indistinguishable from success.
+            (result & 0xFF).Should().NotBe(0);
+        }
+        finally
+        {
+            if (Directory.Exists(workspace))
+                Directory.Delete(workspace, recursive: true);
+        }
+    }
+
     /// <summary>
     /// Test implementation of IGenerationReporter that captures warnings for verification.
     /// </summary>

--- a/src/Refitter.Tests/ReturnTypeGeneratorTests.cs
+++ b/src/Refitter.Tests/ReturnTypeGeneratorTests.cs
@@ -796,4 +796,74 @@ public class ReturnTypeGeneratorTests
 
         result.Should().Be("Task");
     }
+
+    [Test]
+    public async Task Generate_Does_Not_Return_IAsyncEnumerable_For_Mixed_Swagger2_Produces()
+    {
+        var spec = """
+            swagger: '2.0'
+            info:
+              title: Test
+              version: 1.0.0
+            paths:
+              '/test':
+                get:
+                  operationId: getTest
+                  produces:
+                    - application/json
+                    - text/event-stream
+                  responses:
+                    '200':
+                      description: Success
+                      schema:
+                        type: array
+                        items:
+                          type: string
+            """;
+
+        var document = await OpenApiYamlDocument.FromYamlAsync(spec);
+        var settings = new RefitGeneratorSettings();
+        var generator = new CSharpClientGeneratorFactory(settings, document).Create();
+        var sut = new ReturnTypeGenerator(settings, generator);
+
+        var operation = document.Paths["/test"]["get"];
+        var result = sut.Generate(operation);
+
+        result.Should().Be("Task<ICollection<string>>");
+    }
+
+    [Test]
+    public async Task Generate_Does_Not_Return_IAsyncEnumerable_For_Mixed_Document_Level_Swagger2_Produces()
+    {
+        var spec = """
+            swagger: '2.0'
+            info:
+              title: Test
+              version: 1.0.0
+            produces:
+              - application/json
+              - text/event-stream
+            paths:
+              '/test':
+                get:
+                  operationId: getTest
+                  responses:
+                    '200':
+                      description: Success
+                      schema:
+                        type: array
+                        items:
+                          type: string
+            """;
+
+        var document = await OpenApiYamlDocument.FromYamlAsync(spec);
+        var settings = new RefitGeneratorSettings();
+        var generator = new CSharpClientGeneratorFactory(settings, document).Create();
+        var sut = new ReturnTypeGenerator(settings, generator);
+
+        var operation = document.Paths["/test"]["get"];
+        var result = sut.Generate(operation);
+
+        result.Should().Be("Task<ICollection<string>>");
+    }
 }

--- a/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
+++ b/src/Refitter.Tests/Scenarios/GenerateJsonSerializerContextPolymorphismTests.cs
@@ -65,7 +65,7 @@ public class GenerateJsonSerializerContextPolymorphismTests
             <RestorePackagesPath>packages</RestorePackagesPath>
           </PropertyGroup>
           <ItemGroup>
-            <PackageReference Include="Refit.HttpClientFactory" Version="15.1.0" />
+            <PackageReference Include="Refit.HttpClientFactory" Version="15.2.0" />
           </ItemGroup>
         </Project>
         """;

--- a/src/Refitter.Tests/Scenarios/SharedResponseComponentHeadersTests.cs
+++ b/src/Refitter.Tests/Scenarios/SharedResponseComponentHeadersTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Refitter.Core;
+using Refitter.Tests.Build;
+using Refitter.Tests.TestUtilities;
+using TUnit.Core;
+
+namespace Refitter.Tests.Scenarios;
+
+
+public class SharedResponseComponentHeadersTests
+{
+    private const string OpenApiSpec = @"
+openapi: 3.0.1
+info:
+  title: Shared Responses
+  version: 1.0.0
+paths:
+  /plain:
+    get:
+      operationId: getPlain
+      responses:
+        '200':
+          $ref: '#/components/responses/PlainJson'
+  /events:
+    get:
+      operationId: getEvents
+      responses:
+        '200':
+          $ref: '#/components/responses/EventStream'
+components:
+  responses:
+    PlainJson:
+      description: shared json response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Event'
+    EventStream:
+      description: shared streaming response
+      content:
+        text/event-stream:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Event'
+  schemas:
+    Event:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+";
+
+    [Test]
+    public async Task Generates_Accept_Header_For_Referenced_Response()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("Accept: application/json");
+    }
+
+    [Test]
+    public async Task Generates_Accept_Header_For_Referenced_Streaming_Response()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("Accept: text/event-stream");
+    }
+
+    [Test]
+    public async Task Generates_IAsyncEnumerable_For_Referenced_Streaming_Response()
+    {
+        string generatedCode = await GenerateCode();
+        generatedCode.Should().Contain("IAsyncEnumerable<Event> GetEvents(");
+    }
+
+    [Test]
+    [Category("Integration")]
+    public async Task Can_Build_Generated_Code()
+    {
+        string generatedCode = await GenerateCode();
+        BuildHelper
+            .BuildCSharp(generatedCode)
+            .Should()
+            .BeTrue();
+    }
+
+    private static async Task<string> GenerateCode()
+    {
+        string swaggerFile = await SwaggerFileHelper.CreateSwaggerFile(OpenApiSpec);
+        RefitGeneratorSettings settings = new RefitGeneratorSettings
+        {
+            OpenApiPath = swaggerFile,
+            AddAcceptHeaders = true
+        };
+
+        RefitGenerator sut = await RefitGenerator.CreateAsync(settings);
+        return sut.Generate();
+    }
+}

--- a/src/Refitter/GenerationOrchestrator.cs
+++ b/src/Refitter/GenerationOrchestrator.cs
@@ -90,7 +90,16 @@ public sealed class GenerationOrchestrator
             reporter.ReportSupportHelp();
 
             await Analytics.LogError(exception, cliSettings);
-            return exception.HResult;
+            return ToProcessExitCode(exception);
         }
     }
+
+    /// <summary>
+    /// Maps an exception to a process exit code that stays non-zero after the platform
+    /// truncates it. Unix keeps only the low 8 bits, so HResults ending in 0x00 - such as
+    /// 0x80131500, the default for <see cref="Exception"/> and therefore for
+    /// <c>OpenApiValidationException</c> - would otherwise be reported as success.
+    /// </summary>
+    internal static int ToProcessExitCode(Exception exception) =>
+        (exception.HResult & 0xFF) != 0 ? exception.HResult : 1;
 }

--- a/src/Refitter/GenerationOrchestrator.cs
+++ b/src/Refitter/GenerationOrchestrator.cs
@@ -81,7 +81,9 @@ public sealed class GenerationOrchestrator
             if (exception is OpenApiUnsupportedSpecVersionException unsupportedSpecVersionException)
                 reporter.ReportUnsupportedVersion(unsupportedSpecVersionException.SpecificationVersion);
 
-            if (exception is not OpenApiValidationException)
+            if (exception is OpenApiValidationException validationException)
+                ReportValidationDiagnostics(reporter, validationException);
+            else
                 reporter.ReportExceptionDetails(exception);
 
             if (!cliSettings.SkipValidation)
@@ -92,6 +94,19 @@ public sealed class GenerationOrchestrator
             await Analytics.LogError(exception, cliSettings);
             return ToProcessExitCode(exception);
         }
+    }
+
+    private static void ReportValidationDiagnostics(
+        IGenerationReporter reporter,
+        OpenApiValidationException exception)
+    {
+        reporter.ReportValidationFailed();
+
+        foreach (OpenApiError error in exception.ValidationResult.Diagnostics.Errors)
+            reporter.ReportValidationDiagnostic(error, isError: true);
+
+        foreach (OpenApiError warning in exception.ValidationResult.Diagnostics.Warnings)
+            reporter.ReportValidationDiagnostic(warning, isError: false);
     }
 
     /// <summary>

--- a/src/Refitter/GenerationOrchestrator.cs
+++ b/src/Refitter/GenerationOrchestrator.cs
@@ -96,7 +96,7 @@ public sealed class GenerationOrchestrator
         }
     }
 
-    private static void ReportValidationDiagnostics(
+    internal static void ReportValidationDiagnostics(
         IGenerationReporter reporter,
         OpenApiValidationException exception)
     {


### PR DESCRIPTION
## Description:

Bug fixes found while reviewing the changes since 2.1.3 ahead of the 2.2.0 release. Each fix has tests written before the change.

### Failed generation exited with code 0 on Linux and macOS

`GenerationOrchestrator` returned `exception.HResult` as the process exit code. Unix truncates exit codes to the low 8 bits, and the default `HResult` for `Exception` is `0x80131500`, whose low byte is `0x00`. `OpenApiValidationException` inherits that default, so any specification failing validation printed `Generation failed!` and then reported success:

```
$ refitter unsafe.json --output Out.cs --silent
$ echo $?
0
```

No file is written, no error is surfaced, and CI passes. This also silently defeated the attribute-injection guards (GHSA-3fhm-p725-h3g3, GHSA-58x9-vjvp-6mx8, GHSA-p32v-8v8j-j534), broke the MSBuild task, which checks `Process.ExitCode`, and contradicted the new `--silent` contract that errors are still reported through the exit code. The exit code is now `1` when the `HResult` low byte is zero, and unchanged otherwise.

### Validation failures reported no reason

`ReportValidationFailed` and `ReportValidationDiagnostic` were declared on `IGenerationReporter` but never called outside of tests, so a validation failure printed a bare `Generation failed!`. They are now wired into the failure path. `--silent` still suppresses them.

### Document-level `produces` turned every operation into a stream

Streaming detection fell back to `operation.ActualProduces`, which includes the document-level `produces` list. A Swagger 2.0 document offering a streaming media type alongside a regular one turned every operation in the document into `IAsyncEnumerable`, including operations with no response schema.

#### Example OpenAPI Specifications:
```yaml
swagger: '2.0'
info:
  title: Mixed API
  version: 1.0.0
produces:
  - application/json
  - text/event-stream
paths:
  /plain:
    get:
      operationId: getPlain
      responses:
        '200':
          description: ok
          schema:
            $ref: '#/definitions/Event'
  /void:
    get:
      operationId: getVoid
      responses:
        '200':
          description: ok
definitions:
  Event:
    type: object
    properties:
      id: { type: integer, format: int64 }
```

#### Example generated Refit interface

Before:
```cs
public partial interface IMixedAPI
{
    [Get("/plain")]
    IAsyncEnumerable<Event> GetPlain();

    /// <returns>A <see cref="Task"/> that completes when the request is finished.</returns>
    [Get("/void")]
    IAsyncEnumerable<object> GetVoid();
}
```

After:
```cs
public partial interface IMixedAPI
{
    [Get("/plain")]
    Task<Event> GetPlain();

    [Get("/void")]
    Task GetVoid();
}
```

A `produces` list now only selects a streaming return type when every entry is a streaming media type. The OpenAPI 3 content path is untouched, so `lmstudio.json`, which declares `application/json` and `text/event-stream` on the same response, still generates `IAsyncEnumerable<ChatResponse>`.

### Accept headers dropped for responses declared as component refs

`MethodAttributeGenerator` read `response.Content` rather than `response.ActualResponse.Content`, unlike every other consumer of `OpenApiResponse` in the code base. A response declared as a `$ref` to a shared component carries no inline content, so no `Accept` header was emitted at all. This predates 2.2.0 but degrades the new streaming support specifically, since a Server-Sent Events endpoint declared this way sent no `Accept: text/event-stream`.

#### Example OpenAPI Specifications:
```yaml
openapi: 3.0.1
info:
  title: Shared Responses
  version: 1.0.0
paths:
  /events:
    get:
      operationId: getEvents
      responses:
        '200':
          $ref: '#/components/responses/EventStream'
components:
  responses:
    EventStream:
      description: shared streaming response
      content:
        text/event-stream:
          schema:
            type: array
            items:
              $ref: '#/components/schemas/Event'
  schemas:
    Event:
      type: object
      properties:
        id: { type: integer, format: int64 }
```

#### Example generated Refit interface

Before:
```cs
[Get("/events")]
IAsyncEnumerable<Event> GetEvents();
```

After:
```cs
[Headers("Accept: text/event-stream")]
[Get("/events")]
IAsyncEnumerable<Event> GetEvents();
```

### Test build helpers pinned to Refit 15.1.0

Renovate bumped the product to Refit 15.2.0 but missed the hardcoded version strings in the test build helpers, so integration tests were compiling generated code against 15.1.0 rather than the version being shipped.

## Testing

`dotnet build -c Release src/Refitter.slnx`: 0 warnings, 0 errors.

`dotnet test --solution src/Refitter.slnx -c Release`: 2434 passed, 0 failed, including the 106 integration tests that compile generated code.

## Notes

Three things were reviewed and deliberately left alone:

- `--silent` does not suppress argument-validation errors from Spectre, such as `File not found`. Arguably correct, but it is a gap against "suppress all console output".
- Streaming detection scans every success code including `default`, so a typed `200` alongside a streaming `default` selects the `default`. `Generate_Returns_IAsyncEnumerable_For_Default_Streaming_Response_With_SchemaLess_200` codifies that fall-through deliberately.
- `-Verbose` on the smoke test script has no effect for settings-file fixtures, because they all set `"silent": true`, which overrides the verbose gating in `StartRefitter`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated clients now include the correct `Accept` headers for responses referenced through shared components.
  * Streaming return types are generated only when all declared media types support streaming.
  * Validation failures now provide structured diagnostics and reliable non-success exit codes.

* **Tests**
  * Added coverage for shared response components, mixed streaming media types, validation reporting, and generated-code compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->