### PR TITLE
Bump Microsoft.SourceLink.GitHub to 10.0.401

### DIFF
--- a/src/Refitter.Core/Refitter.Core.csproj
+++ b/src/Refitter.Core/Refitter.Core.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.401" PrivateAssets="all" />
     <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="14.7.1" />
     <PackageReference Include="NSwag.Core.Yaml" Version="14.7.1" />
     <PackageReference Include="OasReader" Version="3.7.0.20" />

--- a/src/Refitter/Refitter.csproj
+++ b/src/Refitter/Refitter.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Exceptionless" Version="6.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.23.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.401" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="10.0.10" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
CI restore fails on `main` with `NU1902` because `Microsoft.SourceLink.GitHub` 10.0.301 pulls `Microsoft.Build.Tasks.Git` 10.0.301, which is flagged by [GHSA-23fw-v26w-5fgq](https://github.com/advisories/GHSA-23fw-v26w-5fgq) (`CVE-2026-62900`). Warnings are treated as errors, so restore fails.

This bumps `Microsoft.SourceLink.GitHub` from 10.0.301 to 10.0.401 in:
- `src/Refitter/Refitter.csproj`
- `src/Refitter.Core/Refitter.Core.csproj`

That pulls the patched `Microsoft.Build.Tasks.Git` 10.0.401. SourceLink is `PrivateAssets=all` (build-time only).

Dependabot PR #1230 only added a direct pin in Core and left the CLI project on 10.0.301, so it does not unblock the build.

## Verification
- `dotnet restore` / `dotnet list package --vulnerable --include-transitive`: no vulnerable packages
- Release build of Core, CLI, MSBuild, and tests succeeded (NU1902 gone)
- 2308 unit tests passed

Fixes the failure at https://github.com/christianhelle/refitter/actions/runs/34575634350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Source Link tooling to a newer version for improved build and debugging support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->