### PR TITLE
Emit generic JsonStringEnumConverter<TEnum> on injected enum attributes

### DIFF
--- a/src/Refitter.Core/Contracts/EnumStringConverterInjector.cs
+++ b/src/Refitter.Core/Contracts/EnumStringConverterInjector.cs
@@ -11,7 +11,7 @@ internal sealed class EnumStringConverterInjector : IContractsPostProcessor
         TimeSpan.FromSeconds(1));
 
     private static readonly Regex EnumDeclarationRegex = new(
-        @"^(\s*)((?:public|internal)\s+(?:partial\s+)?enum\s+\w+\b)",
+        @"^(\s*)((?:public|internal)\s+(?:partial\s+)?enum\s+(\w+)\b)",
         RegexOptions.Compiled | RegexOptions.Multiline,
         TimeSpan.FromSeconds(1));
 
@@ -25,7 +25,7 @@ internal sealed class EnumStringConverterInjector : IContractsPostProcessor
                 .Replace(
                     contracts,
                     match =>
-                        $"{match.Groups[1].Value}[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]{newLine}{match.Groups[1].Value}{match.Groups[2].Value}")
+                        $"{match.Groups[1].Value}[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<{match.Groups[3].Value}>))]{newLine}{match.Groups[1].Value}{match.Groups[2].Value}")
                 .TrimEnd();
         }
 

--- a/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
+++ b/src/Refitter.Core/Settings/CodeGeneratorSettings.cs
@@ -267,16 +267,21 @@ public class CodeGeneratorSettings
 
     /// <summary>
     /// Gets or sets a value indicating whether to inline JsonConverter attributes for enum types (default: true).
-    /// When set to true (default), the <c>[JsonConverter(typeof(JsonStringEnumConverter))]</c> attribute is placed
-    /// on the enum type declaration instead of on individual enum properties, allowing users to override the
+    /// When set to true (default), the <c>[JsonConverter(typeof(JsonStringEnumConverter&lt;TEnum&gt;))]</c> attribute
+    /// is placed on the enum type declaration instead of on individual enum properties, allowing users to override the
     /// converter via <c>JsonSerializerOptions.Converters</c> (e.g. to use <c>JsonStringEnumMemberConverter</c>
     /// for enums whose values contain hyphens or other special characters via <c>[EnumMember]</c>).
+    /// The generic converter is used because the non-generic <c>JsonStringEnumConverter</c> is annotated
+    /// <c>[RequiresDynamicCode]</c> and trips SYSLIB1034/IL3050 when the contracts are used with a
+    /// source-generated <c>JsonSerializerContext</c> or published Native AOT.
     /// When set to false, no <c>[JsonConverter]</c> attribute is emitted at all.
     /// </summary>
     [Description(
         "Gets or sets a value indicating whether to inline JsonConverter attributes for enum types (default: true). " +
-        "When set to true (default), [JsonConverter(typeof(JsonStringEnumConverter))] is placed on the enum type declaration " +
-        "so users can override it via JsonSerializerOptions.Converters. When set to false, no [JsonConverter] is emitted."
+        "When set to true (default), [JsonConverter(typeof(JsonStringEnumConverter<TEnum>))] is placed on the enum type " +
+        "declaration so users can override it via JsonSerializerOptions.Converters. The generic converter keeps the " +
+        "contracts usable with a source-generated JsonSerializerContext and Native AOT. " +
+        "When set to false, no [JsonConverter] is emitted."
     )]
     public bool InlineJsonConverters { get; set; } = true;
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/.g.cs
@@ -643,7 +643,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<Status>))]
     public enum Status
     {
 
@@ -659,7 +659,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<OrderStatus>))]
     public enum OrderStatus
     {
 
@@ -675,7 +675,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<PetStatus>))]
     public enum PetStatus
     {
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreOptionalParameters.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreOptionalParameters.g.cs
@@ -643,7 +643,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<Status>))]
     public enum Status
     {
 
@@ -659,7 +659,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<OrderStatus>))]
     public enum OrderStatus
     {
 
@@ -675,7 +675,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<PetStatus>))]
     public enum PetStatus
     {
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithHttpResilience.g.cs
@@ -643,7 +643,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<Status>))]
     public enum Status
     {
 
@@ -659,7 +659,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<OrderStatus>))]
     public enum OrderStatus
     {
 
@@ -675,7 +675,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<PetStatus>))]
     public enum PetStatus
     {
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/SwaggerPetstoreSingleInterfaceWithPolly.g.cs
@@ -353,7 +353,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<Status>))]
     public enum Status
     {
 
@@ -369,7 +369,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<OrderStatus>))]
     public enum OrderStatus
     {
 
@@ -385,7 +385,7 @@ public PetStatus Status { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<PetStatus>))]
     public enum PetStatus
     {
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/UseJsonInheritanceConverter.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/UseJsonInheritanceConverter.g.cs
@@ -106,7 +106,7 @@ namespace Refitter.Tests.UseJsonInheritanceConverter
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<SomeComponentState>))]
     public enum SomeComponentState
     {
 

--- a/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/UsePolymorphicSerialization.g.cs
+++ b/src/Refitter.SourceGenerator.Tests/AdditionalFiles/Generated/UsePolymorphicSerialization.g.cs
@@ -106,7 +106,7 @@ namespace Refitter.Tests.UsePolymorphicSerialization
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter<SomeComponentState>))]
     public enum SomeComponentState
     {
 

--- a/src/Refitter.Tests/Regression/EnumConverterInjectionTests.cs
+++ b/src/Refitter.Tests/Regression/EnumConverterInjectionTests.cs
@@ -80,7 +80,7 @@ public class EnumConverterInjectionTests
         string generatedCode = await GenerateCodeWithInternalTypes();
 
         // All enums should have JsonConverter attribute, regardless of visibility
-        generatedCode.Should().Contain("[JsonConverter(typeof(JsonStringEnumConverter))]");
+        generatedCode.Should().Contain("[JsonConverter(typeof(JsonStringEnumConverter<PetStatus>))]");
 
         // Find internal enum declarations
         generatedCode.Should().Contain("internal enum PetStatus");
@@ -90,7 +90,7 @@ public class EnumConverterInjectionTests
         // Each internal enum should have its own JsonConverter
         var converterCount = System.Text.RegularExpressions.Regex.Matches(
             generatedCode,
-            @"\[JsonConverter\(typeof\(JsonStringEnumConverter\)\)\][\s\r\n]+internal enum"
+            @"\[JsonConverter\(typeof\(JsonStringEnumConverter<\w+>\)\)\][\s\r\n]+internal enum"
         ).Count;
 
         converterCount.Should().BeGreaterThanOrEqualTo(3,
@@ -104,11 +104,11 @@ public class EnumConverterInjectionTests
 
         // Public enums should also have JsonConverter
         generatedCode.Should().Contain("public enum PetStatus");
-        generatedCode.Should().Contain("[JsonConverter(typeof(JsonStringEnumConverter))]");
+        generatedCode.Should().Contain("[JsonConverter(typeof(JsonStringEnumConverter<PetStatus>))]");
 
         var converterCount = System.Text.RegularExpressions.Regex.Matches(
             generatedCode,
-            @"\[JsonConverter\(typeof\(JsonStringEnumConverter\)\)\][\s\r\n]+public enum"
+            @"\[JsonConverter\(typeof\(JsonStringEnumConverter<\w+>\)\)\][\s\r\n]+public enum"
         ).Count;
 
         converterCount.Should().BeGreaterThanOrEqualTo(3,

--- a/src/Refitter.Tests/Scenarios/HyphenatedEnumValuesTests.cs
+++ b/src/Refitter.Tests/Scenarios/HyphenatedEnumValuesTests.cs
@@ -12,7 +12,7 @@ namespace Refitter.Tests.Scenarios;
 /// When enum values contain characters that require [EnumMember(Value = "...")] attributes
 /// (e.g. "allegro-pl", "AC_1_PHASE"), JsonStringEnumConverter cannot deserialize them because
 /// it uses the C# identifier name, not the [EnumMember] value.
-/// The fix is to place [JsonConverter(typeof(JsonStringEnumConverter))] on the enum TYPE
+/// The fix is to place [JsonConverter(typeof(JsonStringEnumConverter&lt;TEnum&gt;))] on the enum TYPE
 /// so users can override it via JsonSerializerOptions.Converters with a converter that
 /// respects [EnumMember] (e.g. JsonStringEnumMemberConverter).
 /// </summary>
@@ -96,7 +96,7 @@ public class HyphenatedEnumValuesTests
         {
             // [JsonConverter] should appear immediately before the enum type declaration
             generatedCode.Should().MatchRegex(
-                @"\[JsonConverter\(typeof\(JsonStringEnumConverter\)\)\][\r\n\s]+public enum");
+                @"\[JsonConverter\(typeof\(JsonStringEnumConverter<\w+>\)\)\][\r\n\s]+public enum");
             // Enum properties should NOT have [JsonConverter] directly on them
             generatedCode.Should().NotMatchRegex(
                 @"\[JsonConverter\(typeof\(JsonStringEnumConverter[^)]*\)\)\][\r\n\s]+public \w+Id\b");
@@ -135,6 +135,7 @@ public class HyphenatedEnumValuesTests
             generatedCode.Should().NotContain("[JsonConverter(typeof(JsonStringEnumConverter))]");
             generatedCode.Should().NotContain("[JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]");
             generatedCode.Should().NotContain("[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]");
+            generatedCode.Should().NotContain("JsonStringEnumConverter<");
         }
     }
 

--- a/src/Refitter.Tests/Scenarios/InlineJsonConvertersTests.cs
+++ b/src/Refitter.Tests/Scenarios/InlineJsonConvertersTests.cs
@@ -97,7 +97,7 @@ public class InlineJsonConvertersTests
 
         using (new AssertionScope())
         {
-            generatedCode.Should().Contain("[JsonConverter(typeof(JsonStringEnumConverter))]");
+            generatedCode.Should().Contain("[JsonConverter(typeof(JsonStringEnumConverter<PetStatus>))]");
             generatedCode.Should().Contain("public enum PetStatus");
             generatedCode.Should().Contain("Status { get; set; }");
         }
@@ -112,7 +112,7 @@ public class InlineJsonConvertersTests
         {
             // [JsonConverter] should appear immediately before the enum type declaration
             generatedCode.Should().MatchRegex(
-                @"\[JsonConverter\(typeof\(JsonStringEnumConverter\)\)\][\r\n\s]+public enum PetStatus");
+                @"\[JsonConverter\(typeof\(JsonStringEnumConverter<PetStatus>\)\)\][\r\n\s]+public enum PetStatus");
             // The property line itself should NOT be preceded by [JsonConverter]
             generatedCode.Should().NotMatchRegex(
                 @"\[JsonConverter\(typeof\(JsonStringEnumConverter[^)]*\)\)\][\r\n\s]+public PetStatus");
@@ -134,9 +134,79 @@ public class InlineJsonConvertersTests
         var injector = new EnumStringConverterInjector();
         var result = injector.Process(new OpenApiDocument(), settings, contracts);
 
-        result.Should().Contain("[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]\r\npublic enum PetStatus");
+        result.Should().Contain("[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PetStatus>))]\r\npublic enum PetStatus");
         Regex.Matches(result, "(?<!\\r)\\n").Should().BeEmpty();
     }
+
+    [Test]
+    public async Task Generated_Code_Uses_Generic_JsonStringEnumConverter()
+    {
+        string generatedCode = await GenerateCode(inlineJsonConverters: true);
+
+        using (new AssertionScope())
+        {
+            // The non-generic JsonStringEnumConverter is annotated [RequiresDynamicCode]: it builds
+            // EnumConverter<T> through MakeGenericType at runtime, so contracts carrying it trip
+            // SYSLIB1034 under a source-generated JsonSerializerContext and IL3050 under Native AOT.
+            generatedCode.Should().NotMatchRegex(@"JsonStringEnumConverter\s*\)\s*\)");
+            generatedCode.Should().Contain("JsonStringEnumConverter<PetStatus>");
+        }
+    }
+
+    [Test]
+    public void Injected_Converter_Closes_Over_Each_Enum_It_Is_Applied_To()
+    {
+        const string contracts =
+            "public enum First\n{\n}\n\ninternal partial enum Second\n{\n}\n\npublic enum Third : long\n{\n}\n";
+
+        var result = Inject(contracts);
+
+        using (new AssertionScope())
+        {
+            result.Should().Contain("JsonStringEnumConverter<First>");
+            // internal and partial enums are injected too - they would otherwise silently fall back
+            // to integer serialization, since the per-property converters are stripped either way
+            result.Should().Contain("JsonStringEnumConverter<Second>");
+            // an extended value range (": long") must not be swallowed into the captured type name
+            result.Should().Contain("JsonStringEnumConverter<Third>");
+            result.Should().Contain("public enum Third : long");
+        }
+    }
+
+    [Test]
+    public void Injecting_Twice_Is_Idempotent()
+    {
+        const string contracts = "public enum PetStatus\n{\n}\n";
+
+        var once = Inject(contracts);
+        var twice = Inject(once);
+
+        twice.Should().Be(once);
+    }
+
+    [Test]
+    public void Existing_Non_Generic_Converter_Is_Upgraded_To_Generic()
+    {
+        const string contracts =
+            "[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]\npublic enum PetStatus\n{\n}\n";
+
+        var result = Inject(contracts);
+
+        using (new AssertionScope())
+        {
+            result.Should().Contain("JsonStringEnumConverter<PetStatus>");
+            result.Should().NotMatchRegex(@"JsonStringEnumConverter\s*\)\s*\)");
+        }
+    }
+
+    private static string Inject(string contracts) =>
+        new EnumStringConverterInjector().Process(
+            new OpenApiDocument(),
+            new RefitGeneratorSettings
+            {
+                CodeGeneratorSettings = new CodeGeneratorSettings { InlineJsonConverters = true }
+            },
+            contracts);
 
     [Test]
     public async Task Generated_Code_Does_Not_Contain_JsonConverter_When_Disabled()
@@ -148,6 +218,7 @@ public class InlineJsonConvertersTests
             generatedCode.Should().NotContain("[JsonConverter(typeof(JsonStringEnumConverter))]");
             generatedCode.Should().NotContain("[JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]");
             generatedCode.Should().NotContain("[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]");
+            generatedCode.Should().NotContain("JsonStringEnumConverter<");
             generatedCode.Should().Contain("Status { get; set; }");
             generatedCode.Should().Contain("public enum PetStatus");
         }

--- a/src/Refitter.Tests/Scenarios/JsonLibraryVersionTests.cs
+++ b/src/Refitter.Tests/Scenarios/JsonLibraryVersionTests.cs
@@ -170,7 +170,9 @@ public class JsonLibraryVersionTests
     {
         string generatedCode = await GenerateCode(jsonLibraryVersion: 9.0m);
 
-        generatedCode.Should().Contain("[JsonConverter(typeof(JsonStringEnumConverter))]");
+        // Name-agnostic: the point is that the converter is present AND closed over its enum,
+        // which is what keeps the contracts usable from a source-generated JsonSerializerContext.
+        generatedCode.Should().MatchRegex(@"\[JsonConverter\(typeof\(JsonStringEnumConverter<\w+>\)\)\]");
     }
 
     [Test]

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -304,7 +304,7 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool SimpleOutput { get; set; }
 
-    [Description("Don't inline JsonConverter attributes for enum properties. When disabled, enum properties will not have [[JsonConverter(typeof(JsonStringEnumConverter))]] attributes")]
+    [Description("Don't inline JsonConverter attributes for enum types. When enabled (default), [[JsonConverter(typeof(JsonStringEnumConverter<TEnum>))]] is placed on the enum type declaration; when disabled, no [[JsonConverter]] attribute is emitted")]
     [CommandOption("--no-inline-json-converters")]
     [DefaultValue(false)]
     public bool NoInlineJsonConverters { get; set; }

--- a/src/Refitter/Settings.cs
+++ b/src/Refitter/Settings.cs
@@ -304,7 +304,7 @@ public sealed class Settings : CommandSettings
     [DefaultValue(false)]
     public bool SimpleOutput { get; set; }
 
-    [Description("Don't inline JsonConverter attributes for enum types. When enabled (default), [[JsonConverter(typeof(JsonStringEnumConverter<TEnum>))]] is placed on the enum type declaration; when disabled, no [[JsonConverter]] attribute is emitted")]
+    [Description("Don't inline JsonConverter attributes for enum types. When this option is specified, no [[JsonConverter]] attribute is emitted; when omitted (default), [[JsonConverter(typeof(JsonStringEnumConverter<TEnum>))]] is placed on the enum type declaration")]
     [CommandOption("--no-inline-json-converters")]
     [DefaultValue(false)]
     public bool NoInlineJsonConverters { get; set; }


### PR DESCRIPTION
## Description:

Fixes the injected enum converter so it is usable from a source-generated `JsonSerializerContext` and under Native AOT.

`EnumStringConverterInjector` strips the per-property converters NSwag emits and injects a type-level one on every enum. That injected attribute used the **non-generic** `JsonStringEnumConverter`, which is annotated `[RequiresDynamicCode]` — it builds `EnumConverter<T>` through `MakeGenericType` at runtime. Contracts carrying it trip [SYSLIB1034](https://learn.microsoft.com/dotnet/fundamentals/syslib-diagnostics/syslib1034) under a source-generated context and IL3050 when published Native AOT.

This was originally reported as #778 and fixed in 1.7.0 by picking up NSwag 14.6.2, which emits the generic converter. The type-level injection added in 2.0 reintroduced the non-generic form, as noted in #1014 — whose recommended fix landed only in part: injection is now gated on System.Text.Json and the declaration regex matches `internal` enums, but the converter itself stayed non-generic.

### The change

`EnumDeclarationRegex` did not capture the enum name, so the injector had nothing to close the converter over. Capturing it is the whole fix:

```diff
- @"^(\s*)((?:public|internal)\s+(?:partial\s+)?enum\s+\w+\b)",
+ @"^(\s*)((?:public|internal)\s+(?:partial\s+)?enum\s+(\w+)\b)",

- ...JsonStringEnumConverter))]...
+ ...JsonStringEnumConverter<{match.Groups[3].Value}>))]...
```

Per-type placement introduced in 2.0 is deliberately unchanged (per #1032), so overriding via `JsonSerializerOptions.Converters` still works, and enums whose wire values need `[EnumMember]` are unaffected — both converters resolve names identically.

Also updates the `InlineJsonConverters` XML docs and the `--no-inline-json-converters` CLI description, which both still described the non-generic attribute.

### Verification

Checked against a real 41-endpoint OpenAPI document with 23 enums. Normalising line endings, output is **byte-identical to 2.2.0 except that every converter is now closed over its enum** — the only other differing line is the version stamp.

`Refitter.Tests` 2355 passed / 0 failed; `Refitter.SourceGenerator.Tests` 25 passed / 0 failed. Four tests added:

- the emitted converter is generic, asserting the non-generic form is *absent* — that absence is the AOT-relevant claim
- it closes over the right enum across `public`, `internal partial`, and `enum : long` (confirming `: long` is not swallowed into the captured name)
- injection is idempotent
- an existing non-generic attribute is upgraded rather than duplicated

Five existing tests asserted the old form and now assert the new one. The `Refitter.SourceGenerator.Tests` `.g.cs` files are build outputs and regenerated themselves; that is the second commit, 14 lines, all converter attributes.

#### Example OpenAPI Specifications:
```yaml
swagger: '2.0'
info:
  title: Enum Test API
  version: 1.0.0
paths:
  /api/pets:
    get:
      operationId: getPets
      responses:
        '200':
          description: Success
          schema:
            $ref: '#/definitions/Pet'
definitions:
  Pet:
    type: object
    properties:
      status:
        type: string
        enum:
          - available
          - pending
          - sold
```

#### Example generated Refit interface
```cs
[System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0")]
[JsonConverter(typeof(JsonStringEnumConverter<PetStatus>))]
public enum PetStatus
{
    [System.Runtime.Serialization.EnumMember(Value = @"available")]
    Available = 0,

    [System.Runtime.Serialization.EnumMember(Value = @"pending")]
    Pending = 1,

    [System.Runtime.Serialization.EnumMember(Value = @"sold")]
    Sold = 2,
}
```

Before this change the attribute read `[JsonConverter(typeof(JsonStringEnumConverter))]`, which is what raises SYSLIB1034 when `PetStatus` is reachable from a `JsonSerializerContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAW3iSpJm5YSdZJcbh4qoD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated enum converters now use strongly typed `JsonStringEnumConverter<TEnum>` attributes.
  * Improved compatibility with source-generated JSON serialization and Native AOT scenarios.
  * Existing non-generic enum converters are upgraded, and repeated processing remains idempotent.

* **Documentation**
  * Updated configuration descriptions to clarify generic converter behavior and the effect of disabling inline converters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->